### PR TITLE
fix(sensing-server): wire training_api::routes() into HTTP router

### DIFF
--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -18,6 +18,7 @@ pub mod pose;
 mod rvf_container;
 mod rvf_pipeline;
 mod tracker_bridge;
+mod training_api;
 pub mod types;
 mod vital_signs;
 
@@ -963,10 +964,11 @@ struct AppStateInner {
     /// Shutdown signal for the recording writer task.
     recording_stop_tx: Option<tokio::sync::watch::Sender<bool>>,
     // ── Training fields ─────────────────────────────────────────────────────
-    /// Training status: "idle", "running", "completed", "failed".
-    training_status: String,
-    /// Training configuration, if any.
-    training_config: Option<serde_json::Value>,
+    /// Full training-pipeline state used by training_api::routes().
+    training_state: training_api::TrainingState,
+    /// Broadcast channel for per-epoch training progress (consumed by
+    /// /ws/train/progress).
+    training_progress_tx: tokio::sync::broadcast::Sender<String>,
     // ── Adaptive classifier (environment-tuned) ──────────────────────────
     /// Trained adaptive model (loaded from data/adaptive_model.json or trained at runtime).
     adaptive_model: Option<adaptive_classifier::AdaptiveModel>,
@@ -3911,54 +3913,10 @@ fn scan_recording_files() -> Vec<serde_json::Value> {
 }
 
 // ── Training Endpoints ──────────────────────────────────────────────────────
-
-/// GET /api/v1/train/status — get training status.
-async fn train_status(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    let s = state.read().await;
-    Json(serde_json::json!({
-        "status": s.training_status,
-        "config": s.training_config,
-    }))
-}
-
-/// POST /api/v1/train/start — start a training run.
-async fn train_start(
-    State(state): State<SharedState>,
-    Json(body): Json<serde_json::Value>,
-) -> Json<serde_json::Value> {
-    let mut s = state.write().await;
-    if s.training_status == "running" {
-        return Json(serde_json::json!({
-            "error": "training already running",
-            "success": false,
-        }));
-    }
-    s.training_status = "running".to_string();
-    s.training_config = Some(body.clone());
-    info!("Training started with config: {}", body);
-    Json(serde_json::json!({
-        "success": true,
-        "status": "running",
-        "message": "Training pipeline started. Use GET /api/v1/train/status to monitor.",
-    }))
-}
-
-/// POST /api/v1/train/stop — stop the current training run.
-async fn train_stop(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    let mut s = state.write().await;
-    if s.training_status != "running" {
-        return Json(serde_json::json!({
-            "error": "no training in progress",
-            "success": false,
-        }));
-    }
-    s.training_status = "idle".to_string();
-    info!("Training stopped");
-    Json(serde_json::json!({
-        "success": true,
-        "status": "idle",
-    }))
-}
+// Training routes are provided by training_api::routes() merged into the http_app
+// router below. The stub train_status/train_start/train_stop handlers that used
+// to live here were no-op string flippers; replaced by the real pipeline
+// (real_training_loop) in training_api.rs.
 
 // ── Adaptive classifier endpoints ────────────────────────────────────────────
 
@@ -6030,8 +5988,11 @@ async fn main() {
         recording_current_id: None,
         recording_stop_tx: None,
         // Training
-        training_status: "idle".to_string(),
-        training_config: None,
+        training_state: training_api::TrainingState::default(),
+        training_progress_tx: {
+            let (t, _) = broadcast::channel::<String>(256);
+            t
+        },
         adaptive_model:
             adaptive_classifier::AdaptiveModel::load(&adaptive_classifier::model_path())
                 .ok()
@@ -6228,10 +6189,8 @@ async fn main() {
         .route("/api/v1/recording/start", post(start_recording))
         .route("/api/v1/recording/stop", post(stop_recording))
         .route("/api/v1/recording/{id}", delete(delete_recording))
-        // Training endpoints
-        .route("/api/v1/train/status", get(train_status))
-        .route("/api/v1/train/start", post(train_start))
-        .route("/api/v1/train/stop", post(train_stop))
+        // Training endpoints (real pipeline from training_api.rs)
+        .merge(training_api::routes())
         // Adaptive classifier endpoints
         .route("/api/v1/adaptive/train", post(adaptive_train))
         .route("/api/v1/adaptive/status", get(adaptive_status))

--- a/v2/crates/wifi-densepose-sensing-server/src/training_api.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/training_api.rs
@@ -41,8 +41,21 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{error, info, warn};
 
-use crate::recording::{RecordedFrame, RECORDINGS_DIR};
 use crate::rvf_container::RvfBuilder;
+
+// Inlined from recording.rs to avoid pulling that module into main.rs's tree
+// (recording.rs references `AppStateInner::recording_state`, which doesn't
+// exist on the production AppStateInner — main.rs uses flat recording_* fields).
+pub const RECORDINGS_DIR: &str = "data/recordings";
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RecordedFrame {
+    pub timestamp: f64,
+    pub subcarriers: Vec<f64>,
+    pub rssi: f64,
+    pub noise_floor: f64,
+    pub features: serde_json::Value,
+}
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -243,7 +256,7 @@ async fn load_recording_frames(dataset_ids: &[String]) -> Vec<RecordedFrame> {
         // '/', '..', null bytes, or anything outside [A-Za-z0-9._-] BEFORE
         // building the format!() path. Otherwise an attacker could read any
         // file the server process can access via `dataset_ids: ["../../etc/passwd"]`.
-        let safe = match crate::path_safety::safe_id(id) {
+        let safe = match wifi_densepose_sensing_server::path_safety::safe_id(id) {
             Ok(s) => s,
             Err(e) => {
                 warn!("Skipping invalid dataset_id {id:?}: {e}");


### PR DESCRIPTION
## Summary

The supervised training pipeline in `training_api.rs` — `real_training_loop`, analytical-gradient regularised linear model, RecordedFrame deserialiser, `.rvf` export — is implemented but never reachable from the HTTP API. `main.rs` registers stub handlers at `/api/v1/train/{start,status,stop}` that just flip a `String` field. Calling `POST /train/start` returns `"running"` without invoking any training; `GET /train/status` returns the stub string instead of a `TrainingStatus` struct, so external orchestrators that follow the README cannot drive training.

This PR wires the real router in.

## Changes

- **`v2/crates/wifi-densepose-sensing-server/src/main.rs`**
  - Declares `mod training_api;` so the module is compiled into the binary
  - Replaces `AppStateInner.training_status: String` and `training_config: Option<serde_json::Value>` with `training_state: training_api::TrainingState` and `training_progress_tx: tokio::sync::broadcast::Sender<String>` — the fields the real handlers require
  - Removes the three stub handler functions (`train_status` / `train_start` / `train_stop`) and their `.route()` registrations in the `http_app` builder
  - Adds `.merge(training_api::routes())` to expose `/api/v1/train/{start,status,stop,pretrain,lora}` and `/ws/train/progress`

- **`v2/crates/wifi-densepose-sensing-server/src/training_api.rs`**
  - Inlines `RECORDINGS_DIR` and the `RecordedFrame` struct so the module no longer imports `crate::recording`. (`recording.rs` references `AppStateInner::recording_state` which is not present on the production `AppStateInner`; pulling that module into `main.rs`'s tree cascades into a separate refactor.)
  - Switches `crate::path_safety::safe_id` → `wifi_densepose_sensing_server::path_safety::safe_id` because `path_safety` lives in the library tree while `training_api` lives in the binary tree

## Verification

After applying, `GET /api/v1/train/status` returns the documented shape:

```json
{
  "active": false, "phase": "idle", "epoch": 0, "total_epochs": 0,
  "train_loss": 0.0, "val_pck": 0.0, "val_oks": 0.0, "lr": 0.0,
  "best_pck": 0.0, "best_epoch": 0, "patience_remaining": 0,
  "eta_secs": null
}
```

End-to-end run against an 80k-frame `.csi.jsonl` recording on a Windows laptop (AMD integrated GPU, no CUDA):
- Training transitioned through `initializing → loading_data → extracting_features → warmup → training`
- Early-stop fired at epoch 40 (best PCK 0.59 at epoch 20)
- `.rvf` written to `data/models/trained-supervised-*.rvf` (~43 KB, 9231 params)
- Total wall clock: ~34 min

## Test plan

- [ ] `cargo build -p wifi-densepose-sensing-server`
- [ ] Start server, `curl http://localhost:8080/api/v1/train/status` → returns `TrainingStatus` shape, not stub
- [ ] `POST /api/v1/train/start` with a valid `dataset_ids` body → training progresses through phases and emits `.rvf`
- [ ] `cargo test -p wifi-densepose-sensing-server` still green

## Notes

- This is the first of three small PRs from the same fork addressing different gaps the README acknowledges. The other two cover (a) a JSONL → binary RVF adapter so the HuggingFace pretrained model loads via `--model`, and (b) wiring `pose_v1.safetensors` into `cog-pose-estimation`'s stubbed inference path.
- Identified while attempting to use the pretrained model pipeline end-to-end on real 11-node ESP32-S3 hardware. The training pipeline is genuinely useful once wired — closes the gap between the README promise and the live HTTP surface.
