### PR TITLE
fix(edge): gate multi-person count on presence — no phantom persons (#803, #496)

### DIFF
--- a/firmware/esp32-csi-node/main/edge_processing.c
+++ b/firmware/esp32-csi-node/main/edge_processing.c
@@ -478,6 +478,18 @@ static void update_multi_person_vitals(const uint8_t *iq_data, uint16_t n_sc,
 {
     if (s_top_k_count < 2) return;
 
+    /* Presence gate (issues #803, #496): only activate persons when presence is
+     * actually detected. Without this, the loop below unconditionally marks
+     * top_k/2 persons active every frame, so the reported n_persons is a fixed
+     * artifact of the subcarrier count (never 0) regardless of occupancy — an
+     * empty room still reports e.g. 4 "people". s_presence_detected is updated
+     * earlier in the same process_frame() pass. (This bounds the count to
+     * presence; true multi-person separation is a separate, larger problem.) */
+    if (!s_presence_detected) {
+        for (uint8_t p = 0; p < EDGE_MAX_PERSONS; p++) s_persons[p].active = false;
+        return;
+    }
+
     /* Determine number of active persons based on available subcarriers. */
     uint8_t n_persons = s_top_k_count / 2;
     if (n_persons > EDGE_MAX_PERSONS) n_persons = EDGE_MAX_PERSONS;


### PR DESCRIPTION
Addresses #803 and #496.

## Problem
`update_multi_person_vitals()` (edge_processing.c) sets `pv->active = true` **unconditionally** for `n_persons = s_top_k_count / 2` (= 4 at the default `EDGE_TOP_K=8`) every frame. So the reported `n_persons` is a fixed function of the subcarrier count — **never 0**, regardless of how many people are actually present. An empty room reports 4; users see a constant phantom count.

Root cause behind:
- **#803** — "consistently shows 1 person" / "is people-counting even implemented?"
- **#496** — "shows 2 people, but I'm alone in the room"

The firmware already computes presence (`s_presence_detected`, set earlier in the same `process_frame()` pass) — but the multi-person path never consults it.

## Fix
Gate person activation on `s_presence_detected`: when no presence is detected, mark all persons inactive and return → `n_persons = 0` in an empty room; persons activate only once presence crosses the (adaptive) threshold.

```c
if (!s_presence_detected) {
    for (uint8_t p = 0; p < EDGE_MAX_PERSONS; p++) s_persons[p].active = false;
    return;
}
```

## Scope / honest limitations
This **bounds the count to presence** (0 when empty, ≥1 when someone is there). It does **not** attempt true multi-person *separation* — when present, the count is still the subcarrier-derived `top_k/2`. Real counting/separation from a single link is a larger DSP problem; this PR just removes the "always N phantom people" behavior everyone is hitting.

## Testing
- Builds clean — ESP-IDF v5.4, `idf.py set-target esp32s3 && idf.py build`.
- The gating signal was verified on hardware: `presence_score` (= `motion_energy`) / `s_presence_detected` read ~0 at idle and rise with movement, so the gate yields 0 when empty and activates on presence. The pre-fix constant count (4 at `top_k=8`) was observed directly on an ESP32-S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
