### PR TITLE
fix(ui): unbreak viz.html — OrbitControls importmap, WS URL, toast NPE (#760)

### DIFF
--- a/ui/services/websocket-client.js
+++ b/ui/services/websocket-client.js
@@ -1,9 +1,19 @@
 // WebSocket Client for Three.js Visualization - WiFi DensePose
-// Connects to ws://localhost:8000/ws/pose and manages real-time data flow
+// Default endpoint is `/ws/sensing` on the same host the page was served from.
+// Callers (e.g. viz.html) usually pass an explicit `url` derived from
+// `buildSensingWsUrl()` so HTTP/WS port pairings are handled centrally.
+
+function _defaultWsUrl() {
+  if (typeof window === 'undefined' || !window.location) {
+    return 'ws://localhost:8765/ws/sensing';
+  }
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${protocol}//${window.location.host}/ws/sensing`;
+}
 
 export class WebSocketClient {
   constructor(options = {}) {
-    this.url = options.url || 'ws://localhost:8000/ws/pose';
+    this.url = options.url || _defaultWsUrl();
     this.ws = null;
     this.state = 'disconnected'; // disconnected, connecting, connected, error
     this.isRealData = false;

--- a/ui/utils/toast.js
+++ b/ui/utils/toast.js
@@ -27,6 +27,8 @@ export class ToastManager {
       action = null
     } = options;
 
+    if (!this.container) this.init();
+
     const id = ++this.idCounter;
     const toast = document.createElement('div');
     toast.className = `toast toast-${type}`;

--- a/ui/viz.html
+++ b/ui/viz.html
@@ -84,9 +84,23 @@
     <div id="stats-container"></div>
   </div>
 
-  <!-- Three.js and OrbitControls from CDN -->
-  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
-  <script src="https://unpkg.com/three@0.160.0/examples/js/controls/OrbitControls.js"></script>
+  <!-- Three.js r160 dropped examples/js/. Load via importmap and expose
+       THREE + OrbitControls as globals so the existing component modules
+       (scene.js, body-model.js, …) keep working without an audit. -->
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
+    }
+  }
+  </script>
+  <script type="module">
+    import * as THREE from 'three';
+    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+    window.THREE = THREE;
+    THREE.OrbitControls = OrbitControls;
+  </script>
   <!-- Stats.js for performance monitoring -->
   <script src="https://unpkg.com/stats.js@0.17.0/build/stats.min.js"></script>
 
@@ -100,6 +114,7 @@
     import { DashboardHUD } from './components/dashboard-hud.js';
     import { WebSocketClient } from './services/websocket-client.js';
     import { DataProcessor } from './services/data-processor.js';
+    import { buildSensingWsUrl } from './services/sensing.service.js';
 
     // -- Application State --
     const state = {
@@ -175,9 +190,12 @@
         state.stats = initStats();
         setLoadingProgress(85, 'Connecting to server...');
 
-        // 8. WebSocket client
+        // 8. WebSocket client — derive URL from window.location so the page
+        //    works on both default (HTTP 8080 / WS 8765) and Docker (3000/3001)
+        //    port pairings. `?ws=…` query overrides for advanced setups.
+        const wsOverride = new URLSearchParams(window.location.search).get('ws');
         state.wsClient = new WebSocketClient({
-          url: 'ws://localhost:8000/ws/pose',
+          url: wsOverride || buildSensingWsUrl(),
           onMessage: (msg) => handleWebSocketMessage(msg),
           onStateChange: (newState, oldState) => handleConnectionStateChange(newState, oldState),
           onError: (err) => console.error('[VIZ] WebSocket error:', err)

--- a/ui/viz.html
+++ b/ui/viz.html
@@ -84,9 +84,12 @@
     <div id="stats-container"></div>
   </div>
 
-  <!-- Three.js r160 dropped examples/js/. Load via importmap and expose
-       THREE + OrbitControls as globals so the existing component modules
-       (scene.js, body-model.js, …) keep working without an audit. -->
+  <!-- Three.js r160 dropped examples/js/ UMD builds. Load via importmap and
+       expose THREE + OrbitControls as a mutable global so the existing
+       component modules (scene.js, body-model.js, …) keep working without
+       a wider refactor. Note: `import * as THREE` returns a frozen Module
+       Namespace Object — spread it into a plain object before attaching
+       OrbitControls, otherwise the assignment silently no-ops. -->
   <script type="importmap">
   {
     "imports": {
@@ -95,26 +98,27 @@
     }
   }
   </script>
-  <script type="module">
-    import * as THREE from 'three';
-    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-    window.THREE = THREE;
-    THREE.OrbitControls = OrbitControls;
-  </script>
   <!-- Stats.js for performance monitoring -->
   <script src="https://unpkg.com/stats.js@0.17.0/build/stats.min.js"></script>
 
-  <!-- Application modules loaded as ES modules via importmap workaround -->
+  <!-- All app code lives in one module so global THREE is installed before
+       the component modules run. Two separate module scripts would race
+       since each is independently async-resolved. -->
   <script type="module">
-    // Import all modules
-    import { Scene } from './components/scene.js';
-    import { BodyModel, BodyModelManager } from './components/body-model.js';
-    import { SignalVisualization } from './components/signal-viz.js';
-    import { Environment } from './components/environment.js';
-    import { DashboardHUD } from './components/dashboard-hud.js';
-    import { WebSocketClient } from './services/websocket-client.js';
-    import { DataProcessor } from './services/data-processor.js';
-    import { buildSensingWsUrl } from './services/sensing.service.js';
+    import * as ThreeNS from 'three';
+    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+    const THREE = { ...ThreeNS, OrbitControls };
+    window.THREE = THREE;
+
+    // Component modules use `THREE.*` as a global — must be installed first.
+    const { Scene } = await import('./components/scene.js');
+    const { BodyModel, BodyModelManager } = await import('./components/body-model.js');
+    const { SignalVisualization } = await import('./components/signal-viz.js');
+    const { Environment } = await import('./components/environment.js');
+    const { DashboardHUD } = await import('./components/dashboard-hud.js');
+    const { WebSocketClient } = await import('./services/websocket-client.js');
+    const { DataProcessor } = await import('./services/data-processor.js');
+    const { buildSensingWsUrl } = await import('./services/sensing.service.js');
 
     // -- Application State --
     const state = {


### PR DESCRIPTION
## Summary
- Switches Three.js + OrbitControls to importmap-based ES module load (r160 removed `examples/js/`). `THREE` + `THREE.OrbitControls` are re-exposed as globals so the existing component modules don't need a wider refactor.
- Replaces the hardcoded `ws://localhost:8000/ws/pose` with the existing `buildSensingWsUrl()` helper so the page hits the correct `/ws/sensing` endpoint regardless of port pairing (8080/8765 default, 3000/3001 Docker). `?ws=…` query overrides for non-standard deployments.
- Lazy-inits the toast container in `ToastManager.show()` so the "backend connected" notification no longer NPEs and kills the rest of page init (patch from #760 reporter).

## Test plan
- [ ] Start server: `cargo run -p wifi-densepose-sensing-server -- --http-port 3000 --ws-port 3001 --source esp32`
- [ ] Open `http://localhost:3000/ui/viz.html` — 3D scene loads, no OrbitControls error in console
- [ ] WebSocket connects to `/ws/sensing`, demo mode flips to live data when frames arrive
- [ ] Toast notifications render without console errors
- [ ] Default port pairing also works: `--http-port 8080 --ws-port 8765`, open `http://localhost:8080/ui/viz.html`

Closes #760.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)