### PR TITLE
docs(adr): ADR-100 + ADR-101 — record v0.0.1 shipping status

### DIFF
--- a/docs/adr/ADR-100-cog-packaging-specification.md
+++ b/docs/adr/ADR-100-cog-packaging-specification.md
@@ -1,6 +1,6 @@
 # ADR-100: Cognitum Cog Packaging Specification
 
-- **Status:** Accepted (formalises existing convention)
+- **Status:** Accepted (formalises existing convention) — **first conforming cog shipped 2026-05-19** (`cog-pose-estimation@0.0.1`, see ADR-101)
 - **Date:** 2026-05-19
 - **Deciders:** ruv
 
@@ -152,8 +152,8 @@ stdout JSON line format (one event per line):
 
 ## Migration
 
-1. Land this ADR.
-2. Land ADR-101 (`cog-pose-estimation` — first Cog built to this spec).
+1. ✅ Land this ADR.
+2. ✅ Land ADR-101 (`cog-pose-estimation` — first Cog built to this spec). Shipped in PR #642 + #643 on 2026-05-19; signed `arm` and `x86_64` binaries live at `gs://cognitum-apps/cogs/{arm,x86_64}/`; install verified on cognitum-v0.
 3. After two clean releases of `cog-pose-estimation`, re-publish the existing cogs (`anomaly-detect`, `presence`, etc.) with `binary_sha256` + `binary_signature`. Track in a follow-up issue.
 4. Flip `cognitum-cog-gateway` from "verify when present" to "require signature" — separate ADR, separate review.
 

--- a/docs/adr/ADR-101-pose-estimation-cog.md
+++ b/docs/adr/ADR-101-pose-estimation-cog.md
@@ -1,6 +1,6 @@
 # ADR-101: Pose Estimation Cog (WiFi-DensePose side)
 
-- **Status:** Accepted
+- **Status:** Accepted — **v0.0.1 shipped 2026-05-19** (merged in PRs #642 + #643, signed binaries on GCS, live install on cognitum-v0)
 - **Date:** 2026-05-19
 - **Deciders:** ruv
 - **Companion ADR (v0-appliance side):** v0-appliance ADR-225 (cognitum-pose-estimation crate)
@@ -169,10 +169,40 @@ This confirms the pipeline trains end-to-end and produces a signal-bearing model
 3. First release `cog-pose-estimation@0.0.1` ships **only** to `ruvultra` and `cognitum-v0`. Not pushed to the cluster Pis yet.
 4. After P7→P9 data work (#640) brings PCK above a usable threshold, rebuild + re-publish; only then enable cluster rollout via `cognitum-cog-gateway`'s OTA channel.
 
+## v0.0.1 shipping status — 2026-05-19
+
+PRs `#642` (scaffold + arm release + ONNX + live install) and `#643` (x86_64 release) landed on `main`. Acceptance gates from ADR-100 met as follows:
+
+| Gate | Status |
+|------|--------|
+| Cog binary exists per arch | ✅ arm (`3,741,976 B`) + x86_64 (`4,548,856 B`) on GCS |
+| Manifest matches schema | ✅ `cog/artifacts/manifests/{arm,x86_64}/manifest.json` |
+| Binary sha256 + Ed25519 signature | ✅ both signed with `COGNITUM_OWNER_SIGNING_KEY`, round-trip verified |
+| Public-readable GCS | ✅ anonymous HTTP GET works, SHA matches |
+| Live install on a real appliance | ✅ `/var/lib/cognitum/apps/pose-estimation/` on `cognitum-v0` (Pi 5), same layout as `anomaly-detect` |
+| Runtime contract (`version \| manifest \| health \| run`) | ✅ all four return correct output; `run` emits `pose.frame` events |
+| Real weights loaded (not stub) | ✅ `cargo test` asserts `backend.starts_with("candle-")` + non-zero confidence |
+| ONNX artifact (for downstream HEF) | ✅ `pose_v1.onnx` (12 KB), parity vs torch = 8.94e-8 |
+
+| Metric | Value |
+|--------|-------|
+| Training time (RTX 5080 / Candle CUDA) | 2.1 s for 400 epochs |
+| PCK@20 / PCK@50 / MPJPE (1,077-sample seated-desk session) | 3.0% / 18.5% / 0.093 |
+| Cold-start: Windows x86_64 | 76 ms |
+| Cold-start: ruvultra x86_64 | **5.4 ms** |
+| Cold-start: Pi 5 aarch64 | **8.4 ms** |
+| Tests | 5/5 pass |
+
+Open follow-ups carried forward from this ADR's "Acceptance gates" section:
+
+- **Hailo HEF cross-compile** — `pose_v1.onnx` is ready; still gated on Hailo Dataflow Compiler + self-hosted runner provisioning. Tracked separately.
+- **PCK@20 ≥ 35%** — explicitly not an acceptance gate of this ADR, but the limiting factor on practical usefulness. Tracked in [#640](https://github.com/ruvnet/RuView/issues/640): needs ~30× more paired samples + multi-room camera framing. Today's seated-desk session is the demonstrated bottleneck.
+
 ## See also
 
 - ADR-079: Camera-supervised pose training pipeline (the model we're shipping).
 - ADR-100: Cog packaging specification (the format we're shipping in).
 - v0-appliance ADR-225: cognitum-pose-estimation crate (the appliance-side runtime).
 - v0-appliance ADR-220: cog management surface (where this cog appears in the dashboard).
-- Issue #640: PCK gap (current 0% → ≥35% target).
+- Issue #640: PCK gap (current 3% / 18.5% → ≥35% target).
+- `docs/benchmarks/pose-estimation-cog.md`: full benchmark log, all measured numbers.


### PR DESCRIPTION
## Summary

Updates ADR-100 and ADR-101 to reflect that the first conforming cog (\`cog-pose-estimation@0.0.1\`) shipped earlier today via PRs #642 + #643.

- **ADR-100**: status line + migration step 2 marked complete with PR refs and GCS paths.
- **ADR-101**: status line + new "v0.0.1 shipping status" section that walks every ADR-100 acceptance gate with concrete pass/fail evidence (sha256 round-trip, signature, live install on cognitum-v0, ONNX parity 8.94e-8). Measured-metrics table for training time + PCK + cross-arch cold-start latency.

Open follow-ups carried forward in both ADRs:

- Hailo HEF cross-compile (still SDK-gated on a self-hosted runner).
- PCK@20 ≥ 35% (data-bound, #640).

Docs-only; no code changes.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)