### PR TITLE
fix(firmware): validate provisioning NVS ranges

### DIFF
--- a/firmware/esp32-csi-node/provision.py
+++ b/firmware/esp32-csi-node/provision.py
@@ -55,6 +55,10 @@ import tempfile
 # 0x6000 (24576) bytes.
 NVS_PARTITION_OFFSET = 0x9000
 NVS_PARTITION_SIZE = 0x6000  # 24 KiB
+NVS_U8_MAX = 0xFF
+NVS_U16_MAX = 0xFFFF
+NVS_U32_MAX = 0xFFFFFFFF
+NVS_HOP_CHANNELS_MAX = 6
 
 
 CONFIG_VALUE_CHECKS = [
@@ -82,12 +86,75 @@ CONFIG_VALUE_CHECKS = [
 ]
 
 
+NVS_INT_RANGE_CHECKS = [
+    ("target_port", "--target-port", 1, NVS_U16_MAX),
+    ("node_id", "--node-id", 0, NVS_U8_MAX),
+    ("tdm_slot", "--tdm-slot", 0, NVS_U8_MAX),
+    ("tdm_total", "--tdm-total", 1, NVS_U8_MAX),
+    ("pres_thresh", "--pres-thresh", 0, NVS_U16_MAX),
+    ("fall_thresh", "--fall-thresh", 0, NVS_U16_MAX),
+    ("vital_win", "--vital-win", 32, 256),
+    ("vital_int", "--vital-int", 100, NVS_U16_MAX),
+    ("subk_count", "--subk-count", 1, 32),
+    ("swarm_hb", "--swarm-hb", 1, NVS_U16_MAX),
+    ("swarm_ingest", "--swarm-ingest", 1, NVS_U16_MAX),
+]
+
+
 def has_config_value(args):
     """Return True when args include at least one NVS-writing config value."""
     return any(
         check(getattr(args, name, None))
         for name, check in CONFIG_VALUE_CHECKS
     )
+
+
+def is_valid_wifi_channel(channel):
+    """Return True for 2.4 GHz or 5 GHz WiFi channel numbers accepted by firmware."""
+    return (1 <= channel <= 14) or (36 <= channel <= 177)
+
+
+def parse_hop_channels(value):
+    """Parse a comma-separated hop channel list into integers."""
+    return [int(channel.strip()) for channel in value.split(",")]
+
+
+def validate_int_range(args, parser, attr, flag, minimum, maximum):
+    value = getattr(args, attr, None)
+    if value is None:
+        return
+    if value < minimum or value > maximum:
+        parser.error(f"{flag} must be in range {minimum}-{maximum}, got {value}")
+
+
+def validate_config_ranges(args, parser):
+    """Fail fast before generating an NVS image with values firmware cannot load."""
+    for attr, flag, minimum, maximum in NVS_INT_RANGE_CHECKS:
+        validate_int_range(args, parser, attr, flag, minimum, maximum)
+
+    if args.channel is not None and not is_valid_wifi_channel(args.channel):
+        parser.error(f"--channel must be 1-14 (2.4GHz) or 36-177 (5GHz), got {args.channel}")
+
+    if args.hop_channels is None:
+        return
+
+    try:
+        channels = parse_hop_channels(args.hop_channels)
+    except ValueError:
+        parser.error(f"--hop-channels must be comma-separated integers, got '{args.hop_channels}'")
+
+    if not channels:
+        parser.error("--hop-channels must include at least one channel")
+    if len(channels) > NVS_HOP_CHANNELS_MAX:
+        parser.error(
+            f"--hop-channels supports at most {NVS_HOP_CHANNELS_MAX} channels, got {len(channels)}"
+        )
+    for channel in channels:
+        if not is_valid_wifi_channel(channel):
+            parser.error(
+                f"--hop-channels entries must be 1-14 (2.4GHz) or 36-177 (5GHz), got {channel}"
+            )
+    validate_int_range(args, parser, "hop_dwell", "--hop-dwell", 10, NVS_U32_MAX)
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +284,7 @@ def build_nvs_csv(args):
         writer.writerow(["filter_mac", "data", "hex2bin", mac_bytes.hex()])
     # ADR-073: Multi-frequency channel hopping
     if args.hop_channels is not None:
-        channels = [int(c.strip()) for c in args.hop_channels.split(",")]
+        channels = parse_hop_channels(args.hop_channels)
         writer.writerow(["hop_count", "data", "u8", str(len(channels))])
         # Store as NVS blob (firmware reads "chan_list" as uint8 blob)
         chan_bytes = bytes(channels)
@@ -416,16 +483,15 @@ def main():
             file=sys.stderr,
         )
 
+    validate_config_ranges(args, parser)
+
     # Validate TDM: if one is given, both should be
     if (args.tdm_slot is not None) != (args.tdm_total is not None):
         parser.error("--tdm-slot and --tdm-total must be specified together")
     if args.tdm_slot is not None and args.tdm_slot >= args.tdm_total:
         parser.error(f"--tdm-slot ({args.tdm_slot}) must be less than --tdm-total ({args.tdm_total})")
 
-    # ADR-060: Validate channel and MAC filter
-    if args.channel is not None:
-        if not ((1 <= args.channel <= 14) or (36 <= args.channel <= 177)):
-            parser.error(f"--channel must be 1-14 (2.4GHz) or 36-177 (5GHz), got {args.channel}")
+    # ADR-060: Validate MAC filter
     if args.filter_mac is not None:
         parts = args.filter_mac.split(":")
         if len(parts) != 6:

--- a/firmware/esp32-csi-node/tests/test_provision.py
+++ b/firmware/esp32-csi-node/tests/test_provision.py
@@ -1,6 +1,7 @@
 import csv
 import importlib.util
 import io
+import argparse
 import types
 import unittest
 from pathlib import Path
@@ -21,6 +22,11 @@ def make_args(**overrides):
 
 def csv_rows(content):
     return list(csv.DictReader(io.StringIO(content)))
+
+
+class RaisingArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        raise ValueError(message)
 
 
 class ProvisionConfigValueTests(unittest.TestCase):
@@ -57,6 +63,86 @@ class ProvisionConfigValueTests(unittest.TestCase):
         self.assertEqual(values_by_key["seed_token"], "token-123")
         self.assertEqual(values_by_key["swarm_hb"], "15")
         self.assertEqual(values_by_key["swarm_ingest"], "3")
+
+
+class ProvisionValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.parser = RaisingArgumentParser(prog="provision.py")
+
+    def assert_range_error(self, **overrides):
+        with self.assertRaises(ValueError):
+            provision.validate_config_ranges(make_args(**overrides), self.parser)
+
+    def test_rejects_values_that_do_not_fit_nvs_integer_types(self):
+        invalid_cases = [
+            {"target_port": 0},
+            {"target_port": 65536},
+            {"node_id": -1},
+            {"node_id": 256},
+            {"tdm_slot": -1},
+            {"tdm_slot": 256},
+            {"tdm_total": 0},
+            {"tdm_total": 256},
+            {"pres_thresh": -1},
+            {"pres_thresh": 65536},
+            {"fall_thresh": -1},
+            {"fall_thresh": 65536},
+            {"vital_win": 31},
+            {"vital_win": 257},
+            {"vital_int": 99},
+            {"vital_int": 65536},
+            {"subk_count": 0},
+            {"subk_count": 33},
+            {"swarm_hb": 0},
+            {"swarm_hb": 65536},
+            {"swarm_ingest": 0},
+            {"swarm_ingest": 65536},
+        ]
+
+        for values in invalid_cases:
+            with self.subTest(values=values):
+                self.assert_range_error(**values)
+
+    def test_accepts_valid_nvs_integer_boundaries(self):
+        args = make_args(
+            target_port=65535,
+            node_id=255,
+            tdm_slot=254,
+            tdm_total=255,
+            pres_thresh=65535,
+            fall_thresh=65535,
+            vital_win=256,
+            vital_int=65535,
+            subk_count=32,
+            swarm_hb=65535,
+            swarm_ingest=65535,
+        )
+
+        provision.validate_config_ranges(args, self.parser)
+
+    def test_rejects_invalid_hop_channel_lists(self):
+        invalid_cases = [
+            {"hop_channels": "1,6,11,36,40,44,48"},
+            {"hop_channels": "1,abc"},
+            {"hop_channels": "0"},
+            {"hop_channels": "178"},
+            {"hop_channels": "1,6", "hop_dwell": 9},
+        ]
+
+        for values in invalid_cases:
+            with self.subTest(values=values):
+                self.assert_range_error(**values)
+
+    def test_accepts_six_valid_hop_channels(self):
+        args = make_args(hop_channels="1,6,11,36,149,177", hop_dwell=10)
+
+        provision.validate_config_ranges(args, self.parser)
+        rows = csv_rows(provision.build_nvs_csv(args))
+        values_by_key = {row["key"]: row["value"] for row in rows}
+
+        self.assertEqual(values_by_key["hop_count"], "6")
+        self.assertEqual(values_by_key["chan_list"], "01060b2495b1")
+        self.assertEqual(values_by_key["dwell_ms"], "10")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add fail-fast validation for provisioning values written as NVS `u8`, `u16`, or `u32` fields.
- Validate hop-channel lists before CSV generation, including the firmware's six-channel maximum and accepted WiFi channel ranges.
- Add regression tests for invalid ranges and valid boundary values.

## Problem
`firmware/esp32-csi-node/provision.py` writes many CLI values directly into typed NVS CSV fields (`u8`, `u16`, `u32`, and `hex2bin`). Values outside those ranges can fail later in the NVS generator, throw a Python `bytes(...)` error for hop channels, or produce a config the firmware ignores at boot. The most operator-visible case is `--hop-channels`: the firmware only loads up to `NVS_CFG_HOP_MAX` (6) channels, but the CLI accepted longer lists.

## Maintainer value
This keeps bad provisioning input from reaching the NVS generation/flash path and turns confusing runtime behavior into immediate actionable CLI errors. The change is narrow and follows the recent `provision.py` test pattern.

## Validation
- `python -m unittest discover -s firmware\esp32-csi-node\tests -p "test_*.py"`
- `python -m py_compile firmware\esp32-csi-node\provision.py firmware\esp32-csi-node\tests\test_provision.py`
- `git diff --check`
- `python firmware\esp32-csi-node\provision.py --port COM1 --ssid test --password test --target-ip 192.168.1.20 --hop-channels 1,6,11,36,40,44,48 --dry-run` (fails before NVS generation with the new max-channel error)

## Duplicate check
Searched existing PRs for `provision.py` range validation, `target-port` / `node-id` validation, and `hop_channels` / `chan_list` / NVS overlap; no open or recent PR covers this guard.