### PR TITLE
fix(led): Explicitly disable onboard WS2812 LED during CSI collection

### DIFF
--- a/firmware/esp32-csi-node/main/idf_component.yml
+++ b/firmware/esp32-csi-node/main/idf_component.yml
@@ -8,3 +8,6 @@ dependencies:
 
   ## LCD touch abstraction
   espressif/esp_lcd_touch: "^1.0"
+
+  ## Onboard WS2812 LED Disabling
+  espressif/led_strip: "^3.0.0"

--- a/firmware/esp32-csi-node/main/main.c
+++ b/firmware/esp32-csi-node/main/main.c
@@ -17,6 +17,7 @@
 #include "esp_log.h"
 #include "nvs_flash.h"
 #include "sdkconfig.h"
+#include "led_strip.h"
 
 #include "csi_collector.h"
 #include "stream_sender.h"
@@ -137,6 +138,23 @@ void app_main(void)
     nvs_config_load(&g_nvs_config);
 
     ESP_LOGI(TAG, "ESP32-S3 CSI Node (ADR-018) — Node ID: %d", g_nvs_config.node_id);
+
+    /* Turn off onboard WS2812 LED on GPIO 38 */
+    led_strip_handle_t led_strip;
+    led_strip_config_t strip_config = {
+        .strip_gpio_num = 38,
+        .max_leds = 1,
+        .led_model = LED_MODEL_WS2812,
+        .color_component_format = LED_STRIP_COLOR_COMPONENT_FMT_GRB,
+        .flags.invert_out = false,
+    };
+    led_strip_rmt_config_t rmt_config = {
+        .resolution_hz = 10 * 1000 * 1000, // 10MHz
+        .flags.with_dma = false,
+    };
+    if (led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip) == ESP_OK) {
+        led_strip_clear(led_strip);
+    }
 
     /* Initialize WiFi STA (skip entirely under QEMU mock — no RF hardware) */
 #ifndef CONFIG_CSI_MOCK_SKIP_WIFI_CONNECT


### PR DESCRIPTION
Description
This PR explicitly disables the onboard WS2812 RGB LED (NeoPixel) during CSI collection on ESP32-S3 boards.

The Problem
When compiling the esp32-csi-node firmware using ESP-IDF v5.2, the core Wi-Fi library automatically assumes control of any detected onboard NeoPixel to use as a Wi-Fi status indicator. Because CSI collection generates immense Wi-Fi traffic, this triggers the LED to shine at blinding brightness constantly, drawing unnecessary power and causing a distraction.

The Solution
Added the espressif/led_strip driver (v3.0.0+) to the project components.
Hooked into 
app_main
 to initialize the RMT peripheral on GPIO 38.
Explicitly command the strip to clear (0,0,0) its latched state right before the Wi-Fi station connects.
Testing
Flashed to an ESP32-S3-WROOM-1 N8R8 board.
Successfully verified the RGB LED clears to black during boot and remains off while throwing UDP CSI frames.
Verified LVGL UI elements continue compounding without interruption.