### PR TITLE
fix(archive/v1/pose-service): call sanitize_phase, not sanitize (closes #612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`archive/v1/src/services/pose_service.py:223` calls the right method on `PhaseSanitizer`** (closes #612). The call was `self.phase_sanitizer.sanitize(phase_data)`, but `PhaseSanitizer`'s full-pipeline entry point is named `sanitize_phase()` (`unwrap_phase` + `remove_outliers` + `smooth_phase` chained, see `archive/v1/src/core/phase_sanitizer.py:266`). The shorter `sanitize` name doesn't exist on the class, so any path that reached this branch raised `AttributeError` and crashed the pose service mid-frame.
 - **`adaptive_classifier.rs:94` no longer panics on NaN feature values** (closes #611).
   `sorted.sort_by(|a, b| a.partial_cmp(b).unwrap())` returned `None` and panicked
   whenever a single `NaN` reached the classifier from real ESP32 hardware (silent

--- a/archive/v1/src/services/pose_service.py
+++ b/archive/v1/src/services/pose_service.py
@@ -220,7 +220,11 @@ class PoseService:
                 # Apply phase sanitization if we have phase data
                 if hasattr(detection_result.features, 'phase_difference'):
                     phase_data = detection_result.features.phase_difference
-                    sanitized_phase = self.phase_sanitizer.sanitize(phase_data)
+                    # PhaseSanitizer's full-pipeline method is sanitize_phase,
+                    # not sanitize (issue #612). The shorter name was an
+                    # AttributeError waiting to fire on any code path that
+                    # reaches this branch.
+                    sanitized_phase = self.phase_sanitizer.sanitize_phase(phase_data)
                     # Combine amplitude and phase data
                     return np.concatenate([amplitude_data, sanitized_phase])
                 


### PR DESCRIPTION
Closes #612 — credit @bannned-bit for the exact line + diff.

## Bug

`archive/v1/src/services/pose_service.py:223`:

```python
sanitized_phase = self.phase_sanitizer.sanitize(phase_data)
```

`PhaseSanitizer` exposes the full-pipeline entry point as **`sanitize_phase()`** (`archive/v1/src/core/phase_sanitizer.py:266`), which chains `unwrap_phase` + `remove_outliers` + `smooth_phase`. The shorter `sanitize` name doesn't exist on the class, so any path that reaches this branch raises `AttributeError` and crashes the pose service mid-frame.

## Fix

```diff
- sanitized_phase = self.phase_sanitizer.sanitize(phase_data)
+ sanitized_phase = self.phase_sanitizer.sanitize_phase(phase_data)
```

## Audit

`grep -rn 'phase_sanitizer\.sanitize\b' archive/v1/src/` — only one call site uses the wrong name; this PR fixes the only occurrence.

## Why this matters even though it's v1 archived code

The proof verify path (`./verify` → `archive/v1/data/proof/verify.py`) still imports `from src.core.csi_processor` and `from src.hardware.csi_extractor` under `archive/v1/`. The pose service code isn't on the proof's hot path, but any consumer who reactivates v1 (some forks do — see the closed #150 / #207 PRs) would hit the AttributeError immediately.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)