### PR TITLE
fix(sensing): finish #611 NaN-panic audit — 7 sites missed by #613

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   process. Swapped for `unwrap_or(Ordering::Equal)`, matching the pattern the
   same file already used at lines 149-150 and 155. Per-frame hot path; this was
   a real production crash vector.
+- **Completed the #611 NaN-panic audit across the sensing-server crate** (follow-up
+  to #613). The original audit grepped for the literal `partial_cmp(b).unwrap()`
+  and missed seven additional production sites that use comparator variants
+  (`partial_cmp(b.1).unwrap()`, `partial_cmp(&variances[b]).unwrap()`). All share
+  the same crash class — a single `NaN` in CSI-derived state panics the whole
+  sensing-server. Fixed:
+  - `adaptive_classifier.rs:205` — `AdaptiveModel::classify()` argmax over softmax
+    probs. **Same per-frame hot path as #611**; NaN flows through normalise →
+    logits → softmax and still reaches this site even after the #613 IQR fix.
+  - `adaptive_classifier.rs:480, 500` — training-loop argmax in `train()`
+    (training/per-class accuracy reporting).
+  - `main.rs:2446, 2449` and `csi.rs:602, 605` — variance-based source/sink
+    selection in `count_persons_mincut`. The outer `unwrap_or((0, &0))` only
+    catches an empty iterator; it cannot rescue a comparator panic.
+
+  Remaining `partial_cmp(...).unwrap()` sites in the workspace are all inside
+  `#[cfg(test)]` / `#[test]` blocks (`spectrogram.rs:269`, `depth.rs:234`,
+  `connectivity.rs:477`, `vital_signs.rs:737`) where inputs are controlled.
 - **`ui/utils/pose-renderer.js` no longer divides by zero** when two render frames land in the same `performance.now()` tick (issue #519 Bug 2). `deltaTime` is now `Math.max(currentTime - lastFrameTime, 1)` before the `1000 / deltaTime` division, capping displayed FPS at 1000 — far above any real render rate, but finite so the EMA `averageFps = averageFps * 0.9 + fps * 0.1` no longer poisons itself to `Infinity` on a single zero-dt tick.
 
 ### Removed

--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -200,9 +200,11 @@ impl AdaptiveModel {
             probs[c] = ((logits[c] - max_logit).exp()) / exp_sum;
         }
 
-        // Pick argmax.
+        // Pick argmax. Same NaN-panic class as #611: if any raw_feature is NaN
+        // it propagates through normalize → logits → softmax, then partial_cmp
+        // returns None and unwrap() panics the sensing server on every frame.
         let (best_c, best_p) = probs.iter().enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
             .unwrap();
         let label = if best_c < self.class_names.len() {
             self.class_names[best_c].clone()
@@ -477,7 +479,7 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
             }
         }
         let pred = logits.iter().enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
             .unwrap().0;
         if pred == *target { correct += 1; }
     }
@@ -497,7 +499,7 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
             }
         }
         let pred = logits.iter().enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
             .unwrap().0;
         if pred == *target { class_correct[*target] += 1; }
     }

--- a/v2/crates/wifi-densepose-sensing-server/src/csi.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/csi.rs
@@ -598,11 +598,13 @@ pub fn estimate_persons_from_correlation(frame_history: &VecDeque<Vec<f64>>) -> 
         }
     }
 
+    // partial_cmp returns None on NaN; the outer unwrap_or only catches an
+    // empty iterator, not a comparator panic. Same NaN-panic class as #611.
     let (max_var_idx, _) = active.iter().enumerate()
-        .max_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap())
+        .max_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap_or(std::cmp::Ordering::Equal))
         .unwrap_or((0, &0));
     let (min_var_idx, _) = active.iter().enumerate()
-        .min_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap())
+        .min_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap_or(std::cmp::Ordering::Equal))
         .unwrap_or((0, &0));
     if max_var_idx == min_var_idx { return 1; }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -2441,12 +2441,15 @@ fn estimate_persons_from_correlation(frame_history: &VecDeque<Vec<f64>>) -> usiz
         }
     }
 
-    // Source → highest-variance subcarrier, Sink → lowest-variance
+    // Source → highest-variance subcarrier, Sink → lowest-variance.
+    // partial_cmp returns None on NaN; the outer unwrap_or only catches an
+    // empty iterator, not a comparator panic. Same NaN-panic class as #611
+    // — a single NaN variance frame would kill the sensing-server process.
     let (max_var_idx, _) = active.iter().enumerate()
-        .max_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap())
+        .max_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap_or(std::cmp::Ordering::Equal))
         .unwrap_or((0, &0));
     let (min_var_idx, _) = active.iter().enumerate()
-        .min_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap())
+        .min_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap_or(std::cmp::Ordering::Equal))
         .unwrap_or((0, &0));
 
     if max_var_idx == min_var_idx {


### PR DESCRIPTION
## Summary

Follow-up to #613 (which closed #611). #613 fixed `adaptive_classifier.rs:94` and explicitly stated the audit was complete. That audit grepped for the literal pattern `partial_cmp(b).unwrap()` and missed **seven additional production sites** that use comparator variants — all share the same crash class as #611 (NaN in `f64` data → `partial_cmp` returns `None` → `unwrap()` panics the sensing server).

## Sites fixed

| File | Line | Function | Why it matters |
|------|------|----------|----------------|
| `v2/.../adaptive_classifier.rs` | 205 | `AdaptiveModel::classify()` argmax over softmax probs | **Same per-frame hot path as #611.** A NaN in `raw_features` survives normalise (`NaN / x = NaN`) → logits → softmax (`exp(NaN)/exp(NaN) = NaN`), and the #613 IQR fix does not gate this branch. |
| `v2/.../adaptive_classifier.rs` | 480, 500 | `train_from_recordings()` argmax | Training accuracy / per-class accuracy loops. |
| `v2/.../main.rs` | 2446, 2449 | `count_persons_mincut` variance source/sink select | The outer `.unwrap_or((0, &0))` only catches an empty iterator — it cannot rescue a panic raised inside the comparator. A single NaN in `variances[]` aborts the process. |
| `v2/.../csi.rs` | 602, 605 | same logic, duplicated in `csi.rs` | Same as above. |

## Fix

Drop-in: swap `.unwrap()` for `.unwrap_or(std::cmp::Ordering::Equal)` inside the comparator closure. This is the same one-line behavioural change as #613 and matches the pattern the same files already use elsewhere (e.g. `adaptive_classifier.rs:149-150, 155`, and now `:94` from #613).

No API change, no test changes needed — the existing fix(sensing) commit precedent in CHANGELOG describes this as a behavioural fix only.

## Re-audit of remaining `partial_cmp(...).unwrap()` sites

After this PR, the only remaining `partial_cmp(…).unwrap()` matches in `v2/` are inside `#[cfg(test)]` / `#[test]` blocks where inputs are controlled and panic-on-NaN is acceptable:

- `wifi-densepose-signal/src/spectrogram.rs:269` — `#[test] fn test_single_frequency_peak`
- `wifi-densepose-pointcloud/src/depth.rs:234` — backproject test
- `ruv-neural/ruv-neural-signal/src/connectivity.rs:477` — coherence test
- `wifi-densepose-sensing-server/src/vital_signs.rs:737` — `#[test] fn test_fft_peak`

(#613's PR body listed the first three explicitly as benign; this PR confirms `vital_signs.rs:737` is the same category.)

## Test plan

- [ ] `cd v2 && cargo check -p wifi-densepose-sensing-server --no-default-features` (no Rust toolchain available in my environment — relying on CI).
- [ ] `cd v2 && cargo test --workspace --no-default-features` — 1,031+ passed expected, behavioural change should not affect any test that doesn't already inject NaN.
- [ ] Spot-grep `partial_cmp(...).unwrap()` after merge — only test/bench sites should remain.

Closes the audit gap from #611 / #613. No related open issue — filing this directly since the gap was caught by following the same grep methodology the original audit described.