### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
   <a href="https://ruvnet.github.io/RuView/">
     <img src="assets/ruview-small-gemini.jpg" alt="RuView - WiFi DensePose" width="100%">
   </a>
+  <a href="https://gitcgr.com/ruvnet/RuView">
+    <img src="https://gitcgr.com/badge/ruvnet/RuView.svg" alt="gitcgr" />
+  </a>
 </p>
 
 ## **See through walls with WiFi + Ai** ##


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/ruvnet/RuView.svg)](https://gitcgr.com/ruvnet/RuView)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).