### PR TITLE
v2: pin Rust 1.89 and fix sensing-server UI path when run from v2

### DIFF
--- a/v2/crates/wifi-densepose-sensing-server/src/cli.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/cli.rs
@@ -19,8 +19,8 @@ pub struct Args {
     #[arg(long, default_value = "5005")]
     pub udp_port: u16,
 
-    /// Path to UI static files
-    #[arg(long, default_value = "../../ui")]
+    /// Path to UI static files (from `v2/` cwd use `../ui`)
+    #[arg(long, default_value = "../ui")]
     pub ui_path: PathBuf,
 
     /// Tick interval in milliseconds (default 100 ms = 10 fps for smooth pose animation)

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -83,8 +83,8 @@ struct Args {
     #[arg(long, default_value = "5005")]
     udp_port: u16,
 
-    /// Path to UI static files
-    #[arg(long, default_value = "../../ui")]
+    /// Path to UI static files (repo `ui/`; from `v2/` use `../ui` or rely on auto-detect)
+    #[arg(long, default_value = "../ui")]
     ui_path: PathBuf,
 
     /// Tick interval in milliseconds (default 100 ms = 10 fps for smooth pose animation)
@@ -4223,6 +4223,25 @@ async fn broadcast_tick_task(state: SharedState, tick_ms: u64) {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
+/// If `--ui-path` points nowhere (wrong cwd), try common repo layouts relative to cwd.
+fn coalesce_ui_path(initial: std::path::PathBuf) -> std::path::PathBuf {
+    if initial.is_dir() {
+        return initial;
+    }
+    for rel in &["../ui", "./ui", "../../ui"] {
+        let p = std::path::PathBuf::from(rel);
+        if p.is_dir() {
+            warn!(
+                "UI path {} not found; using {} (set --ui-path explicitly if wrong)",
+                initial.display(),
+                p.display()
+            );
+            return p;
+        }
+    }
+    initial
+}
+
 #[tokio::main]
 async fn main() {
     // Initialize tracing
@@ -4233,7 +4252,8 @@ async fn main() {
         )
         .init();
 
-    let args = Args::parse();
+    let mut args = Args::parse();
+    args.ui_path = coalesce_ui_path(args.ui_path);
 
     // Handle --benchmark mode: run vital sign benchmark and exit
     if args.benchmark {

--- a/v2/rust-toolchain.toml
+++ b/v2/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# wifi-densepose-sensing-server (ruvector-mincut -> ruvector-core / hnsw_rs / mmap-rs):
+# - mmap-rs 0.7: Cargo must accept edition 2024 in a dependency manifest (1.85+).
+# - hnsw_rs 0.3.4: u*.is_multiple_of (1.86+).
+# - ruvector-core 2.0.5 x86_64: #[target_feature(enable = "avx512f")] (1.89+ stable).
+[toolchain]
+channel = "1.89"
+profile = "minimal"


### PR DESCRIPTION
## Summary

Make the sensing server and its static UI usable from a normal `v2/` checkout
without hand-editing paths, and pin a Rust toolchain that matches the workspace
dependency graph (edition 2024 / newer APIs).

## Changes

- Add `v2/rust-toolchain.toml` pinning **Rust 1.89** (required by the current
  `mmap-rs` / edition-2024 chain and related crates in this workspace).
- **Sensing server:** Default UI static path to `../ui` (repo layout: `ui/` next
  to `v2/`), and coalesce fallbacks (`../ui`, `./ui`, `../../ui`) when the default
  is missing so `cargo run` from `v2/` does not serve an empty `/ui`.

## Test plan

- [ ] `cd v2 && cargo build -p wifi-densepose-sensing-server`
- [ ] Run the binary from `v2/` with default args; open the dashboard and confirm
  assets load (no blank UI).

## Notes

Toolchain pin is **repo-wide for `v2/`** via `rust-toolchain.toml`, not only the
sensing server crate; the PR title calls out sensing-server because that is the
user-visible workflow fixed alongside UI path resolution.