### PR TITLE
fix(sensing): keep adaptive classifier confidence finite

### DIFF
--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -222,6 +222,14 @@ fn default_class_names() -> Vec<String> {
     DEFAULT_CLASSES.iter().map(|s| s.to_string()).collect()
 }
 
+fn finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() {
+        value
+    } else {
+        fallback
+    }
+}
+
 impl Default for AdaptiveModel {
     fn default() -> Self {
         let n_classes = DEFAULT_CLASSES.len();
@@ -249,7 +257,11 @@ impl AdaptiveModel {
         // Normalise features.
         let mut x = [0.0f64; N_FEATURES];
         for i in 0..N_FEATURES {
-            x[i] = (raw_features[i] - self.global_mean[i]) / (self.global_std[i] + 1e-9);
+            let mean = finite_or(self.global_mean[i], 0.0);
+            let std = finite_or(self.global_std[i], 1.0);
+            let denom = finite_or(std + 1e-9, 1.0);
+            let feature = finite_or(raw_features[i], mean);
+            x[i] = finite_or((feature - mean) / denom, 0.0);
         }
 
         // Compute logits: w·x + b for each class.
@@ -273,20 +285,21 @@ impl AdaptiveModel {
             probs[c] = ((logits[c] - max_logit).exp()) / exp_sum;
         }
 
-        // Pick argmax. Same NaN-panic class as #611: if any raw_feature is NaN
-        // it propagates through normalize → logits → softmax, then partial_cmp
-        // returns None and unwrap() panics the sensing server on every frame.
+        // Pick argmax. Non-finite hardware samples are neutralized during
+        // normalization so confidence values do not leak NaN downstream.
         let (best_c, best_p) = probs
             .iter()
             .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-            .unwrap();
+            .filter(|(_, p)| p.is_finite())
+            .max_by(|a, b| a.1.total_cmp(b.1))
+            .map(|(class_idx, prob)| (class_idx, *prob))
+            .unwrap_or((0, 0.0));
         let label = if best_c < self.class_names.len() {
             self.class_names[best_c].clone()
         } else {
             "present_still".to_string()
         };
-        (label, *best_p)
+        (label, best_p)
     }
 
     /// Save model to a JSON file.
@@ -641,4 +654,50 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
 /// Default path for the saved adaptive model.
 pub fn model_path() -> PathBuf {
     PathBuf::from("data/adaptive_model.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn two_class_model() -> AdaptiveModel {
+        AdaptiveModel {
+            class_stats: vec![
+                ClassStats {
+                    label: "absent".to_string(),
+                    count: 1,
+                    mean: [0.0; N_FEATURES],
+                    stddev: [1.0; N_FEATURES],
+                },
+                ClassStats {
+                    label: "present_still".to_string(),
+                    count: 1,
+                    mean: [0.0; N_FEATURES],
+                    stddev: [1.0; N_FEATURES],
+                },
+            ],
+            weights: vec![vec![0.0; N_FEATURES + 1], vec![0.0; N_FEATURES + 1]],
+            global_mean: [0.0; N_FEATURES],
+            global_std: [1.0; N_FEATURES],
+            trained_frames: 2,
+            training_accuracy: 1.0,
+            version: 1,
+            class_names: vec!["absent".to_string(), "present_still".to_string()],
+        }
+    }
+
+    #[test]
+    fn classify_returns_finite_confidence_for_non_finite_features() {
+        let mut model = two_class_model();
+        model.weights[0][N_FEATURES] = 1.0;
+        let mut features = [0.25; N_FEATURES];
+        features[0] = f64::NAN;
+        features[7] = f64::INFINITY;
+
+        let (label, confidence) = model.classify(&features);
+
+        assert_eq!(label, "absent");
+        assert!(confidence.is_finite());
+        assert!(confidence > 0.5 && confidence < 1.0);
+    }
 }


### PR DESCRIPTION
## Summary

- sanitize non-finite adaptive classifier inputs during normalization by falling back to the trained feature mean
- ignore non-finite probabilities during argmax and fall back to a zero-confidence class if all probabilities are invalid
- add a regression test covering `NaN`/`Infinity` runtime features so classifier confidence remains finite

## Why

#613 / #624 closed the direct `partial_cmp(...).unwrap()` panic path, but a bad CSI hardware sample can still flow through normalization and softmax as `NaN`. That leaves `AdaptiveModel::classify()` returning a non-finite confidence, which can leak into API responses, UI state, or telemetry on every frame after a noisy sample. This keeps the classifier output safe without changing normal finite-input behavior.

## Duplicate check

Searched existing PRs for `adaptive_classifier NaN confidence`, `finite confidence sensing`, and the previous #611 / #613 / #624 NaN audit. I found the merged panic fixes, but no open/current PR that clamps classifier confidence or adds this regression coverage.

## Validation

- Ran: `cargo fmt -p wifi-densepose-sensing-server -- --check`
- Ran: `git diff --check`
- Ran: `cargo test -p wifi-densepose-sensing-server classify_returns_finite_confidence_for_non_finite_features --bin sensing-server`