### PR TITLE
fix(mobile): clean up sockets when simulation starts

### DIFF
--- a/ui/mobile/src/__tests__/services/ws.service.test.ts
+++ b/ui/mobile/src/__tests__/services/ws.service.test.ts
@@ -109,6 +109,62 @@ describe('WsService', () => {
       expect(ws.getStatus()).toBe('simulated');
       ws.disconnect();
     });
+
+    it('cleans up active sockets and pending reconnects when switching to simulation mode', () => {
+      const sockets: MockWebSocketInstance[] = [];
+      const OrigWebSocket = globalThis.WebSocket;
+
+      class MockWebSocket {
+        static OPEN = 1;
+        static CONNECTING = 0;
+        static CLOSED = 3;
+        readyState = MockWebSocket.OPEN;
+        onopen: (() => void) | null = null;
+        onclose: ((event: { code: number }) => void) | null = null;
+        onerror: (() => void) | null = null;
+        onmessage: (() => void) | null = null;
+        close = jest.fn((code?: number) => {
+          this.readyState = MockWebSocket.CLOSED;
+          this.onclose?.({ code: code ?? 1000 });
+        });
+
+        constructor(_url: string) {
+          sockets.push(this as unknown as MockWebSocketInstance);
+        }
+      }
+
+      type MockWebSocketInstance = {
+        onclose: ((event: { code: number }) => void) | null;
+        close: jest.Mock;
+      };
+
+      globalThis.WebSocket = MockWebSocket as any;
+
+      try {
+        const ws = createWsService();
+        ws.connect('http://localhost:3000');
+        expect(sockets).toHaveLength(1);
+
+        ws.connect('');
+        expect(sockets[0].close).toHaveBeenCalledWith(1000, 'switch to simulation');
+        expect(ws.getStatus()).toBe('simulated');
+        ws.disconnect();
+
+        const wsWithReconnect = createWsService();
+        wsWithReconnect.connect('http://localhost:3000');
+        expect(sockets).toHaveLength(2);
+
+        sockets[1].onclose?.({ code: 1006 });
+        wsWithReconnect.connect('');
+
+        jest.advanceTimersByTime(60_000);
+        expect(sockets).toHaveLength(2);
+        expect(wsWithReconnect.getStatus()).toBe('simulated');
+        wsWithReconnect.disconnect();
+      } finally {
+        globalThis.WebSocket = OrigWebSocket;
+      }
+    });
   });
 
   describe('subscribe and unsubscribe', () => {

--- a/ui/mobile/src/services/ws.service.ts
+++ b/ui/mobile/src/services/ws.service.ts
@@ -22,6 +22,13 @@ class WsService {
     this.reconnectAttempt = 0;
 
     if (!url) {
+      this.clearReconnectTimer();
+      if (this.ws) {
+        const socket = this.ws;
+        this.ws = null;
+        socket.onclose = null;
+        socket.close(1000, 'switch to simulation');
+      }
       this.handleStatusChange('simulated');
       this.startSimulation();
       return;


### PR DESCRIPTION
## Summary

- close the active WebSocket and clear pending reconnect timers when the settings URL is emptied and the client switches back to simulation mode
- add a focused websocket-service regression covering both active-socket cleanup and pending reconnect cancellation
- keep the patch isolated to `ws.service.ts`, separate from open RuView PR scopes `#151` and `#236`

## Validation

- `cd ui/mobile && npm test -- --runInBand src/__tests__/services/ws.service.test.ts`
- `ESLINT_USE_FLAT_CONFIG=false npx -y eslint@8 -c .eslintrc.js src/services/ws.service.ts src/__tests__/services/ws.service.test.ts` *(still fails because of a pre-existing repo ESLint/@typescript-eslint rule wiring mismatch, not because of this patch)*

## Notes

- this fix specifically covers the “switch from reconnecting/connected socket to empty URL” case that the existing simulation-mode tests did not exercise