### PR TITLE
chore(scripts): probe-fft-platform.py — root-cause aid for #560

### DIFF
--- a/scripts/probe-fft-platform.py
+++ b/scripts/probe-fft-platform.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Platform probe: reproduce verify.py's hash-relevant FFT steps in isolation.
+
+Runs the same scipy.fft.fft / scipy.signal calls that verify.py hashes
+(csi_processor.py:426, :438, :349) on a deterministic synthetic input,
+without dragging in src.app / pydantic Settings. Used to empirically
+locate the source of platform divergence in issue #560.
+
+Usage:  python3 scripts/probe-fft-platform.py
+Output: single JSON object on stdout. Run on each platform and diff.
+
+If two machines print the same `first8_doppler_bytes_hex` and the same
+`first4_psd_floats` but different `sha256`, the divergence is in later
+FFT bins (SIMD reordering). If even the first values differ, it's a
+true ULP-level divergence at every bin (Apple Silicon NEON vs x86_64
+AVX, or different scipy pocketfft builds).
+"""
+import hashlib
+import json
+import platform
+import struct
+import sys
+
+import numpy as np
+import scipy.fft
+import scipy.signal
+
+# Deterministic synthetic input -- no IO, no .env, no Settings
+rng = np.random.RandomState(42)
+N_FRAMES = 100
+N_SUBC = 100
+amp = rng.randn(N_FRAMES, N_SUBC).astype(np.float64)
+
+# Mirror the three scipy calls verify.py's hash depends on:
+#   archive/v1/src/core/csi_processor.py:349 -> scipy.signal.windows.hamming
+#   archive/v1/src/core/csi_processor.py:426 -> scipy.fft.fft(mean_phase_diff, n=64)
+#   archive/v1/src/core/csi_processor.py:438 -> scipy.fft.fft(amp.flatten(), n=128)
+mean_phase_diff = amp.mean(axis=1)
+doppler = np.abs(scipy.fft.fft(mean_phase_diff, n=64)) ** 2
+psd = np.abs(scipy.fft.fft(amp.flatten(), n=128)) ** 2
+window = scipy.signal.windows.hamming(56)
+
+# Pack the same way verify.py:features_to_bytes does (little-endian f64)
+parts = []
+for arr in (doppler, psd, window):
+    flat = np.asarray(arr, dtype=np.float64).ravel()
+    parts.append(struct.pack(f"<{len(flat)}d", *flat))
+blob = b"".join(parts)
+
+try:
+    blas_info = np.show_config(mode="dicts")
+except Exception:
+    blas_info = {"error": "show_config(mode=dicts) unavailable"}
+
+print(json.dumps({
+    "uname": platform.uname()._asdict(),
+    "python": sys.version.split()[0],
+    "numpy": np.__version__,
+    "scipy": __import__("scipy").__version__,
+    "blob_len": len(blob),
+    "sha256": hashlib.sha256(blob).hexdigest(),
+    "first8_doppler_bytes_hex": doppler[:8].tobytes().hex(),
+    "first4_psd_floats": psd[:4].tolist(),
+    "blas_backend": blas_info if isinstance(blas_info, dict) else str(blas_info),
+}, indent=2, default=str))


### PR DESCRIPTION
## Summary

Adds `scripts/probe-fft-platform.py`, a single-file diagnostic that reproduces `verify.py`'s hash-relevant FFT steps in isolation on a deterministic synthetic input, without pulling in `src.app` / pydantic `Settings`. Used to empirically locate the source of the platform-specific hash divergence reported in **#560**.

The script:
- Runs the same `scipy.fft.fft` + `scipy.signal.windows.hamming` calls that `verify.py` hashes
- Prints `uname`, `python`, `numpy`/`scipy` versions, SHA-256 of the output buffer, the first 8 Doppler bytes, the first 4 PSD floats, and the SciPy BLAS backend metadata
- One JSON object on stdout per run — easy to diff across machines

## Why

The docstring at `archive/v1/data/proof/verify.py:172` ("platform-independent for IEEE 754 compliant systems") is **incorrect**. SciPy's pocketfft uses SIMD vector kernels — AVX2/AVX-512 on x86_64, NEON on Apple Silicon — that reorder FP operations differently across builds. IEEE 754 guarantees per-operation determinism, not associativity under reordering. The SHA-256 of the production pipeline diverges at ULP precision per platform, which is what bug report #560 caught on macOS arm64.

## Empirical evidence (across three machines via Tailscale)

| Platform | numpy/scipy | first 4 PSD floats | sha256 |
|----------|-------------|--------------------|--------|
| Windows (Intel AVX-512) | 2.4.2 / 1.17.1 | `..., 94.40426770856882, ..., 51.677496924642476` | `78b3fb…` |
| ruvultra (Linux x86_64) | 1.26.4 / 1.14.1 | `..., 94.40426770856882, ..., 51.677496924642476` | `41dc56…` |
| ruv-mac-mini (Apple Silicon NEON) | 2.4.4 / 1.17.1 | `..., 94.4042677085688, ..., 51.67749692464246` | `9b5e19…` |

- Win + Linux agree on first PSD values but produce different SHA-256s → divergence is in **later** FFT bins (different scipy pocketfft SIMD paths).
- Mac arm64 differs from x86_64 at the first bins at ~1 ULP precision (~2e-14 on a value of ~94).

## What this PR does NOT do

The architectural fix for #560 is **quantize-before-hash** in `features_to_bytes()` — round float64 to a fixed precision well above SIMD-ULP (e.g. 1e-9) before packing — then regenerate `expected_features.sha256` on a canonical CI platform. That changes a published trust-anchor artifact (the witness chain) and merits a deliberate maintainer call. This PR ships only the diagnostic, so the empirical evidence is in-repo when that decision happens.

## Relation to #577

PR **#577** bundled the verify path fix for #559 + this probe script for #560. The verify path fix already shipped via PR **#590** (merged earlier this session), so #577's diff against current `main` is now mostly empty for the `verify` portion. This PR extracts only the still-useful probe script; #577 can be closed.

## Test plan

- [x] `python3 scripts/probe-fft-platform.py` runs cleanly on Windows (verified locally on `ruvzen` — output matches the Windows row of the table above)
- [ ] (Maintainer) Run on macOS / Linux hosts to confirm the divergence pattern is reproducible
- [ ] (Future) Use the output to validate that any chosen `features_to_bytes()` quantization actually collapses the per-platform hash to a single value

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)