### PR TITLE
fix(desktop): implement save_settings and get_settings commands

### DIFF
--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-desktop/src/commands/mod.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-desktop/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod flash;
 pub mod ota;
 pub mod provision;
 pub mod server;
+pub mod settings;
 pub mod wasm;

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-desktop/src/commands/settings.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-desktop/src/commands/settings.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+/// Application settings that persist across restarts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppSettings {
+    pub server_http_port: u16,
+    pub server_ws_port: u16,
+    pub server_udp_port: u16,
+    pub bind_address: String,
+    pub ui_path: String,
+    pub ota_psk: String,
+    pub auto_discover: bool,
+    pub discover_interval_ms: u32,
+    pub theme: String,
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            server_http_port: 8080,
+            server_ws_port: 8765,
+            server_udp_port: 5005,
+            bind_address: "127.0.0.1".into(),
+            ui_path: String::new(),
+            ota_psk: String::new(),
+            auto_discover: true,
+            discover_interval_ms: 10_000,
+            theme: "dark".into(),
+        }
+    }
+}
+
+/// Get the settings file path in the app data directory.
+fn settings_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+
+    // Ensure directory exists
+    fs::create_dir_all(&app_dir)
+        .map_err(|e| format!("Failed to create app data dir: {}", e))?;
+
+    Ok(app_dir.join("settings.json"))
+}
+
+/// Load settings from disk.
+#[tauri::command]
+pub async fn get_settings(app: AppHandle) -> Result<Option<AppSettings>, String> {
+    let path = settings_path(&app)?;
+
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let contents = fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read settings: {}", e))?;
+
+    let settings: AppSettings = serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse settings: {}", e))?;
+
+    Ok(Some(settings))
+}
+
+/// Save settings to disk.
+#[tauri::command]
+pub async fn save_settings(app: AppHandle, settings: AppSettings) -> Result<(), String> {
+    let path = settings_path(&app)?;
+
+    let contents = serde_json::to_string_pretty(&settings)
+        .map_err(|e| format!("Failed to serialize settings: {}", e))?;
+
+    fs::write(&path, contents)
+        .map_err(|e| format!("Failed to write settings: {}", e))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_settings() {
+        let settings = AppSettings::default();
+        assert_eq!(settings.server_http_port, 8080);
+        assert_eq!(settings.bind_address, "127.0.0.1");
+        assert!(settings.auto_discover);
+    }
+
+    #[test]
+    fn test_settings_serialization() {
+        let settings = AppSettings::default();
+        let json = serde_json::to_string(&settings).unwrap();
+        let parsed: AppSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.server_http_port, settings.server_http_port);
+    }
+}

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-desktop/src/lib.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-desktop/src/lib.rs
@@ -2,7 +2,7 @@ pub mod commands;
 pub mod domain;
 pub mod state;
 
-use commands::{discovery, flash, ota, provision, server, wasm};
+use commands::{discovery, flash, ota, provision, server, settings, wasm};
 
 pub fn run() {
     tauri::Builder::default()
@@ -30,6 +30,9 @@ pub fn run() {
             // Provision
             provision::provision_node,
             provision::read_nvs,
+            // Settings
+            settings::get_settings,
+            settings::save_settings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- Implements `save_settings` and `get_settings` Tauri commands
- Settings are persisted to the app data directory as `settings.json`
- Supports all AppSettings fields from the UI

Fixes #206

## Changes
- Add `commands/settings.rs` with `get_settings` and `save_settings` Tauri commands
- Register commands in `lib.rs`
- Add unit tests for serialization and defaults

## Settings Location
- **macOS**: `~/Library/Application Support/net.ruv.ruview/settings.json`
- **Windows**: `%APPDATA%/net.ruv.ruview/settings.json`
- **Linux**: `~/.config/net.ruv.ruview/settings.json`

## Test plan
- [x] `cargo check -p wifi-densepose-desktop` passes
- [x] `cargo test -p wifi-densepose-desktop` passes (2 new tests)
- [ ] Manual test: Open Settings, change values, save, restart app, verify persistence

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)