### PR TITLE
fix(ci): update Python paths after v1 → archive/v1 reorganization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,16 @@ jobs:
         pip install black flake8 mypy bandit safety
 
     - name: Code formatting check (Black)
-      run: black --check --diff src/ tests/
+      run: black --check --diff archive/v1/src/ archive/v1/tests/
 
     - name: Linting (Flake8)
-      run: flake8 src/ tests/ --max-line-length=88 --extend-ignore=E203,W503
+      run: flake8 archive/v1/src/ archive/v1/tests/ --max-line-length=88 --extend-ignore=E203,W503
 
     - name: Type checking (MyPy)
-      run: mypy src/ --ignore-missing-imports
+      run: mypy archive/v1/src/ --ignore-missing-imports
 
     - name: Security scan (Bandit)
-      run: bandit -r src/ -f json -o bandit-report.json
+      run: bandit -r archive/v1/src/ -f json -o bandit-report.json
       continue-on-error: true
 
     - name: Dependency vulnerability scan (Safety)

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Run Bandit security scan
       run: |
-        bandit -r src/ -f sarif -o bandit-results.sarif
+        bandit -r archive/v1/src/ -f sarif -o bandit-results.sarif
       continue-on-error: true
 
     - name: Upload Bandit results to GitHub Security
@@ -66,7 +66,7 @@ jobs:
         
     - name: Generate Semgrep SARIF
       run: |
-        semgrep --config=p/security-audit --config=p/secrets --config=p/python --sarif --output=semgrep.sarif src/
+        semgrep --config=p/security-audit --config=p/secrets --config=p/python --sarif --output=semgrep.sarif archive/v1/src/
       continue-on-error: true
 
     - name: Upload Semgrep results to GitHub Security
@@ -356,7 +356,7 @@ jobs:
     - name: Check for security headers in code
       run: |
         # Check for security-related configurations
-        grep -r "X-Frame-Options\|X-Content-Type-Options\|X-XSS-Protection\|Content-Security-Policy" src/ || echo "⚠️ Consider adding security headers"
+        grep -r "X-Frame-Options\|X-Content-Type-Options\|X-XSS-Protection\|Content-Security-Policy" archive/v1/src/ || echo "⚠️ Consider adding security headers"
 
     - name: Validate Kubernetes security contexts
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   saturation, hyperfine spectroscopy, or pulsed protocols become required.
 
 ### Fixed
+- Fixed: CI Black/flake8/mypy/bandit/semgrep checks pointed at the old `src/` and `tests/` paths. Updated to `archive/v1/src/` and `archive/v1/tests/` to match the v1 → archive/v1 reorganization. Restores green CI on main and all open PRs.
 - **Ghost skeletons in live UI with multi-node ESP32 setups** (#420, ADR-082) —
   `tracker_bridge::tracker_to_person_detections` documented itself as filtering
   to `is_alive()` tracks but in fact passed every non-Terminated track to the


### PR DESCRIPTION
## Motivation

Commit `81cc241b` moved `v1/` to `archive/v1/`. Two CI workflow files still reference the old `src/` and `tests/` paths, which makes their early steps fail on every push to main and every PR:

- `Code Quality & Security` job (ci.yml): Black, flake8, mypy, and bandit all error with `Path 'src/' does not exist.`
- `Static Application Security Testing` (security-scan.yml): bandit and semgrep error similarly.
- This cascades into `Tests (3.10) / (3.11) / (3.12)` getting CANCELLED via job dependencies.

Result: every PR shows ~10 failed checks regardless of correctness.

## Changes

- `.github/workflows/ci.yml` — point Python tooling at `archive/v1/src/` + `archive/v1/tests/`
- `.github/workflows/security-scan.yml` — point bandit/semgrep at `archive/v1/src/`
- CHANGELOG entry under `[Unreleased]`

## Verification

Workflows are YAML-only changes; structural correctness is the test. After merge:
- main branch CI should turn green
- All currently-failing PRs should re-run and turn green (or surface real issues, currently masked)

Note: this PR does not touch any application code.
