### PR TITLE
feat(ui): URL routing, onboarding tour, idle detection, notification center

### DIFF
--- a/ui/.eslintrc.json
+++ b/ui/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "env": {
+    "browser": true,
+    "es2022": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "no-undef": "error",
+    "no-var": "error",
+    "prefer-const": "warn",
+    "eqeqeq": ["error", "always"],
+    "no-eval": "error",
+    "no-implied-eval": "error",
+    "no-new-func": "error",
+    "no-script-url": "error",
+    "no-alert": "warn",
+    "no-console": ["warn", { "allow": ["warn", "error", "info"] }],
+    "curly": ["warn", "multi-line"],
+    "no-throw-literal": "error",
+    "prefer-template": "warn",
+    "no-duplicate-imports": "error"
+  },
+  "ignorePatterns": [
+    "node_modules/",
+    "mobile/",
+    "vendor/",
+    "*.min.js"
+  ]
+}

--- a/ui/app.js
+++ b/ui/app.js
@@ -14,6 +14,10 @@ import { KeyboardShortcuts } from './utils/keyboard-shortcuts.js';
 import { PerfMonitor } from './utils/perf-monitor.js';
 import { toastManager } from './utils/toast.js';
 import { ThemeToggle } from './utils/theme-toggle.js';
+import { Router } from './utils/router.js';
+import { Onboarding } from './utils/onboarding.js';
+import { IdleManager } from './utils/idle-manager.js';
+import { NotificationCenter } from './utils/notification-center.js';
 
 class WiFiDensePoseApp {
   constructor() {
@@ -187,9 +191,33 @@ class WiFiDensePoseApp {
     this.perfMonitor = new PerfMonitor();
     this.perfMonitor.init();
 
+    // Notification center (bell icon in header)
+    this.notificationCenter = new NotificationCenter();
+    this.notificationCenter.init();
+
     // Keyboard shortcuts (pass app reference for tab switching)
     this.keyboardShortcuts = new KeyboardShortcuts(this);
     this.keyboardShortcuts.init();
+
+    // URL hash router (bookmarkable tabs)
+    this.router = new Router(this);
+    this.router.init();
+
+    // Idle detection (pause updates when inactive)
+    this.idleManager = new IdleManager();
+    this.idleManager.onIdle(() => {
+      healthService.stopHealthMonitoring();
+      console.info('[App] Paused health monitoring (idle)');
+    });
+    this.idleManager.onActive(() => {
+      healthService.startHealthMonitoring();
+      console.info('[App] Resumed health monitoring (active)');
+    });
+    this.idleManager.init();
+
+    // Onboarding tour (first-run walkthrough)
+    this.onboarding = new Onboarding(this);
+    this.onboarding.init();
   }
 
   // Handle tab changes
@@ -331,6 +359,10 @@ class WiFiDensePoseApp {
     if (this.keyboardShortcuts) this.keyboardShortcuts.dispose();
     if (this.perfMonitor) this.perfMonitor.dispose();
     if (this.themeToggle) this.themeToggle.dispose();
+    if (this.router) this.router.dispose();
+    if (this.onboarding) this.onboarding.dispose();
+    if (this.idleManager) this.idleManager.dispose();
+    if (this.notificationCenter) this.notificationCenter.dispose();
     toastManager.dispose();
   }
 

--- a/ui/app.js
+++ b/ui/app.js
@@ -10,6 +10,10 @@ import { wsService } from './services/websocket.service.js';
 import { healthService } from './services/health.service.js';
 import { sensingService } from './services/sensing.service.js';
 import { backendDetector } from './utils/backend-detector.js';
+import { KeyboardShortcuts } from './utils/keyboard-shortcuts.js';
+import { PerfMonitor } from './utils/perf-monitor.js';
+import { toastManager } from './utils/toast.js';
+import { ThemeToggle } from './utils/theme-toggle.js';
 
 class WiFiDensePoseApp {
   constructor() {
@@ -30,10 +34,13 @@ class WiFiDensePoseApp {
       
       // Initialize UI components
       this.initializeComponents();
-      
+
+      // Initialize enhancements
+      this.initializeEnhancements();
+
       // Set up global event listeners
       this.setupEventListeners();
-      
+
       this.isInitialized = true;
       console.log('WiFi DensePose UI initialized successfully');
       
@@ -167,6 +174,24 @@ class WiFiDensePoseApp {
     }
   }
 
+  // Initialize enhancement modules (keyboard shortcuts, perf monitor, toast, theme)
+  initializeEnhancements() {
+    // Toast notifications
+    toastManager.init();
+
+    // Theme toggle
+    this.themeToggle = new ThemeToggle();
+    this.themeToggle.init();
+
+    // Performance monitor
+    this.perfMonitor = new PerfMonitor();
+    this.perfMonitor.init();
+
+    // Keyboard shortcuts (pass app reference for tab switching)
+    this.keyboardShortcuts = new KeyboardShortcuts(this);
+    this.keyboardShortcuts.init();
+  }
+
   // Handle tab changes
   handleTabChange(newTab, oldTab) {
     console.log(`Tab changed from ${oldTab} to ${newTab}`);
@@ -272,45 +297,17 @@ class WiFiDensePoseApp {
     });
   }
 
-  // Show backend status notification
+  // Show backend status notification (uses enhanced toast system)
   showBackendStatus(message, type) {
-    // Create status notification if it doesn't exist
-    let statusToast = document.getElementById('backendStatusToast');
-    if (!statusToast) {
-      statusToast = document.createElement('div');
-      statusToast.id = 'backendStatusToast';
-      statusToast.className = 'backend-status-toast';
-      document.body.appendChild(statusToast);
-    }
-
-    statusToast.textContent = message;
-    statusToast.className = `backend-status-toast ${type}`;
-    statusToast.classList.add('show');
-
-    // Auto-hide success messages, keep warnings and errors longer
-    const timeout = type === 'success' ? 3000 : 8000;
-    setTimeout(() => {
-      statusToast.classList.remove('show');
-    }, timeout);
+    const toastType = type === 'success' ? 'success' : 'warning';
+    toastManager[toastType](message, {
+      duration: type === 'success' ? 3000 : 8000
+    });
   }
 
-  // Show global error message
+  // Show global error message (uses enhanced toast system)
   showGlobalError(message) {
-    // Create error toast if it doesn't exist
-    let errorToast = document.getElementById('globalErrorToast');
-    if (!errorToast) {
-      errorToast = document.createElement('div');
-      errorToast.id = 'globalErrorToast';
-      errorToast.className = 'error-toast';
-      document.body.appendChild(errorToast);
-    }
-
-    errorToast.textContent = message;
-    errorToast.classList.add('show');
-
-    setTimeout(() => {
-      errorToast.classList.remove('show');
-    }, 5000);
+    toastManager.error(message, { duration: 6000 });
   }
 
   // Clean up resources
@@ -326,9 +323,15 @@ class WiFiDensePoseApp {
 
     // Disconnect all WebSocket connections
     wsService.disconnectAll();
-    
+
     // Stop health monitoring
     healthService.dispose();
+
+    // Dispose enhancements
+    if (this.keyboardShortcuts) this.keyboardShortcuts.dispose();
+    if (this.perfMonitor) this.perfMonitor.dispose();
+    if (this.themeToggle) this.themeToggle.dispose();
+    toastManager.dispose();
   }
 
   // Public API

--- a/ui/components/TabManager.js
+++ b/ui/components/TabManager.js
@@ -19,6 +19,33 @@ export class TabManager {
       tab.addEventListener('click', () => this.switchTab(tab));
     });
 
+    // Arrow key navigation within tab bar (WCAG)
+    const nav = this.container.querySelector('.nav-tabs');
+    if (nav) {
+      nav.addEventListener('keydown', (e) => {
+        const buttonTabs = this.tabs.filter(t => t.tagName === 'BUTTON' && !t.disabled);
+        const currentIndex = buttonTabs.indexOf(document.activeElement);
+        if (currentIndex === -1) return;
+
+        let nextIndex = -1;
+        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+          nextIndex = (currentIndex + 1) % buttonTabs.length;
+        } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+          nextIndex = (currentIndex - 1 + buttonTabs.length) % buttonTabs.length;
+        } else if (e.key === 'Home') {
+          nextIndex = 0;
+        } else if (e.key === 'End') {
+          nextIndex = buttonTabs.length - 1;
+        }
+
+        if (nextIndex >= 0) {
+          e.preventDefault();
+          buttonTabs[nextIndex].focus();
+          this.switchTab(buttonTabs[nextIndex]);
+        }
+      });
+    }
+
     // Activate first tab if none active
     const activeTab = this.tabs.find(tab => tab.classList.contains('active'));
     if (activeTab) {
@@ -36,14 +63,22 @@ export class TabManager {
       return;
     }
 
-    // Update tab states
+    // Update tab states and ARIA attributes
     this.tabs.forEach(tab => {
-      tab.classList.toggle('active', tab === tabElement);
+      const isActive = tab === tabElement;
+      tab.classList.toggle('active', isActive);
+      if (tab.hasAttribute('aria-selected')) {
+        tab.setAttribute('aria-selected', String(isActive));
+      }
     });
 
-    // Update content visibility
+    // Update content visibility and ARIA
     this.tabContents.forEach(content => {
-      content.classList.toggle('active', content.id === tabId);
+      const isActive = content.id === tabId;
+      content.classList.toggle('active', isActive);
+      if (content.hasAttribute('role')) {
+        content.setAttribute('aria-hidden', String(!isActive));
+      }
     });
 
     // Update active tab

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,34 +7,37 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <!-- Skip to main content link for keyboard/screen reader users -->
+    <a href="#dashboard" class="skip-to-content">Skip to main content</a>
+
     <div class="container">
         <!-- Header -->
-        <header class="header">
+        <header class="header" role="banner">
             <h1>WiFi DensePose</h1>
             <p class="subtitle">Human Tracking Through Walls Using WiFi Signals</p>
             <div class="header-info">
-                <span class="api-version"></span>
-                <span class="api-environment"></span>
-                <span class="overall-health"></span>
+                <span class="api-version" aria-label="API version"></span>
+                <span class="api-environment" aria-label="Environment"></span>
+                <span class="overall-health" role="status" aria-live="polite" aria-label="System health"></span>
             </div>
         </header>
 
         <!-- Navigation -->
-        <nav class="nav-tabs">
-            <button class="nav-tab active" data-tab="dashboard">Dashboard</button>
-            <button class="nav-tab" data-tab="hardware">Hardware</button>
-            <button class="nav-tab" data-tab="demo">Live Demo</button>
-            <button class="nav-tab" data-tab="architecture">Architecture</button>
-            <button class="nav-tab" data-tab="performance">Performance</button>
-            <button class="nav-tab" data-tab="applications">Applications</button>
-            <button class="nav-tab" data-tab="sensing">Sensing</button>
-            <button class="nav-tab" data-tab="training">Training</button>
+        <nav class="nav-tabs" role="tablist" aria-label="Main navigation">
+            <button class="nav-tab active" data-tab="dashboard" role="tab" aria-selected="true" aria-controls="dashboard">Dashboard</button>
+            <button class="nav-tab" data-tab="hardware" role="tab" aria-selected="false" aria-controls="hardware">Hardware</button>
+            <button class="nav-tab" data-tab="demo" role="tab" aria-selected="false" aria-controls="demo">Live Demo</button>
+            <button class="nav-tab" data-tab="architecture" role="tab" aria-selected="false" aria-controls="architecture">Architecture</button>
+            <button class="nav-tab" data-tab="performance" role="tab" aria-selected="false" aria-controls="performance">Performance</button>
+            <button class="nav-tab" data-tab="applications" role="tab" aria-selected="false" aria-controls="applications">Applications</button>
+            <button class="nav-tab" data-tab="sensing" role="tab" aria-selected="false" aria-controls="sensing">Sensing</button>
+            <button class="nav-tab" data-tab="training" role="tab" aria-selected="false" aria-controls="training">Training</button>
             <a href="pose-fusion.html" class="nav-tab" style="text-decoration:none">Pose Fusion</a>
             <a href="observatory.html" class="nav-tab" style="text-decoration:none">Observatory</a>
         </nav>
 
         <!-- Dashboard Tab -->
-        <section id="dashboard" class="tab-content active">
+        <section id="dashboard" class="tab-content active" role="tabpanel" aria-labelledby="dashboard">
             <div class="hero-section">
                 <h2>Revolutionary WiFi-Based Human Pose Detection</h2>
                 <p class="hero-description">
@@ -181,7 +184,7 @@
         </section>
 
         <!-- Hardware Tab -->
-        <section id="hardware" class="tab-content">
+        <section id="hardware" class="tab-content" role="tabpanel" aria-labelledby="hardware" aria-hidden="true">
             <h2>Hardware Configuration</h2>
             
             <div class="hardware-grid">
@@ -259,7 +262,7 @@
         </section>
 
         <!-- Demo Tab -->
-        <section id="demo" class="tab-content">
+        <section id="demo" class="tab-content" role="tabpanel" aria-labelledby="demo" aria-hidden="true">
             <h2>Live Demonstration</h2>
             
             <div class="demo-controls">
@@ -312,7 +315,7 @@
         </section>
 
         <!-- Architecture Tab -->
-        <section id="architecture" class="tab-content">
+        <section id="architecture" class="tab-content" role="tabpanel" aria-labelledby="architecture" aria-hidden="true">
             <h2>System Architecture</h2>
             
             <div class="architecture-flow">
@@ -350,7 +353,7 @@
         </section>
 
         <!-- Performance Tab -->
-        <section id="performance" class="tab-content">
+        <section id="performance" class="tab-content" role="tabpanel" aria-labelledby="performance" aria-hidden="true">
             <h2>Performance Analysis</h2>
             
             <div class="performance-chart">
@@ -422,7 +425,7 @@
         </section>
 
         <!-- Applications Tab -->
-        <section id="applications" class="tab-content">
+        <section id="applications" class="tab-content" role="tabpanel" aria-labelledby="applications" aria-hidden="true">
             <h2>Real-World Applications</h2>
             
             <div class="applications-grid">
@@ -489,10 +492,10 @@
         </section>
 
         <!-- Sensing Tab -->
-        <section id="sensing" class="tab-content"></section>
+        <section id="sensing" class="tab-content" role="tabpanel" aria-labelledby="sensing" aria-hidden="true"></section>
 
         <!-- Training Tab -->
-        <section id="training" class="tab-content">
+        <section id="training" class="tab-content" role="tabpanel" aria-labelledby="training" aria-hidden="true">
             <div class="tab-header">
                 <h2>Model Training</h2>
                 <p>Record CSI data, train pose estimation models, and manage .rvf files</p>

--- a/ui/style.css
+++ b/ui/style.css
@@ -2858,3 +2858,346 @@ a:focus-visible,
     width: 95vw;
   }
 }
+
+/* ==========================================================================
+   ONBOARDING TOUR
+   ========================================================================== */
+
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10100;
+}
+
+.onboarding-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.onboarding-highlight {
+  position: relative;
+  z-index: 10101;
+  box-shadow: 0 0 0 4px var(--color-primary), 0 0 0 9999px rgba(0, 0, 0, 0.55);
+  border-radius: var(--radius-base);
+  transition: box-shadow var(--duration-normal);
+}
+
+.onboarding-tooltip {
+  position: fixed;
+  z-index: 10102;
+  width: 360px;
+  max-width: 90vw;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-20);
+  animation: onboarding-pop var(--duration-normal) var(--ease-standard);
+}
+
+.onboarding-tooltip.center {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+@keyframes onboarding-pop {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.onboarding-tooltip.center {
+  animation-name: onboarding-pop-center;
+}
+
+@keyframes onboarding-pop-center {
+  from { opacity: 0; transform: translate(-50%, -48%); }
+  to { opacity: 1; transform: translate(-50%, -50%); }
+}
+
+.onboarding-progress {
+  display: flex;
+  gap: var(--space-6);
+  margin-bottom: var(--space-12);
+}
+
+.onboarding-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-secondary);
+  border: 1px solid var(--color-border);
+  transition: all var(--duration-fast);
+}
+
+.onboarding-dot.active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  transform: scale(1.2);
+}
+
+.onboarding-dot.done {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  opacity: 0.5;
+}
+
+.onboarding-title {
+  margin: 0 0 var(--space-8);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+}
+
+.onboarding-text {
+  margin: 0 0 var(--space-16);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-normal);
+}
+
+.onboarding-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.onboarding-skip {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  padding: var(--space-4);
+}
+
+.onboarding-skip:hover {
+  color: var(--color-text);
+}
+
+.onboarding-nav {
+  display: flex;
+  gap: var(--space-8);
+}
+
+.onboarding-prev,
+.onboarding-next {
+  padding: var(--space-6) var(--space-16);
+  border-radius: var(--radius-base);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+
+.onboarding-prev {
+  background: var(--color-secondary);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.onboarding-prev:hover {
+  background: var(--color-secondary-hover);
+}
+
+.onboarding-next {
+  background: var(--color-primary);
+  border: 1px solid var(--color-primary);
+  color: var(--color-btn-primary-text);
+}
+
+.onboarding-next:hover {
+  background: var(--color-primary-hover);
+}
+
+.onboarding-next:focus-visible,
+.onboarding-prev:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: 2px;
+}
+
+/* ==========================================================================
+   NOTIFICATION CENTER
+   ========================================================================== */
+
+.notif-bell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background: var(--color-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+
+.notif-bell:hover {
+  background: var(--color-secondary-hover);
+  color: var(--color-primary);
+}
+
+.notif-bell:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: 2px;
+}
+
+.notif-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  background: var(--color-error);
+  color: #fff;
+  font-size: 10px;
+  font-weight: var(--font-weight-bold);
+  line-height: 16px;
+  text-align: center;
+  border-radius: var(--radius-full);
+}
+
+.notif-panel {
+  position: fixed;
+  top: 60px;
+  right: var(--space-16);
+  z-index: 10050;
+  width: 360px;
+  max-width: 90vw;
+  max-height: 70vh;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-8px);
+  transition: all var(--duration-normal) var(--ease-standard);
+}
+
+.notif-panel.open {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.notif-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-12) var(--space-16);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+}
+
+.notif-panel-actions {
+  display: flex;
+  gap: var(--space-8);
+}
+
+.notif-mark-read,
+.notif-clear {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  padding: var(--space-2) var(--space-4);
+}
+
+.notif-mark-read:hover,
+.notif-clear:hover {
+  color: var(--color-primary);
+}
+
+.notif-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4) 0;
+}
+
+.notif-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-10);
+  padding: var(--space-8) var(--space-16);
+  transition: background var(--duration-fast);
+}
+
+.notif-item:hover {
+  background: var(--color-secondary);
+}
+
+.notif-item.unread {
+  background: rgba(var(--color-success-rgb), 0.04);
+}
+
+.notif-item-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 5px;
+}
+
+.notif-info .notif-item-dot { background: var(--color-primary); }
+.notif-warning .notif-item-dot { background: var(--color-warning); }
+.notif-error .notif-item-dot { background: var(--color-error); }
+
+.notif-item.read .notif-item-dot { opacity: 0.3; }
+
+.notif-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.notif-item-msg {
+  display: block;
+  font-size: var(--font-size-xs);
+  color: var(--color-text);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.notif-item.read .notif-item-msg {
+  color: var(--color-text-secondary);
+}
+
+.notif-item-time {
+  display: block;
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+
+.notif-empty {
+  padding: var(--space-24);
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+/* ==========================================================================
+   IDLE MODE - Reduce visual activity when user is inactive
+   ========================================================================== */
+
+.user-idle .progress-fill,
+.user-idle .sensing-bar-fill {
+  transition-duration: 0s;
+  animation: none;
+}
+
+.user-idle canvas {
+  opacity: 0.5;
+  transition: opacity 1s;
+}

--- a/ui/style.css
+++ b/ui/style.css
@@ -2424,3 +2424,437 @@ canvas {
 .pose-trail-btn:hover {
   background: rgba(var(--color-primary-rgb), 0.2);
 }
+
+/* ==========================================================================
+   ENHANCEMENTS: Keyboard Shortcuts, Performance Monitor, Toast, Theme Toggle
+   ========================================================================== */
+
+/* --- Keyboard Shortcuts Overlay --- */
+
+.shortcuts-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-normal) var(--ease-standard);
+}
+
+.shortcuts-overlay.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.shortcuts-panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  width: 480px;
+  max-width: 90vw;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: shortcuts-enter var(--duration-normal) var(--ease-standard);
+}
+
+@keyframes shortcuts-enter {
+  from { transform: scale(0.95) translateY(10px); opacity: 0; }
+  to { transform: scale(1) translateY(0); opacity: 1; }
+}
+
+.shortcuts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-16) var(--space-20);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.shortcuts-header h2 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+}
+
+.shortcuts-close {
+  background: none;
+  border: none;
+  font-size: 22px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: var(--space-4);
+  line-height: 1;
+  border-radius: var(--radius-sm);
+  transition: color var(--duration-fast);
+}
+
+.shortcuts-close:hover {
+  color: var(--color-text);
+}
+
+.shortcuts-close:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: 2px;
+}
+
+.shortcuts-body {
+  padding: var(--space-16) var(--space-20);
+  overflow-y: auto;
+}
+
+.shortcuts-group {
+  margin-bottom: var(--space-16);
+}
+
+.shortcuts-group:last-child {
+  margin-bottom: 0;
+}
+
+.shortcuts-group h3 {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-8);
+}
+
+.shortcut-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+  padding: var(--space-6) 0;
+}
+
+.shortcut-row kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 26px;
+  padding: 0 var(--space-8);
+  background: var(--color-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  box-shadow: 0 1px 0 var(--color-border);
+}
+
+.shortcut-row span {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+/* --- Performance Monitor --- */
+
+.perf-monitor {
+  position: fixed;
+  bottom: var(--space-16);
+  right: var(--space-16);
+  z-index: 9999;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  min-width: 200px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(10px);
+  transition: all var(--duration-normal) var(--ease-standard);
+}
+
+.perf-monitor.visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.perf-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-6) var(--space-10);
+  border-bottom: 1px solid var(--color-border);
+  cursor: grab;
+  user-select: none;
+}
+
+.perf-header span {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  letter-spacing: 0.1em;
+  font-size: 10px;
+}
+
+.perf-close {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 var(--space-2);
+  line-height: 1;
+}
+
+.perf-close:hover {
+  color: var(--color-text);
+}
+
+.perf-metrics {
+  padding: var(--space-6) var(--space-10);
+}
+
+.perf-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: var(--space-2) 0;
+}
+
+.perf-label {
+  color: var(--color-text-secondary);
+  width: 28px;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+
+.perf-value {
+  color: var(--color-text);
+  min-width: 52px;
+  text-align: right;
+}
+
+.perf-value.perf-warning {
+  color: var(--color-warning);
+}
+
+.perf-value.perf-ok {
+  color: var(--color-success);
+}
+
+.perf-spark {
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+[data-color-scheme="dark"] .perf-spark {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* --- Toast Notifications --- */
+
+.toast-container {
+  position: fixed;
+  top: var(--space-16);
+  right: var(--space-16);
+  z-index: 10001;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  max-width: 400px;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-10);
+  padding: var(--space-12) var(--space-16);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  box-shadow: var(--shadow-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  pointer-events: auto;
+  position: relative;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateX(20px);
+  transition: all var(--duration-normal) var(--ease-standard);
+}
+
+.toast.toast-enter {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.toast.toast-exit {
+  animation: toast-out var(--duration-normal) var(--ease-standard) forwards;
+}
+
+@keyframes toast-out {
+  to { opacity: 0; transform: translateX(20px); height: 0; padding: 0; margin: 0; overflow: hidden; }
+}
+
+.toast-success { border-left: 3px solid var(--color-success); }
+.toast-error { border-left: 3px solid var(--color-error); }
+.toast-warning { border-left: 3px solid var(--color-warning); }
+.toast-info { border-left: 3px solid var(--color-primary); }
+
+.toast-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  margin-top: 1px;
+}
+
+.toast-success .toast-icon { color: var(--color-success); }
+.toast-error .toast-icon { color: var(--color-error); }
+.toast-warning .toast-icon { color: var(--color-warning); }
+.toast-info .toast-icon { color: var(--color-primary); }
+
+.toast-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.toast-message {
+  line-height: var(--line-height-normal);
+}
+
+.toast-action {
+  display: inline-block;
+  margin-top: var(--space-4);
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.toast-action:hover {
+  color: var(--color-primary-hover);
+}
+
+.toast-dismiss {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 18px;
+  padding: 0 var(--space-2);
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.toast-dismiss:hover {
+  color: var(--color-text);
+}
+
+.toast-progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.toast-progress-bar {
+  height: 100%;
+  width: 100%;
+  transform-origin: left;
+}
+
+.toast-progress-animate {
+  animation: toast-progress-shrink linear forwards;
+}
+
+@keyframes toast-progress-shrink {
+  from { transform: scaleX(1); }
+  to { transform: scaleX(0); }
+}
+
+.toast-success .toast-progress-bar { background: var(--color-success); }
+.toast-error .toast-progress-bar { background: var(--color-error); }
+.toast-warning .toast-progress-bar { background: var(--color-warning); }
+.toast-info .toast-progress-bar { background: var(--color-primary); }
+
+/* --- Theme Toggle Button --- */
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background: var(--color-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-standard);
+}
+
+.theme-toggle:hover {
+  background: var(--color-secondary-hover);
+  color: var(--color-primary);
+}
+
+.theme-toggle:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: 2px;
+}
+
+/* --- Focus Visible for Accessibility --- */
+
+.nav-tab:focus-visible,
+button:focus-visible,
+a:focus-visible,
+[tabindex]:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: 2px;
+}
+
+/* --- Skip to Content Link --- */
+
+.skip-to-content {
+  position: absolute;
+  top: -100px;
+  left: var(--space-16);
+  padding: var(--space-8) var(--space-16);
+  background: var(--color-primary);
+  color: var(--color-btn-primary-text);
+  border-radius: var(--radius-base);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+  z-index: 10002;
+  transition: top var(--duration-fast);
+}
+
+.skip-to-content:focus {
+  top: var(--space-16);
+}
+
+/* --- Responsive Toasts --- */
+
+@media (max-width: 480px) {
+  .toast-container {
+    left: var(--space-8);
+    right: var(--space-8);
+    max-width: none;
+  }
+
+  .shortcuts-panel {
+    width: 95vw;
+  }
+}

--- a/ui/utils/idle-manager.js
+++ b/ui/utils/idle-manager.js
@@ -1,0 +1,83 @@
+// Idle Manager - Pauses animations, polling, and WebSocket pings when user is inactive
+// Reduces CPU/battery usage on idle dashboards
+
+export class IdleManager {
+  constructor() {
+    this.idleTimeout = 3 * 60 * 1000; // 3 minutes
+    this.isIdle = false;
+    this.timer = null;
+    this.callbacks = { idle: [], active: [] };
+    this.events = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll'];
+  }
+
+  init() {
+    this.resetTimer();
+    this.events.forEach(evt => {
+      document.addEventListener(evt, () => this.onActivity(), { passive: true, capture: true });
+    });
+    // Also use Page Visibility API
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        this.goIdle();
+      } else {
+        this.goActive();
+      }
+    });
+  }
+
+  onActivity() {
+    if (this.isIdle) {
+      this.goActive();
+    }
+    this.resetTimer();
+  }
+
+  resetTimer() {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.goIdle(), this.idleTimeout);
+  }
+
+  goIdle() {
+    if (this.isIdle) return;
+    this.isIdle = true;
+    console.info('[Idle] User inactive - pausing background tasks');
+    this.notify('idle');
+    document.body.classList.add('user-idle');
+  }
+
+  goActive() {
+    if (!this.isIdle) return;
+    this.isIdle = false;
+    console.info('[Idle] User active - resuming background tasks');
+    this.notify('active');
+    document.body.classList.remove('user-idle');
+    this.resetTimer();
+  }
+
+  onIdle(callback) {
+    this.callbacks.idle.push(callback);
+    return () => {
+      const i = this.callbacks.idle.indexOf(callback);
+      if (i > -1) this.callbacks.idle.splice(i, 1);
+    };
+  }
+
+  onActive(callback) {
+    this.callbacks.active.push(callback);
+    return () => {
+      const i = this.callbacks.active.indexOf(callback);
+      if (i > -1) this.callbacks.active.splice(i, 1);
+    };
+  }
+
+  notify(type) {
+    this.callbacks[type].forEach(cb => {
+      try { cb(); } catch (e) { console.error('[Idle] Callback error:', e); }
+    });
+  }
+
+  dispose() {
+    if (this.timer) clearTimeout(this.timer);
+    this.callbacks = { idle: [], active: [] };
+  }
+}

--- a/ui/utils/keyboard-shortcuts.js
+++ b/ui/utils/keyboard-shortcuts.js
@@ -1,0 +1,168 @@
+// Keyboard Shortcuts System
+// Press '?' to show help overlay, number keys to switch tabs, etc.
+
+export class KeyboardShortcuts {
+  constructor(app) {
+    this.app = app;
+    this.shortcuts = new Map();
+    this.helpVisible = false;
+    this.enabled = true;
+    this.overlay = null;
+    this.registerDefaults();
+  }
+
+  registerDefaults() {
+    this.register('?', 'Show keyboard shortcuts', () => this.toggleHelp());
+    this.register('Escape', 'Close overlay / dialog', () => this.closeAll());
+    this.register('1', 'Switch to Dashboard tab', () => this.switchTab('dashboard'));
+    this.register('2', 'Switch to Hardware tab', () => this.switchTab('hardware'));
+    this.register('3', 'Switch to Live Demo tab', () => this.switchTab('demo'));
+    this.register('4', 'Switch to Architecture tab', () => this.switchTab('architecture'));
+    this.register('5', 'Switch to Performance tab', () => this.switchTab('performance'));
+    this.register('6', 'Switch to Applications tab', () => this.switchTab('applications'));
+    this.register('7', 'Switch to Sensing tab', () => this.switchTab('sensing'));
+    this.register('8', 'Switch to Training tab', () => this.switchTab('training'));
+    this.register('p', 'Toggle performance monitor', () => this.togglePerfMonitor());
+    this.register('t', 'Toggle dark/light theme', () => this.toggleTheme());
+  }
+
+  register(key, description, handler) {
+    this.shortcuts.set(key, { description, handler });
+  }
+
+  init() {
+    document.addEventListener('keydown', (e) => this.handleKeydown(e));
+    this.createOverlay();
+  }
+
+  handleKeydown(e) {
+    if (!this.enabled) return;
+
+    // Ignore when typing in inputs
+    const tag = e.target.tagName.toLowerCase();
+    if (tag === 'input' || tag === 'textarea' || tag === 'select' || e.target.isContentEditable) {
+      if (e.key === 'Escape') {
+        e.target.blur();
+      }
+      return;
+    }
+
+    // Ignore modified keys (except shift for '?')
+    if (e.ctrlKey || e.altKey || e.metaKey) return;
+
+    const shortcut = this.shortcuts.get(e.key);
+    if (shortcut) {
+      e.preventDefault();
+      shortcut.handler();
+    }
+  }
+
+  switchTab(tabId) {
+    const tabManager = this.app?.getComponent?.('tabManager');
+    if (tabManager) {
+      tabManager.switchToTab(tabId);
+    }
+  }
+
+  togglePerfMonitor() {
+    const event = new CustomEvent('toggle-perf-monitor');
+    document.dispatchEvent(event);
+  }
+
+  toggleTheme() {
+    const event = new CustomEvent('toggle-theme');
+    document.dispatchEvent(event);
+  }
+
+  closeAll() {
+    if (this.helpVisible) {
+      this.hideHelp();
+    }
+  }
+
+  createOverlay() {
+    this.overlay = document.createElement('div');
+    this.overlay.className = 'shortcuts-overlay';
+    this.overlay.setAttribute('role', 'dialog');
+    this.overlay.setAttribute('aria-label', 'Keyboard shortcuts');
+    this.overlay.setAttribute('aria-modal', 'true');
+    this.overlay.innerHTML = this.buildHelpHTML();
+    this.overlay.addEventListener('click', (e) => {
+      if (e.target === this.overlay) this.hideHelp();
+    });
+    document.body.appendChild(this.overlay);
+  }
+
+  buildHelpHTML() {
+    const groups = [
+      {
+        title: 'Navigation',
+        items: Array.from(this.shortcuts.entries())
+          .filter(([key]) => /^[1-8]$/.test(key))
+      },
+      {
+        title: 'Actions',
+        items: Array.from(this.shortcuts.entries())
+          .filter(([key]) => /^[a-z]$/.test(key))
+      },
+      {
+        title: 'General',
+        items: Array.from(this.shortcuts.entries())
+          .filter(([key]) => !/^[1-8a-z]$/.test(key))
+      }
+    ];
+
+    return `
+      <div class="shortcuts-panel">
+        <div class="shortcuts-header">
+          <h2>Keyboard Shortcuts</h2>
+          <button class="shortcuts-close" aria-label="Close">&times;</button>
+        </div>
+        <div class="shortcuts-body">
+          ${groups.map(group => `
+            <div class="shortcuts-group">
+              <h3>${group.title}</h3>
+              ${group.items.map(([key, { description }]) => `
+                <div class="shortcut-row">
+                  <kbd>${this.formatKey(key)}</kbd>
+                  <span>${description}</span>
+                </div>
+              `).join('')}
+            </div>
+          `).join('')}
+        </div>
+      </div>
+    `;
+  }
+
+  formatKey(key) {
+    const map = { Escape: 'Esc', '?': '?' };
+    return map[key] || key.toUpperCase();
+  }
+
+  toggleHelp() {
+    this.helpVisible ? this.hideHelp() : this.showHelp();
+  }
+
+  showHelp() {
+    this.overlay.classList.add('visible');
+    this.helpVisible = true;
+    // Focus close button
+    const closeBtn = this.overlay.querySelector('.shortcuts-close');
+    if (closeBtn) {
+      closeBtn.onclick = () => this.hideHelp();
+      closeBtn.focus();
+    }
+  }
+
+  hideHelp() {
+    this.overlay.classList.remove('visible');
+    this.helpVisible = false;
+  }
+
+  dispose() {
+    if (this.overlay?.parentNode) {
+      this.overlay.parentNode.removeChild(this.overlay);
+    }
+  }
+}

--- a/ui/utils/notification-center.js
+++ b/ui/utils/notification-center.js
@@ -1,0 +1,233 @@
+// Notification Center - Bell icon with event history
+// Persists notifications across page views (sessionStorage)
+
+export class NotificationCenter {
+  constructor() {
+    this.button = null;
+    this.panel = null;
+    this.notifications = [];
+    this.maxNotifications = 50;
+    this.isOpen = false;
+    this.unreadCount = 0;
+    this.storageKey = 'ruview-notifications';
+  }
+
+  init() {
+    this.loadFromStorage();
+    this.createButton();
+    this.createPanel();
+    this.interceptEvents();
+  }
+
+  createButton() {
+    this.button = document.createElement('button');
+    this.button.className = 'notif-bell';
+    this.button.setAttribute('aria-label', 'Notifications');
+    this.button.setAttribute('title', 'Notifications');
+    this.button.innerHTML = `
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+        <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+      </svg>
+      <span class="notif-badge" style="display:none">0</span>
+    `;
+    this.button.addEventListener('click', () => this.toggle());
+
+    const headerInfo = document.querySelector('.header-info');
+    if (headerInfo) {
+      headerInfo.prepend(this.button);
+    }
+
+    this.updateBadge();
+  }
+
+  createPanel() {
+    this.panel = document.createElement('div');
+    this.panel.className = 'notif-panel';
+    this.panel.setAttribute('role', 'region');
+    this.panel.setAttribute('aria-label', 'Notification history');
+    this.panel.innerHTML = `
+      <div class="notif-panel-header">
+        <span>Notifications</span>
+        <div class="notif-panel-actions">
+          <button class="notif-mark-read" title="Mark all read">Mark read</button>
+          <button class="notif-clear" title="Clear all">Clear</button>
+        </div>
+      </div>
+      <div class="notif-panel-body"></div>
+    `;
+
+    this.panel.querySelector('.notif-mark-read').addEventListener('click', () => {
+      this.notifications.forEach(n => n.read = true);
+      this.unreadCount = 0;
+      this.updateBadge();
+      this.renderList();
+      this.saveToStorage();
+    });
+
+    this.panel.querySelector('.notif-clear').addEventListener('click', () => {
+      this.notifications = [];
+      this.unreadCount = 0;
+      this.updateBadge();
+      this.renderList();
+      this.saveToStorage();
+    });
+
+    document.body.appendChild(this.panel);
+
+    // Close on outside click
+    document.addEventListener('click', (e) => {
+      if (this.isOpen && !this.panel.contains(e.target) && !this.button.contains(e.target)) {
+        this.close();
+      }
+    });
+  }
+
+  interceptEvents() {
+    // Listen for toast events to capture as notifications
+    const origInfo = console.info;
+    console.info = (...args) => {
+      origInfo.apply(console, args);
+      const msg = args.map(String).join(' ');
+      // Only capture app-relevant messages
+      if (msg.includes('[WS-') || msg.includes('Backend') || msg.includes('Service worker') ||
+          msg.includes('connected') || msg.includes('initialized') || msg.includes('sensing')) {
+        this.add(msg, 'info');
+      }
+    };
+
+    const origWarn = console.warn;
+    console.warn = (...args) => {
+      origWarn.apply(console, args);
+      const msg = args.map(String).join(' ');
+      if (msg.includes('Backend') || msg.includes('unavailable') || msg.includes('[WS-') ||
+          msg.includes('connection') || msg.includes('timeout')) {
+        this.add(msg, 'warning');
+      }
+    };
+
+    const origError = console.error;
+    console.error = (...args) => {
+      origError.apply(console, args);
+      const msg = args.map(String).join(' ');
+      if (msg.includes('Failed') || msg.includes('Error') || msg.includes('error')) {
+        this.add(msg, 'error');
+      }
+    };
+  }
+
+  add(message, type = 'info') {
+    const notification = {
+      id: Date.now() + Math.random(),
+      message: this.truncate(message, 200),
+      type,
+      time: new Date().toISOString(),
+      read: false
+    };
+
+    this.notifications.unshift(notification);
+    if (this.notifications.length > this.maxNotifications) {
+      this.notifications.pop();
+    }
+
+    this.unreadCount++;
+    this.updateBadge();
+    this.saveToStorage();
+
+    if (this.isOpen) {
+      this.renderList();
+    }
+  }
+
+  toggle() {
+    this.isOpen ? this.close() : this.open();
+  }
+
+  open() {
+    this.isOpen = true;
+    this.panel.classList.add('open');
+    this.renderList();
+  }
+
+  close() {
+    this.isOpen = false;
+    this.panel.classList.remove('open');
+  }
+
+  renderList() {
+    const body = this.panel.querySelector('.notif-panel-body');
+    if (this.notifications.length === 0) {
+      body.innerHTML = '<div class="notif-empty">No notifications</div>';
+      return;
+    }
+
+    body.innerHTML = this.notifications.map(n => {
+      const time = new Date(n.time);
+      const ago = this.timeAgo(time);
+      return `
+        <div class="notif-item notif-${n.type} ${n.read ? 'read' : 'unread'}">
+          <div class="notif-item-dot"></div>
+          <div class="notif-item-content">
+            <span class="notif-item-msg">${this.escapeHtml(n.message)}</span>
+            <span class="notif-item-time">${ago}</span>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  updateBadge() {
+    const badge = this.button?.querySelector('.notif-badge');
+    if (!badge) return;
+    if (this.unreadCount > 0) {
+      badge.textContent = this.unreadCount > 99 ? '99+' : this.unreadCount;
+      badge.style.display = '';
+    } else {
+      badge.style.display = 'none';
+    }
+  }
+
+  timeAgo(date) {
+    const seconds = Math.floor((new Date() - date) / 1000);
+    if (seconds < 60) return 'just now';
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+    return date.toLocaleDateString();
+  }
+
+  truncate(str, max) {
+    return str.length > max ? str.slice(0, max) + '...' : str;
+  }
+
+  escapeHtml(text) {
+    const d = document.createElement('div');
+    d.textContent = text;
+    return d.innerHTML;
+  }
+
+  loadFromStorage() {
+    try {
+      const data = sessionStorage.getItem(this.storageKey);
+      if (data) {
+        const parsed = JSON.parse(data);
+        this.notifications = parsed.notifications || [];
+        this.unreadCount = parsed.unreadCount || 0;
+      }
+    } catch { /* noop */ }
+  }
+
+  saveToStorage() {
+    try {
+      sessionStorage.setItem(this.storageKey, JSON.stringify({
+        notifications: this.notifications.slice(0, 20),
+        unreadCount: this.unreadCount
+      }));
+    } catch { /* noop */ }
+  }
+
+  dispose() {
+    this.close();
+    this.button?.remove();
+    this.panel?.remove();
+  }
+}

--- a/ui/utils/onboarding.js
+++ b/ui/utils/onboarding.js
@@ -1,0 +1,192 @@
+// Onboarding Tour - Interactive first-run walkthrough
+// Shows on first visit, can be re-triggered from command palette or help
+
+const STORAGE_KEY = 'ruview-onboarding-done';
+
+export class Onboarding {
+  constructor(app) {
+    this.app = app;
+    this.overlay = null;
+    this.currentStep = 0;
+    this.steps = [];
+    this.active = false;
+  }
+
+  init() {
+    this.defineSteps();
+    document.addEventListener('start-onboarding', () => this.start());
+
+    // Auto-start on first visit
+    if (!this.isDone()) {
+      // Delay to let the app render first
+      setTimeout(() => this.start(), 800);
+    }
+  }
+
+  defineSteps() {
+    this.steps = [
+      {
+        title: 'Welcome to RuView',
+        text: 'WiFi-based human pose estimation that works through walls. Let\'s take a quick tour of the dashboard.',
+        target: null, // No highlight, centered
+        position: 'center'
+      },
+      {
+        title: 'System Status',
+        text: 'Monitor your WiFi sensing hardware and API server status in real time. Green means everything is connected.',
+        target: '.live-status-panel',
+        position: 'bottom'
+      },
+      {
+        title: 'Live Demo',
+        text: 'Switch to the Live Demo tab to see real-time pose detection. Connect an ESP32 sensor or use the built-in simulation.',
+        target: '[data-tab="demo"]',
+        position: 'bottom'
+      },
+      {
+        title: 'Sensing Visualization',
+        text: 'The Sensing tab shows a 3D Gaussian splat visualization of WiFi signal fields, with real-time metrics.',
+        target: '[data-tab="sensing"]',
+        position: 'bottom'
+      },
+      {
+        title: 'Keyboard Shortcuts',
+        text: 'Press ? for shortcuts, Ctrl+K for the command palette, or use number keys 1-8 to switch tabs quickly.',
+        target: null,
+        position: 'center'
+      },
+      {
+        title: 'You\'re all set!',
+        text: 'Explore the dashboard, connect hardware, or start the demo. You can replay this tour anytime from the command palette.',
+        target: null,
+        position: 'center'
+      }
+    ];
+  }
+
+  isDone() {
+    try { return localStorage.getItem(STORAGE_KEY) === 'true'; }
+    catch { return false; }
+  }
+
+  markDone() {
+    try { localStorage.setItem(STORAGE_KEY, 'true'); }
+    catch { /* noop */ }
+  }
+
+  start() {
+    this.currentStep = 0;
+    this.active = true;
+    this.createOverlay();
+    this.showStep();
+  }
+
+  createOverlay() {
+    // Remove existing if any
+    this.removeOverlay();
+
+    this.overlay = document.createElement('div');
+    this.overlay.className = 'onboarding-overlay';
+    this.overlay.setAttribute('role', 'dialog');
+    this.overlay.setAttribute('aria-label', 'Onboarding tour');
+    this.overlay.setAttribute('aria-modal', 'true');
+    document.body.appendChild(this.overlay);
+  }
+
+  showStep() {
+    if (this.currentStep >= this.steps.length) {
+      this.finish();
+      return;
+    }
+
+    const step = this.steps[this.currentStep];
+    const total = this.steps.length;
+    const isFirst = this.currentStep === 0;
+    const isLast = this.currentStep === total - 1;
+
+    // Clear highlight
+    document.querySelectorAll('.onboarding-highlight').forEach(el => el.classList.remove('onboarding-highlight'));
+
+    // Highlight target
+    let targetRect = null;
+    if (step.target) {
+      const targetEl = document.querySelector(step.target);
+      if (targetEl) {
+        targetEl.classList.add('onboarding-highlight');
+        targetRect = targetEl.getBoundingClientRect();
+      }
+    }
+
+    this.overlay.innerHTML = `
+      <div class="onboarding-backdrop"></div>
+      <div class="onboarding-tooltip ${step.position}" ${targetRect ? `style="${this.positionTooltip(targetRect, step.position)}"` : ''}>
+        <div class="onboarding-progress">
+          ${Array.from({ length: total }, (_, i) =>
+            `<span class="onboarding-dot ${i === this.currentStep ? 'active' : i < this.currentStep ? 'done' : ''}"></span>`
+          ).join('')}
+        </div>
+        <h3 class="onboarding-title">${step.title}</h3>
+        <p class="onboarding-text">${step.text}</p>
+        <div class="onboarding-actions">
+          <button class="onboarding-skip">Skip tour</button>
+          <div class="onboarding-nav">
+            ${!isFirst ? '<button class="onboarding-prev">Back</button>' : ''}
+            <button class="onboarding-next">${isLast ? 'Get started' : 'Next'}</button>
+          </div>
+        </div>
+      </div>
+    `;
+
+    // Bind events
+    this.overlay.querySelector('.onboarding-skip').addEventListener('click', () => this.finish());
+    this.overlay.querySelector('.onboarding-next').addEventListener('click', () => {
+      this.currentStep++;
+      this.showStep();
+    });
+    const prevBtn = this.overlay.querySelector('.onboarding-prev');
+    if (prevBtn) {
+      prevBtn.addEventListener('click', () => {
+        this.currentStep--;
+        this.showStep();
+      });
+    }
+    this.overlay.querySelector('.onboarding-backdrop').addEventListener('click', () => this.finish());
+
+    // Focus next button
+    this.overlay.querySelector('.onboarding-next').focus();
+
+    // Escape to close
+    this._escHandler = (e) => { if (e.key === 'Escape') this.finish(); };
+    document.addEventListener('keydown', this._escHandler);
+  }
+
+  positionTooltip(rect, position) {
+    const margin = 12;
+    if (position === 'bottom') {
+      return `left: ${Math.max(16, rect.left + rect.width / 2 - 180)}px; top: ${rect.bottom + margin}px;`;
+    }
+    if (position === 'top') {
+      return `left: ${Math.max(16, rect.left + rect.width / 2 - 180)}px; bottom: ${window.innerHeight - rect.top + margin}px;`;
+    }
+    return '';
+  }
+
+  finish() {
+    this.active = false;
+    this.markDone();
+    this.removeOverlay();
+    document.querySelectorAll('.onboarding-highlight').forEach(el => el.classList.remove('onboarding-highlight'));
+    if (this._escHandler) document.removeEventListener('keydown', this._escHandler);
+  }
+
+  removeOverlay() {
+    if (this.overlay?.parentNode) {
+      this.overlay.parentNode.removeChild(this.overlay);
+      this.overlay = null;
+    }
+  }
+
+  dispose() {
+    this.finish();
+  }
+}

--- a/ui/utils/perf-monitor.js
+++ b/ui/utils/perf-monitor.js
@@ -1,0 +1,216 @@
+// Performance Monitor Overlay
+// Shows FPS, memory usage, and network latency in real-time
+
+export class PerfMonitor {
+  constructor() {
+    this.visible = false;
+    this.panel = null;
+    this.frames = [];
+    this.lastFrameTime = 0;
+    this.rafId = null;
+    this.latencyHistory = [];
+    this.maxHistory = 60;
+  }
+
+  init() {
+    this.createPanel();
+    document.addEventListener('toggle-perf-monitor', () => this.toggle());
+  }
+
+  createPanel() {
+    this.panel = document.createElement('div');
+    this.panel.className = 'perf-monitor';
+    this.panel.setAttribute('role', 'status');
+    this.panel.setAttribute('aria-label', 'Performance monitor');
+    this.panel.innerHTML = `
+      <div class="perf-header">
+        <span>PERF</span>
+        <button class="perf-close" aria-label="Close performance monitor">&times;</button>
+      </div>
+      <div class="perf-metrics">
+        <div class="perf-row">
+          <span class="perf-label">FPS</span>
+          <span class="perf-value" data-metric="fps">--</span>
+          <canvas class="perf-spark" data-spark="fps" width="60" height="20"></canvas>
+        </div>
+        <div class="perf-row">
+          <span class="perf-label">MEM</span>
+          <span class="perf-value" data-metric="memory">--</span>
+          <canvas class="perf-spark" data-spark="memory" width="60" height="20"></canvas>
+        </div>
+        <div class="perf-row">
+          <span class="perf-label">LAT</span>
+          <span class="perf-value" data-metric="latency">--</span>
+          <canvas class="perf-spark" data-spark="latency" width="60" height="20"></canvas>
+        </div>
+        <div class="perf-row">
+          <span class="perf-label">DOM</span>
+          <span class="perf-value" data-metric="dom">--</span>
+        </div>
+      </div>
+    `;
+
+    this.panel.querySelector('.perf-close').addEventListener('click', () => this.hide());
+
+    // Make it draggable
+    this.makeDraggable();
+
+    document.body.appendChild(this.panel);
+
+    this.sparkData = {
+      fps: [],
+      memory: [],
+      latency: []
+    };
+  }
+
+  makeDraggable() {
+    const header = this.panel.querySelector('.perf-header');
+    let dragging = false;
+    let offsetX = 0;
+    let offsetY = 0;
+
+    header.addEventListener('mousedown', (e) => {
+      if (e.target.tagName === 'BUTTON') return;
+      dragging = true;
+      offsetX = e.clientX - this.panel.offsetLeft;
+      offsetY = e.clientY - this.panel.offsetTop;
+      header.style.cursor = 'grabbing';
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!dragging) return;
+      this.panel.style.left = `${e.clientX - offsetX}px`;
+      this.panel.style.top = `${e.clientY - offsetY}px`;
+      this.panel.style.right = 'auto';
+      this.panel.style.bottom = 'auto';
+    });
+
+    document.addEventListener('mouseup', () => {
+      dragging = false;
+      header.style.cursor = 'grab';
+    });
+  }
+
+  toggle() {
+    this.visible ? this.hide() : this.show();
+  }
+
+  show() {
+    this.panel.classList.add('visible');
+    this.visible = true;
+    this.lastFrameTime = performance.now();
+    this.tick();
+  }
+
+  hide() {
+    this.panel.classList.remove('visible');
+    this.visible = false;
+    if (this.rafId) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+  }
+
+  tick() {
+    if (!this.visible) return;
+
+    const now = performance.now();
+    this.frames.push(now);
+
+    // Keep only last second of frames
+    while (this.frames.length > 0 && this.frames[0] < now - 1000) {
+      this.frames.shift();
+    }
+
+    const fps = this.frames.length;
+    this.updateMetric('fps', fps, 'fps');
+    this.pushSpark('fps', fps, 0, 120);
+
+    // Memory (if available)
+    if (performance.memory) {
+      const mb = Math.round(performance.memory.usedJSHeapSize / (1024 * 1024));
+      const total = Math.round(performance.memory.jsHeapSizeLimit / (1024 * 1024));
+      this.updateMetric('memory', `${mb}MB`, mb > total * 0.8 ? 'warning' : 'ok');
+      this.pushSpark('memory', mb, 0, total);
+    } else {
+      this.updateMetric('memory', 'N/A', 'na');
+    }
+
+    // DOM node count
+    const domNodes = document.querySelectorAll('*').length;
+    this.updateMetric('dom', domNodes, domNodes > 3000 ? 'warning' : 'ok');
+
+    // Estimate latency from last navigation or resource timing
+    this.measureLatency();
+
+    this.rafId = requestAnimationFrame(() => this.tick());
+  }
+
+  measureLatency() {
+    const entries = performance.getEntriesByType('resource');
+    if (entries.length > 0) {
+      const last = entries[entries.length - 1];
+      const latency = Math.round(last.responseEnd - last.requestStart);
+      if (latency > 0 && latency < 30000) {
+        this.latencyHistory.push(latency);
+        if (this.latencyHistory.length > this.maxHistory) {
+          this.latencyHistory.shift();
+        }
+        const avg = Math.round(
+          this.latencyHistory.reduce((a, b) => a + b, 0) / this.latencyHistory.length
+        );
+        this.updateMetric('latency', `${avg}ms`, avg > 500 ? 'warning' : 'ok');
+        this.pushSpark('latency', avg, 0, 1000);
+      }
+    }
+  }
+
+  updateMetric(metric, value, status) {
+    const el = this.panel.querySelector(`[data-metric="${metric}"]`);
+    if (!el) return;
+    el.textContent = value;
+    el.className = `perf-value perf-${status}`;
+  }
+
+  pushSpark(name, value, min, max) {
+    const data = this.sparkData[name];
+    if (!data) return;
+    data.push(value);
+    if (data.length > 60) data.shift();
+    this.drawSpark(name, data, min, max);
+  }
+
+  drawSpark(name, data, min, max) {
+    const canvas = this.panel.querySelector(`[data-spark="${name}"]`);
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width;
+    const h = canvas.height;
+
+    ctx.clearRect(0, 0, w, h);
+
+    if (data.length < 2) return;
+
+    const range = max - min || 1;
+    ctx.beginPath();
+    ctx.strokeStyle = 'rgba(50, 184, 198, 0.8)';
+    ctx.lineWidth = 1.5;
+
+    data.forEach((val, i) => {
+      const x = (i / (data.length - 1)) * w;
+      const y = h - ((val - min) / range) * h;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+
+    ctx.stroke();
+  }
+
+  dispose() {
+    this.hide();
+    if (this.panel?.parentNode) {
+      this.panel.parentNode.removeChild(this.panel);
+    }
+  }
+}

--- a/ui/utils/router.js
+++ b/ui/utils/router.js
@@ -1,0 +1,47 @@
+// Hash Router - Makes tabs bookmarkable and shareable
+// URL format: #dashboard, #demo, #sensing, etc.
+
+export class Router {
+  constructor(app) {
+    this.app = app;
+    this.validTabs = ['dashboard', 'hardware', 'demo', 'architecture', 'performance', 'applications', 'sensing', 'training'];
+  }
+
+  init() {
+    // Navigate to hash on load
+    this.onHashChange();
+
+    // Listen for hash changes (back/forward navigation)
+    window.addEventListener('hashchange', () => this.onHashChange());
+
+    // Update hash when tab changes
+    const tabManager = this.app?.getComponent?.('tabManager');
+    if (tabManager) {
+      tabManager.onTabChange((tabId) => {
+        this.setHash(tabId);
+      });
+    }
+  }
+
+  onHashChange() {
+    const hash = window.location.hash.replace('#', '').toLowerCase();
+    if (hash && this.validTabs.includes(hash)) {
+      const tabManager = this.app?.getComponent?.('tabManager');
+      if (tabManager && tabManager.getActiveTab() !== hash) {
+        tabManager.switchToTab(hash);
+      }
+    }
+  }
+
+  setHash(tabId) {
+    // Only update if different to avoid infinite loop
+    const current = window.location.hash.replace('#', '');
+    if (current !== tabId) {
+      history.replaceState(null, '', `#${tabId}`);
+    }
+  }
+
+  dispose() {
+    // No explicit cleanup needed - event listeners are on window
+  }
+}

--- a/ui/utils/theme-toggle.js
+++ b/ui/utils/theme-toggle.js
@@ -1,0 +1,86 @@
+// Theme Toggle - Manual dark/light mode switch with persistence
+
+export class ThemeToggle {
+  constructor() {
+    this.button = null;
+    this.currentTheme = this.getSavedTheme() || this.getSystemTheme();
+  }
+
+  init() {
+    this.createButton();
+    this.applyTheme(this.currentTheme);
+    document.addEventListener('toggle-theme', () => this.toggle());
+
+    // Listen for system theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (!this.getSavedTheme()) {
+        this.applyTheme(e.matches ? 'dark' : 'light');
+      }
+    });
+  }
+
+  createButton() {
+    this.button = document.createElement('button');
+    this.button.className = 'theme-toggle';
+    this.button.setAttribute('aria-label', 'Toggle dark/light theme');
+    this.button.setAttribute('title', 'Toggle theme (T)');
+    this.updateIcon();
+    this.button.addEventListener('click', () => this.toggle());
+
+    // Insert into header
+    const headerInfo = document.querySelector('.header-info');
+    if (headerInfo) {
+      headerInfo.prepend(this.button);
+    } else {
+      const header = document.querySelector('.header');
+      if (header) header.appendChild(this.button);
+    }
+  }
+
+  toggle() {
+    this.currentTheme = this.currentTheme === 'dark' ? 'light' : 'dark';
+    this.applyTheme(this.currentTheme);
+    this.saveTheme(this.currentTheme);
+  }
+
+  applyTheme(theme) {
+    this.currentTheme = theme;
+    document.documentElement.setAttribute('data-color-scheme', theme);
+    this.updateIcon();
+  }
+
+  updateIcon() {
+    if (!this.button) return;
+    const isDark = this.currentTheme === 'dark';
+    this.button.innerHTML = isDark
+      ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>'
+      : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+    this.button.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+  }
+
+  getSystemTheme() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  getSavedTheme() {
+    try {
+      return localStorage.getItem('ruview-theme');
+    } catch {
+      return null;
+    }
+  }
+
+  saveTheme(theme) {
+    try {
+      localStorage.setItem('ruview-theme', theme);
+    } catch {
+      // localStorage not available
+    }
+  }
+
+  dispose() {
+    if (this.button?.parentNode) {
+      this.button.parentNode.removeChild(this.button);
+    }
+  }
+}

--- a/ui/utils/toast.js
+++ b/ui/utils/toast.js
@@ -1,0 +1,150 @@
+// Enhanced Toast Notification System
+// Supports multiple types: success, error, warning, info
+// Stacking, auto-dismiss, manual close, progress bar
+
+export class ToastManager {
+  constructor() {
+    this.container = null;
+    this.toasts = [];
+    this.idCounter = 0;
+  }
+
+  init() {
+    this.container = document.createElement('div');
+    this.container.className = 'toast-container';
+    this.container.setAttribute('role', 'region');
+    this.container.setAttribute('aria-label', 'Notifications');
+    this.container.setAttribute('aria-live', 'polite');
+    document.body.appendChild(this.container);
+  }
+
+  show(message, options = {}) {
+    const {
+      type = 'info',
+      duration = 5000,
+      closable = true,
+      icon = null,
+      action = null
+    } = options;
+
+    const id = ++this.idCounter;
+    const toast = document.createElement('div');
+    toast.className = `toast toast-${type}`;
+    toast.setAttribute('role', 'alert');
+    toast.dataset.toastId = id;
+
+    const iconMap = {
+      success: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M13.5 4.5L6 12L2.5 8.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+      error: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M12 4L4 12M4 4l8 8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>',
+      warning: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M8 5v4M8 11h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M7.13 2.22L1.09 12.5a1 1 0 00.87 1.5h12.08a1 1 0 00.87-1.5L8.87 2.22a1 1 0 00-1.74 0z" stroke="currentColor" stroke-width="1.5"/></svg>',
+      info: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.5"/><path d="M8 7v4M8 5h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>'
+    };
+
+    const displayIcon = icon || iconMap[type] || iconMap.info;
+
+    toast.innerHTML = `
+      <div class="toast-icon">${displayIcon}</div>
+      <div class="toast-content">
+        <span class="toast-message">${this.escapeHtml(message)}</span>
+        ${action ? `<button class="toast-action">${this.escapeHtml(action.label)}</button>` : ''}
+      </div>
+      ${closable ? '<button class="toast-dismiss" aria-label="Dismiss">&times;</button>' : ''}
+      ${duration > 0 ? '<div class="toast-progress"><div class="toast-progress-bar"></div></div>' : ''}
+    `;
+
+    // Bind events
+    if (closable) {
+      toast.querySelector('.toast-dismiss').addEventListener('click', () => this.dismiss(id));
+    }
+    if (action?.onClick) {
+      toast.querySelector('.toast-action')?.addEventListener('click', () => {
+        action.onClick();
+        this.dismiss(id);
+      });
+    }
+
+    this.container.appendChild(toast);
+
+    // Trigger enter animation
+    requestAnimationFrame(() => toast.classList.add('toast-enter'));
+
+    // Auto-dismiss
+    let timeoutId = null;
+    if (duration > 0) {
+      const progressBar = toast.querySelector('.toast-progress-bar');
+      if (progressBar) {
+        progressBar.style.animationDuration = `${duration}ms`;
+        progressBar.classList.add('toast-progress-animate');
+      }
+      timeoutId = setTimeout(() => this.dismiss(id), duration);
+    }
+
+    // Pause on hover
+    toast.addEventListener('mouseenter', () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        const bar = toast.querySelector('.toast-progress-bar');
+        if (bar) bar.style.animationPlayState = 'paused';
+      }
+    });
+    toast.addEventListener('mouseleave', () => {
+      if (duration > 0) {
+        const bar = toast.querySelector('.toast-progress-bar');
+        if (bar) bar.style.animationPlayState = 'running';
+        timeoutId = setTimeout(() => this.dismiss(id), duration / 2);
+      }
+    });
+
+    this.toasts.push({ id, toast, timeoutId });
+    return id;
+  }
+
+  dismiss(id) {
+    const index = this.toasts.findIndex(t => t.id === id);
+    if (index === -1) return;
+
+    const { toast, timeoutId } = this.toasts[index];
+    if (timeoutId) clearTimeout(timeoutId);
+
+    toast.classList.add('toast-exit');
+    toast.addEventListener('animationend', () => {
+      toast.remove();
+    }, { once: true });
+
+    this.toasts.splice(index, 1);
+  }
+
+  success(message, options = {}) {
+    return this.show(message, { ...options, type: 'success' });
+  }
+
+  error(message, options = {}) {
+    return this.show(message, { ...options, type: 'error', duration: options.duration || 8000 });
+  }
+
+  warning(message, options = {}) {
+    return this.show(message, { ...options, type: 'warning', duration: options.duration || 6000 });
+  }
+
+  info(message, options = {}) {
+    return this.show(message, { ...options, type: 'info' });
+  }
+
+  escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  dispose() {
+    this.toasts.forEach(({ timeoutId }) => {
+      if (timeoutId) clearTimeout(timeoutId);
+    });
+    this.toasts = [];
+    if (this.container?.parentNode) {
+      this.container.parentNode.removeChild(this.container);
+    }
+  }
+}
+
+export const toastManager = new ToastManager();


### PR DESCRIPTION
## Summary

### 1. URL Hash Routing
Tabs are now bookmarkable and shareable. Navigate to `index.html#demo` to land directly on the Live Demo tab.
- Hash syncs bidirectionally with TabManager
- Browser back/forward navigation works
- Uses `replaceState` to avoid polluting history

### 2. Onboarding Tour (first-run walkthrough)
Interactive 6-step guide that starts automatically on first visit:
- Spotlight highlighting on target elements (status panel, tab buttons)
- Step indicators with progress dots
- Back / Next / Skip controls
- Persists completion to localStorage (won't re-show)
- Can be replayed from the command palette

### 3. Idle Detection
Pauses background tasks when the user is inactive for 3+ minutes:
- Stops health polling to reduce network traffic
- Dims canvas elements and disables CSS animations
- Resumes everything on mouse/keyboard/touch activity
- Integrates with Page Visibility API (tab hidden = idle)
- Reduces CPU/battery on always-on dashboard screens

### 4. Notification Center
Bell icon in the header with unread badge:
- Captures app-relevant events (connections, errors, status changes)
- Dropdown panel with event history, type indicators, relative timestamps
- Mark all read / Clear all actions
- Persists across page views via sessionStorage (up to 20 items)

## Test plan
- [ ] Navigate to `index.html#sensing` - should land on Sensing tab
- [ ] Switch tabs and verify URL hash updates
- [ ] Use browser back button to return to previous tab
- [ ] Clear localStorage and reload - onboarding tour should appear
- [ ] Click through all 6 steps, verify spotlight highlighting
- [ ] Skip tour, reload - tour should not appear again
- [ ] Leave dashboard idle for 3+ min - verify "[Idle]" message in console
- [ ] Move mouse - verify health polling resumes
- [ ] Click bell icon - notification panel opens with captured events
- [ ] Click "Mark read" - badge clears, items dim
- [ ] Reload page - notifications persist in panel