### PR TITLE
docs(readme): add 10M+ downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ RuView turns ordinary WiFi into a contactless sensor. A $9 ESP32 board reads the
 [![Vital Signs](https://img.shields.io/badge/vital%20signs-breathing%20%2B%20heartbeat-red.svg)](#vital-sign-detection)
 [![ESP32 Ready](https://img.shields.io/badge/ESP32--S3-CSI%20streaming-purple.svg)](#esp32-s3-hardware-pipeline)
 [![crates.io](https://img.shields.io/crates/v/wifi-densepose-ruvector.svg)](https://crates.io/crates/wifi-densepose-ruvector)
+[![Downloads](https://img.shields.io/badge/downloads-10M%2B-brightgreen.svg)](#-edge-module-catalog)
 
  
 > | What | How | Speed / scale |


### PR DESCRIPTION
Adds a static `downloads 10M+` shields.io badge to the existing row, linking to the Edge Module Catalog section.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)