### PR TITLE
docs(esp32): lv_conf.h is ignored (LV_CONF_SKIP) — configure LVGL via Kconfig

### DIFF
--- a/firmware/esp32-csi-node/README.md
+++ b/firmware/esp32-csi-node/README.md
@@ -287,6 +287,19 @@ CONFIG_WASM_MAX_MODULES=4
 CONFIG_WASM_VERIFY_SIGNATURE=y
 ```
 
+#### LVGL / display config gotcha (ADR-045)
+
+This project builds the managed `lvgl/lvgl` component with **`CONFIG_LV_CONF_SKIP=y`**, so `main/lv_conf.h` is **ignored** — every LVGL option is taken from Kconfig instead. Editing `lv_conf.h` (fonts, tick, widgets, …) has **no effect**. Configure LVGL through `sdkconfig.defaults` (or `idf.py menuconfig` → *Component config → LVGL*):
+
+```ini
+# Fonts: setting LV_FONT_MONTSERRAT_* in lv_conf.h does NOTHING — use Kconfig:
+CONFIG_LV_FONT_MONTSERRAT_20=y
+CONFIG_LV_FONT_MONTSERRAT_36=y
+CONFIG_LV_USE_BAR=y
+```
+
+The same applies to the **LVGL tick**: the display only refreshes if `lv_tick` advances, which requires either `CONFIG_LV_TICK_CUSTOM` (Kconfig) or a firmware-driven `lv_tick_inc()` — `LV_TICK_CUSTOM=1` in `lv_conf.h` is ignored. (The firmware drives the tick via an `esp_timer`.)
+
 ---
 
 ## Flashing


### PR DESCRIPTION
Relates to #889 (documents its root cause). Fix: #890.

## What

Documents the LVGL config trap that was behind #889 (and the silently-ignored fonts): the firmware builds the managed `lvgl/lvgl` component with **`CONFIG_LV_CONF_SKIP=y`**, so `main/lv_conf.h` is ignored and **all** LVGL options come from Kconfig.

Adds a short "LVGL / display config gotcha" note to the ESP32 firmware README's *Custom Configuration* section, covering:
- Fonts: `LV_FONT_MONTSERRAT_*` in `lv_conf.h` does nothing → use `CONFIG_LV_FONT_MONTSERRAT_*`.
- Tick: `LV_TICK_CUSTOM=1` in `lv_conf.h` is ignored → needs `CONFIG_LV_TICK_CUSTOM` or a firmware `lv_tick_inc()` (the cause of the never-refreshing display in #889 / #890).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)