### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,7 +83,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up kubectl
-      uses: azure/setup-kubectl@v3
+      uses: azure/setup-kubectl@v4
       with:
         version: 'v1.28.0'
 
@@ -129,7 +129,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up kubectl
-      uses: azure/setup-kubectl@v3
+      uses: azure/setup-kubectl@v4
       with:
         version: 'v1.28.0'
 
@@ -216,7 +216,7 @@ jobs:
       name: ${{ needs.pre-deployment.outputs.deploy_env }}
     steps:
     - name: Set up kubectl
-      uses: azure/setup-kubectl@v3
+      uses: azure/setup-kubectl@v4
       with:
         version: 'v1.28.0'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         pytest tests/integration/ -v --junitxml=integration-junit.xml
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         flags: unittests
@@ -210,7 +210,7 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         target: production
@@ -236,7 +236,7 @@ jobs:
         output: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'
@@ -272,7 +272,7 @@ jobs:
         "
 
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -46,7 +46,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Bandit results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: bandit-results.sarif
@@ -70,7 +70,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Semgrep results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: semgrep.sarif
@@ -119,7 +119,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Snyk results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: snyk-results.sarif
@@ -153,7 +153,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Build Docker image for scanning
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         target: production
@@ -170,14 +170,14 @@ jobs:
         output: 'trivy-results.sarif'
 
     - name: Upload Trivy results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'
         category: trivy
 
     - name: Run Grype vulnerability scanner
-      uses: anchore/scan-action@v3
+      uses: anchore/scan-action@v7
       id: grype-scan
       with:
         image: 'wifi-densepose:scan'
@@ -186,7 +186,7 @@ jobs:
         output-format: sarif
 
     - name: Upload Grype results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: ${{ steps.grype-scan.outputs.sarif }}
@@ -202,7 +202,7 @@ jobs:
         summary: true
 
     - name: Upload Docker Scout results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: scout-results.sarif
@@ -231,7 +231,7 @@ jobs:
         soft_fail: true
 
     - name: Upload Checkov results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: checkov-results.sarif
@@ -256,7 +256,7 @@ jobs:
         exclude_queries: 'a7ef1e8c-fbf8-4ac1-b8c7-2c3b0e6c6c6c'
 
     - name: Upload KICS results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: kics-results/results.sarif


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `anchore/scan-action` | [`v3`](https://github.com/anchore/scan-action/releases/tag/v3) | [`v7`](https://github.com/anchore/scan-action/releases/tag/v7) | [Release](https://github.com/anchore/scan-action/releases/tag/v7) | security-scan.yml |
| `azure/setup-kubectl` | [`v3`](https://github.com/azure/setup-kubectl/releases/tag/v3) | [`v4`](https://github.com/azure/setup-kubectl/releases/tag/v4) | [Release](https://github.com/azure/setup-kubectl/releases/tag/v4) | cd.yml |
| `codecov/codecov-action` | [`v3`](https://github.com/codecov/codecov-action/releases/tag/v3) | [`v5`](https://github.com/codecov/codecov-action/releases/tag/v5) | [Release](https://github.com/codecov/codecov-action/releases/tag/v5) | ci.yml |
| `docker/build-push-action` | [`v5`](https://github.com/docker/build-push-action/releases/tag/v5) | [`v6`](https://github.com/docker/build-push-action/releases/tag/v6) | [Release](https://github.com/docker/build-push-action/releases/tag/v6) | ci.yml, security-scan.yml |
| `github/codeql-action/upload-sarif` | [`v2`](https://github.com/github/codeql-action/upload-sarif/releases/tag/v2) | [`v4`](https://github.com/github/codeql-action/upload-sarif/releases/tag/v4) | [Release](https://github.com/github/codeql-action/upload-sarif/releases/tag/v4) | ci.yml, security-scan.yml |
| `peaceiris/actions-gh-pages` | [`v3`](https://github.com/peaceiris/actions-gh-pages/releases/tag/v3) | [`v4`](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4) | [Release](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4) | ci.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
