### PR TITLE
fix: add Windows ndarray-linalg openblas-system feature

### DIFF
--- a/docs/build-guide.md
+++ b/docs/build-guide.md
@@ -186,6 +186,11 @@ A high-performance Rust port with ~810x speedup over the Python pipeline for the
 
   # macOS
   brew install openblas
+
+  # Windows (via vcpkg)
+  # Install vcpkg: git clone https://github.com/microsoft/vcpkg.git
+  # Then run: vcpkg install openblas:x64-windows
+  # Or use `openblas-system` feature (default on Windows) which links against system OpenBLAS
   ```
 
 ### Build

--- a/rust-port/wifi-densepose-rs/Cargo.toml
+++ b/rust-port/wifi-densepose-rs/Cargo.toml
@@ -50,7 +50,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Signal processing
 ndarray = { version = "0.15", features = ["serde"] }
-ndarray-linalg = { version = "0.16", features = ["openblas-static"] }
+ndarray-linalg = { version = "0.16", default-features = false, features = ["openblas-static"] }
+
+# Windows: use system OpenBLAS via vcpkg or manual install (openblas-static not supported on Windows)
+[target.'cfg(windows)'.dependencies]
+ndarray-linalg = { version = "0.16", default-features = false, features = ["openblas-system"] }
 rustfft = "6.1"
 num-complex = "0.4"
 num-traits = "0.2"


### PR DESCRIPTION
## Summary

Fix Windows build failure for `openblas-src` in the Rust port. On Windows, `openblas-src` does not support non-vcpkg builds — it requires either the `system` feature or vcpkg bootstrap. This PR adds target-specific ndarray-linalg configuration so Windows uses `openblas-system` feature (links against pre-installed system OpenBLAS) while other platforms continue using `openblas-static`.

## Root Cause

```
error: failed to run custom build command for `openblas-src v0.10.15`
Caused by:
  process didn't exit successfully: ...build-script-build (exit code: 101)
  thread 'main' (14152) panicked at ...openblas-src-0.10.15\build.rs:129:13:
  Non-vcpkg builds are not supported on Windows. You must use the 'system' feature.
```

`ndarray-linalg@0.16` with `features = ["openblas-static"]` uses `openblas-src` which only supports vcpkg builds on Windows.

## Fix

**Cargo.toml** — split `ndarray-linalg` into:
- Default (Linux/macOS): `features = ["openblas-static"]` (unchanged)
- Windows target: `features = ["openblas-system"]` (links against system-installed OpenBLAS)

```toml
ndarray-linalg = { version = "0.16", default-features = false, features = ["openblas-static"] }

[target.'cfg(windows)'.dependencies]
ndarray-linalg = { version = "0.16", default-features = false, features = ["openblas-system"] }
```

**build-guide.md** — added Windows section explaining vcpkg installation and the `openblas-system` option.

## Testing

The fix was verified by checking the Cargo.toml resolves correctly for both Windows and non-Windows targets. Full CI build on Windows requires OpenBLAS installed via vcpkg or system package manager.

## Related Issue

- Reported in https://github.com/ruvnet/RuView/issues/415
