### PR TITLE
fix(verify): repoint wrapper to archive/v1 paths (#559) + cross-platform FFT probe (#560)

### DIFF
--- a/scripts/probe-fft-platform.py
+++ b/scripts/probe-fft-platform.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Platform probe: reproduce verify.py's hash-relevant FFT steps in isolation.
+
+Runs the same scipy.fft.fft / scipy.signal calls that verify.py hashes
+(csi_processor.py:426, :438, :349) on a deterministic synthetic input,
+without dragging in src.app / pydantic Settings. Used to empirically
+locate the source of platform divergence in issue #560.
+
+Usage:  python3 scripts/probe-fft-platform.py
+Output: single JSON object on stdout. Run on each platform and diff.
+
+If two machines print the same `first8_doppler_bytes_hex` and the same
+`first4_psd_floats` but different `sha256`, the divergence is in later
+FFT bins (SIMD reordering). If even the first values differ, it's a
+true ULP-level divergence at every bin (Apple Silicon NEON vs x86_64
+AVX, or different scipy pocketfft builds).
+"""
+import hashlib
+import json
+import platform
+import struct
+import sys
+
+import numpy as np
+import scipy.fft
+import scipy.signal
+
+# Deterministic synthetic input -- no IO, no .env, no Settings
+rng = np.random.RandomState(42)
+N_FRAMES = 100
+N_SUBC = 100
+amp = rng.randn(N_FRAMES, N_SUBC).astype(np.float64)
+
+# Mirror the three scipy calls verify.py's hash depends on:
+#   archive/v1/src/core/csi_processor.py:349 -> scipy.signal.windows.hamming
+#   archive/v1/src/core/csi_processor.py:426 -> scipy.fft.fft(mean_phase_diff, n=64)
+#   archive/v1/src/core/csi_processor.py:438 -> scipy.fft.fft(amp.flatten(), n=128)
+mean_phase_diff = amp.mean(axis=1)
+doppler = np.abs(scipy.fft.fft(mean_phase_diff, n=64)) ** 2
+psd = np.abs(scipy.fft.fft(amp.flatten(), n=128)) ** 2
+window = scipy.signal.windows.hamming(56)
+
+# Pack the same way verify.py:features_to_bytes does (little-endian f64)
+parts = []
+for arr in (doppler, psd, window):
+    flat = np.asarray(arr, dtype=np.float64).ravel()
+    parts.append(struct.pack(f"<{len(flat)}d", *flat))
+blob = b"".join(parts)
+
+try:
+    blas_info = np.show_config(mode="dicts")
+except Exception:
+    blas_info = {"error": "show_config(mode=dicts) unavailable"}
+
+print(json.dumps({
+    "uname": platform.uname()._asdict(),
+    "python": sys.version.split()[0],
+    "numpy": np.__version__,
+    "scipy": __import__("scipy").__version__,
+    "blob_len": len(blob),
+    "sha256": hashlib.sha256(blob).hexdigest(),
+    "first8_doppler_bytes_hex": doppler[:8].tobytes().hex(),
+    "first4_psd_floats": psd[:4].tolist(),
+    "blas_backend": blas_info if isinstance(blas_info, dict) else str(blas_info),
+}, indent=2, default=str))

--- a/verify
+++ b/verify
@@ -19,9 +19,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROOF_DIR="${SCRIPT_DIR}/v1/data/proof"
+PROOF_DIR="${SCRIPT_DIR}/archive/v1/data/proof"
 VERIFY_PY="${PROOF_DIR}/verify.py"
-V1_SRC="${SCRIPT_DIR}/v1/src"
+V1_SRC="${SCRIPT_DIR}/archive/v1/src"
 
 # Colors (disabled if not a terminal)
 if [ -t 1 ]; then
@@ -136,7 +136,7 @@ echo ""
 echo -e "${CYAN}[PHASE 3] PRODUCTION CODE INTEGRITY SCAN${RESET}"
 echo ""
 echo "  Scanning ${V1_SRC} for np.random.rand / np.random.randn calls..."
-echo "  (Excluding v1/src/testing/ -- test helpers are allowed to use random.)"
+echo "  (Excluding archive/v1/src/testing/ -- test helpers are allowed to use random.)"
 echo ""
 
 MOCK_FINDINGS=0
@@ -204,7 +204,7 @@ elif [ $PIPELINE_EXIT -eq 2 ]; then
     echo -e "  ${YELLOW}${BOLD}RESULT: SKIP${RESET}"
     echo ""
     echo "  No expected hash file to compare against."
-    echo "  Run: python v1/data/proof/verify.py --generate-hash"
+    echo "  Run: python archive/v1/data/proof/verify.py --generate-hash"
     echo ""
     echo -e "${BOLD}======================================================================${RESET}"
     exit 2


### PR DESCRIPTION
Closes #559. Adds empirical root-cause evidence for #560 (left open pending maintainer decision on quantize-before-hash).

## #559 — ./verify wrapper points at removed v1/ paths

`./verify` failed before reaching the proof script on a fresh clone because the wrapper still pointed at the pre-archive layout:

```text
FAIL: Reference signal not found at .../RuView/v1/data/proof/sample_csi_data.json
FAIL: verify.py not found at .../RuView/v1/data/proof/verify.py
```

Repointed `PROOF_DIR`, `V1_SRC`, and two diagnostic strings to `archive/v1/...`. Three-line core diff matches exactly what @Fewmanism proposed in #559.

## #560 — Empirical root-cause probe

Added `scripts/probe-fft-platform.py` which runs `verify.py`'s hash-relevant `scipy.fft.fft` + `scipy.signal.windows.hamming` calls in isolation on a deterministic input (no pydantic `Settings` stack), so the source of divergence can be located cleanly.

Tested via Tailscale on three real machines:

| Platform | numpy/scipy | first 4 PSD floats | sha256 |
|----------|-------------|--------------------|--------|
| Windows (Intel AVX-512) | 2.4.2 / 1.17.1 | `..., 94.40426770856882, ..., 51.677496924642476` | `78b3fb…` |
| ruvultra (Linux x86_64) | 1.26.4 / 1.14.1 | `..., 94.40426770856882, ..., 51.677496924642476` | `41dc56…` |
| ruv-mac-mini (Apple Silicon arm64/NEON) | 2.4.4 / 1.17.1 | `..., 94.4042677085688, ..., 51.67749692464246` | `9b5e19…` |

- Win + Linux agree on first PSD/doppler values but produce different SHA-256s → divergence is in **later** FFT bins, where scipy version's pocketfft SIMD path differs.
- Mac arm64 differs from x86_64 **at the first bins** at ULP precision (~2e-14 on value ~94 = ~1 ULP).

The divergence is at the SIMD level: NEON (Apple Silicon) vs AVX2/AVX-512 (x86_64) reorder vectorized FP operations differently. IEEE 754 guarantees per-operation determinism, not associativity under reordering — so the docstring at `archive/v1/data/proof/verify.py:172` ("platform-independent for IEEE 754 compliant systems") is incorrect.

## What this PR does **not** fix

The architectural fix for #560 is **quantize-before-hash** in `features_to_bytes()` (round float64 to a fixed precision well above SIMD-ULP, e.g. 1e-9, before packing) — then regenerate `expected_features.sha256` on a canonical CI platform. That changes a published trust-anchor artifact and merits a maintainer call. This PR ships only the path fix + diagnostic probe so #559 unblocks immediately while #560 gets reviewed.

## Verification

```bash
# Before: FAIL before reaching pipeline (v1/... not found)
./verify
# After:  reaches verify.py and runs the pipeline (path layer healed)

# Cross-platform divergence reproducible:
python3 scripts/probe-fft-platform.py
```

## Test plan
- [x] `./verify` on macOS / Linux / Windows: wrapper reaches `verify.py` and the path-level errors are gone
- [x] `scripts/probe-fft-platform.py` runs cleanly on Windows + ruvultra Linux + ruv-mac-mini Mac arm64
- [x] Probe output empirically demonstrates the platform divergence claim from #560
- [ ] Maintainer decision on #560 fix shape (quantize-before-hash vs platform-pin vs multi-hash)

Thanks to @Fewmanism for the clean repro + the suggested diff in #559.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)