### PR TITLE
fix(mobile): Test the draft settings URL

### DIFF
--- a/ui/mobile/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/ui/mobile/src/__tests__/screens/SettingsScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { ThemeProvider } from '@/theme/ThemeContext';
+import { apiService } from '@/services/api.service';
 import { useSettingsStore } from '@/stores/settingsStore';
 
 jest.mock('@/services/ws.service', () => ({
@@ -23,6 +24,7 @@ jest.mock('@/services/api.service', () => ({
 
 describe('SettingsScreen', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     useSettingsStore.setState({
       serverUrl: 'http://localhost:3000',
       rssiScanEnabled: false,
@@ -81,5 +83,26 @@ describe('SettingsScreen', () => {
     );
     expect(screen.getByText('ABOUT')).toBeTruthy();
     expect(screen.getByText('WiFi-DensePose Mobile v1.0.0')).toBeTruthy();
+  });
+
+  it('tests the current draft URL before it is saved', async () => {
+    const { SettingsScreen } = require('@/screens/SettingsScreen');
+    (apiService.getStatus as jest.Mock).mockResolvedValue({ ok: true });
+
+    render(
+      <ThemeProvider>
+        <SettingsScreen />
+      </ThemeProvider>,
+    );
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText('http://192.168.1.100:8080'),
+      'http://10.0.0.42:9090',
+    );
+    fireEvent.press(screen.getByText('Test Connection'));
+
+    await waitFor(() => {
+      expect(apiService.getStatus).toHaveBeenCalledWith('http://10.0.0.42:9090');
+    });
   });
 });

--- a/ui/mobile/src/__tests__/services/api.service.test.ts
+++ b/ui/mobile/src/__tests__/services/api.service.test.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { API_POSE_STATUS_PATH } from '@/constants/api';
 
 jest.mock('axios', () => {
   const mockAxiosInstance = {
@@ -99,6 +100,25 @@ describe('ApiService', () => {
       apiService.get('/test');
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({ method: 'GET' }),
+      );
+    });
+  });
+
+  describe('getStatus', () => {
+    it('supports a one-off base URL override without mutating the saved base URL', async () => {
+      apiService.setBaseUrl('http://saved-host:3000');
+      mockRequest.mockResolvedValueOnce({ data: { ok: true } });
+      await apiService.getStatus('http://draft-host:4000');
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ url: `http://draft-host:4000${API_POSE_STATUS_PATH}` }),
+      );
+
+      mockRequest.mockResolvedValueOnce({ data: { ok: true } });
+      await apiService.get('/api/next');
+
+      expect(mockRequest).toHaveBeenLastCalledWith(
+        expect.objectContaining({ url: 'http://saved-host:3000/api/next' }),
       );
     });
   });

--- a/ui/mobile/src/screens/SettingsScreen/ServerUrlInput.tsx
+++ b/ui/mobile/src/screens/SettingsScreen/ServerUrlInput.tsx
@@ -25,7 +25,7 @@ export const ServerUrlInput = ({ value, onChange, onSave }: ServerUrlInputProps)
 
     const start = Date.now();
     try {
-      await apiService.getStatus();
+      await apiService.getStatus(value.trim());
       setTestResult(`✓ ${Date.now() - start}ms`);
     } catch {
       setTestResult('✗ Failed');

--- a/ui/mobile/src/services/api.service.ts
+++ b/ui/mobile/src/services/api.service.ts
@@ -20,14 +20,15 @@ class ApiService {
     this.baseUrl = url ?? '';
   }
 
-  private buildUrl(path: string): string {
-    if (!this.baseUrl) {
+  private buildUrl(path: string, baseUrlOverride?: string): string {
+    const baseUrl = baseUrlOverride ?? this.baseUrl;
+    if (!baseUrl) {
       return path;
     }
     if (path.startsWith('http://') || path.startsWith('https://')) {
       return path;
     }
-    const normalized = this.baseUrl.replace(/\/$/, '');
+    const normalized = baseUrl.replace(/\/$/, '');
     return `${normalized}${path.startsWith('/') ? path : `/${path}`}`;
   }
 
@@ -53,31 +54,35 @@ class ApiService {
     return { message: 'Unknown error' };
   }
 
-  private async requestWithRetry<T>(config: AxiosRequestConfig, retriesLeft: number): Promise<T> {
+  private async requestWithRetry<T>(
+    config: AxiosRequestConfig,
+    retriesLeft: number,
+    baseUrlOverride?: string,
+  ): Promise<T> {
     try {
       const response = await this.client.request<T>({
         ...config,
-        url: this.buildUrl(config.url || ''),
+        url: this.buildUrl(config.url || '', baseUrlOverride),
       });
       return response.data;
     } catch (error) {
       if (retriesLeft > 0) {
-        return this.requestWithRetry<T>(config, retriesLeft - 1);
+        return this.requestWithRetry<T>(config, retriesLeft - 1, baseUrlOverride);
       }
       throw this.normalizeError(error);
     }
   }
 
-  get<T>(path: string): Promise<T> {
-    return this.requestWithRetry<T>({ method: 'GET', url: path }, 2);
+  get<T>(path: string, baseUrlOverride?: string): Promise<T> {
+    return this.requestWithRetry<T>({ method: 'GET', url: path }, 2, baseUrlOverride);
   }
 
   post<T>(path: string, body: unknown): Promise<T> {
     return this.requestWithRetry<T>({ method: 'POST', url: path, data: body }, 2);
   }
 
-  getStatus(): Promise<PoseStatus> {
-    return this.get<PoseStatus>(API_POSE_STATUS_PATH);
+  getStatus(baseUrlOverride?: string): Promise<PoseStatus> {
+    return this.get<PoseStatus>(API_POSE_STATUS_PATH, baseUrlOverride);
   }
 
   getZones(): Promise<ZoneConfig[]> {


### PR DESCRIPTION
## Summary
- rebase the previous settings draft URL fix on current `main`
- validate status checks against the unsaved draft URL instead of only persisted config
- add focused tests for draft URL behavior and one-off status URL overrides

## Testing
- `npm --prefix ui/mobile test -- --runInBand src/__tests__/screens/SettingsScreen.test.tsx -t "draft"`
- `npm --prefix ui/mobile test -- --runInBand src/__tests__/services/api.service.test.ts`

## Context
Replacement for closed PR #236 with still-real diff on current `main`.