### PR TITLE
fix: move test-only deps out of requirements.txt into requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,13 @@
+# Development and testing dependencies
+# Install with: pip install -r requirements.txt -r requirements-dev.txt
+
+# Testing
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
+pytest-mock>=3.10.0
+pytest-benchmark>=4.0.0
+
+# Linting and formatting
+black>=23.0.0
+flake8>=6.0.0
+mypy>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,6 @@ scipy>=1.7.0
 torch>=1.12.0
 torchvision>=0.13.0
 
-# Testing dependencies
-pytest>=7.0.0
-pytest-asyncio>=0.21.0
-pytest-mock>=3.10.0
-pytest-benchmark>=4.0.0
-httpx>=0.24.0
-pydantic-settings>=2.0.0
-
 # API dependencies
 fastapi>=0.95.0
 uvicorn>=0.20.0
@@ -20,6 +12,8 @@ pydantic>=1.10.0
 python-jose[cryptography]>=3.3.0
 python-multipart>=0.0.6
 passlib[bcrypt]>=1.7.4
+httpx>=0.24.0
+pydantic-settings>=2.0.0
 
 # Database dependencies
 sqlalchemy>=2.0.0
@@ -42,8 +36,3 @@ scikit-learn>=1.2.0
 
 # Monitoring dependencies
 prometheus-client>=0.16.0
-
-# Development dependencies
-black>=23.0.0
-flake8>=6.0.0
-mypy>=1.0.0


### PR DESCRIPTION
## Summary

Production `requirements.txt` contained test-only dependencies that bloat production installs and increase the attack surface.

### Changes
- Removed `pytest>=7.0.0`, `pytest-asyncio>=0.21.0`, `pytest-mock>=3.10.0`, `pytest-benchmark>=4.0.0` from `requirements.txt`
- Also moved dev-only linting tools (`black`, `flake8`, `mypy`) out of `requirements.txt`
- Created new `requirements-dev.txt` containing all test and development dependencies

Developers can install everything with:
```
pip install -r requirements.txt -r requirements-dev.txt
```

Production deployments only need `requirements.txt`.

Closes #410

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>