### PR TITLE
fix(ui): clamp deltaTime to 1ms in pose-renderer FPS calc (#519 Bug 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`ui/utils/pose-renderer.js` no longer divides by zero** when two render frames land in the same `performance.now()` tick (issue #519 Bug 2). `deltaTime` is now `Math.max(currentTime - lastFrameTime, 1)` before the `1000 / deltaTime` division, capping displayed FPS at 1000 — far above any real render rate, but finite so the EMA `averageFps = averageFps * 0.9 + fps * 0.1` no longer poisons itself to `Infinity` on a single zero-dt tick.
+
 ### Removed
 - **Stub crates `wifi-densepose-api`, `wifi-densepose-db`, `wifi-densepose-config`** (closes #578).
   Each was a single-line doc-comment placeholder with an empty `[dependencies]`

--- a/ui/utils/pose-renderer.js
+++ b/ui/utils/pose-renderer.js
@@ -651,14 +651,18 @@ export class PoseRenderer {
     this.performanceMetrics.frameCount++;
 
     if (this.performanceMetrics.lastFrameTime > 0) {
-      const deltaTime = currentTime - this.performanceMetrics.lastFrameTime;
+      // Clamp to a minimum dt so consecutive frames within the same
+      // performance.now() tick don't yield Infinity (issue #519 Bug 2).
+      // 1 ms floor caps the displayed FPS at 1000 — far above any real
+      // render rate, but finite so the EMA stays well-defined.
+      const deltaTime = Math.max(currentTime - this.performanceMetrics.lastFrameTime, 1);
       const fps = 1000 / deltaTime;
-      
+
       // Update average FPS using exponential moving average
       if (this.performanceMetrics.averageFps === 0) {
         this.performanceMetrics.averageFps = fps;
       } else {
-        this.performanceMetrics.averageFps = 
+        this.performanceMetrics.averageFps =
           (this.performanceMetrics.averageFps * 0.9) + (fps * 0.1);
       }
     }


### PR DESCRIPTION
Closes #519 Bug 2 (FPS shows Infinity).

## Root cause

`ui/utils/pose-renderer.js:655` did `fps = 1000 / deltaTime` without a floor. When two render frames land in the same `performance.now()` tick (common when an animation frame batches multiple renders), `deltaTime === 0` and the EMA `averageFps = averageFps * 0.9 + Infinity * 0.1` poisons itself permanently. The HUD then reads `Infinity FPS` until page reload.

## Fix

```diff
- const deltaTime = currentTime - this.performanceMetrics.lastFrameTime;
+ const deltaTime = Math.max(currentTime - this.performanceMetrics.lastFrameTime, 1);
  const fps = 1000 / deltaTime;
```

The 1 ms floor caps displayed FPS at 1000 — far above any real render rate (a 240 Hz monitor renders every ~4 ms), so the cap is never observed in practice. Keeps the EMA finite.

## Test plan

- [x] Code inspection: only call site touched; rest of `updatePerformanceMetrics` unchanged
- [ ] (Reviewer, optional) Reproduce in browser by rapid-firing render frames; confirm the old build shows `Infinity FPS` and the new build doesn't

## Related

Issue #519 has three other multi-node bugs documented separately:
- Bug 1 (ghost person count) — addressed by PR #491 (awaiting contributor rebase)
- Bug 3 (skeleton flicker) — partially addressed by merged PR #484 (WS Lagged + ping keepalive)
- Bug 4 (jumpy vitals) — fixed by merged PR #595 (vital_signs circular variance)

This PR closes only Bug 2 cleanly. The other three are tracked in their own threads.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)