### PR TITLE
fix: middleware classes inherit BaseHTTPMiddleware to fix 500 errors …

### DIFF
--- a/archive/v1/src/middleware/auth.py
+++ b/archive/v1/src/middleware/auth.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 
 from fastapi import Request, Response, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from starlette.middleware.base import BaseHTTPMiddleware
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 
@@ -155,16 +156,17 @@ class UserManager:
         return False
 
 
-class AuthenticationMiddleware:
+class AuthenticationMiddleware(BaseHTTPMiddleware):
     """Authentication middleware for FastAPI."""
-    
-    def __init__(self, settings: Settings):
+
+    def __init__(self, app, settings: Settings):
+        super().__init__(app)
         self.settings = settings
         self.token_manager = TokenManager(settings)
         self.user_manager = UserManager()
         self.enabled = settings.enable_authentication
-    
-    async def __call__(self, request: Request, call_next: Callable) -> Response:
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """Process request through authentication middleware."""
         start_time = time.time()
         

--- a/archive/v1/src/middleware/rate_limit.py
+++ b/archive/v1/src/middleware/rate_limit.py
@@ -11,6 +11,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 
 from fastapi import Request, Response, HTTPException, status
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
 from src.config.settings import Settings
@@ -299,15 +300,16 @@ class RateLimiter:
         }
 
 
-class RateLimitMiddleware:
+class RateLimitMiddleware(BaseHTTPMiddleware):
     """Rate limiting middleware for FastAPI."""
-    
-    def __init__(self, settings: Settings):
+
+    def __init__(self, app, settings: Settings):
+        super().__init__(app)
         self.settings = settings
         self.rate_limiter = RateLimiter(settings)
         self.enabled = settings.enable_rate_limiting
-    
-    async def __call__(self, request: Request, call_next: Callable) -> Response:
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """Process request through rate limiting middleware."""
         if not self.enabled:
             return await call_next(request)


### PR DESCRIPTION
## Problem
Both RateLimitMiddleware and AuthenticationMiddleware were not inheriting 
from BaseHTTPMiddleware. Starlette's add_middleware() injects the `app` 
argument automatically, but the __init__ methods only accepted `settings`, 
causing:

  TypeError: RateLimitMiddleware.__init__() got multiple values for argument 'settings'

This made every single API endpoint return a 500 error immediately.

## Fix
- Made both classes inherit from BaseHTTPMiddleware
- Added `app` as first parameter to __init__ and called super().__init__(app)
- Renamed __call__ to dispatch (required by BaseHTTPMiddleware)

## Files changed
- archive/v1/src/middleware/rate_limit.py
- archive/v1/src/middleware/auth.py

## Tested on
- macOS, Python 3.13, FastAPI latest
