### PR TITLE
fix(firmware): capture DATA frames on display-less boards — #893/#866/#897 (yield=0pps root cause)

### DIFF
--- a/firmware/esp32-csi-node/main/csi_collector.c
+++ b/firmware/esp32-csi-node/main/csi_collector.c
@@ -637,6 +637,23 @@ static void hop_timer_cb(void *arg)
     csi_hop_next_channel();
 }
 
+void csi_collector_enable_data_capture(void)
+{
+    /* MGMT-only (RuView#396) starves the CSI callback on display-less boards
+     * (RuView#521/#893): beacons alone are sparse, yield collapses to 0 pps.
+     * Without a display there is no QSPI/SPI-flash cache contention with the
+     * DATA-frame interrupt load, so capture DATA frames too. */
+    wifi_promiscuous_filter_t filt = {
+        .filter_mask = WIFI_PROMIS_FILTER_MASK_MGMT | WIFI_PROMIS_FILTER_MASK_DATA,
+    };
+    esp_err_t err = esp_wifi_set_promiscuous_filter(&filt);
+    if (err == ESP_OK) {
+        ESP_LOGI(TAG, "CSI filter upgraded to MGMT+DATA (no display, RuView#893)");
+    } else {
+        ESP_LOGW(TAG, "Failed to enable DATA-frame CSI capture: %s", esp_err_to_name(err));
+    }
+}
+
 void csi_collector_start_hop_timer(void)
 {
     if (s_hop_count <= 1) {

--- a/firmware/esp32-csi-node/main/csi_collector.h
+++ b/firmware/esp32-csi-node/main/csi_collector.h
@@ -91,6 +91,19 @@ void csi_hop_next_channel(void);
 void csi_collector_start_hop_timer(void);
 
 /**
+ * Upgrade the promiscuous filter to capture DATA frames in addition to MGMT
+ * (RuView#893/#521).
+ *
+ * Called on display-less boards: the MGMT-only filter (the #396 display-crash
+ * workaround set in csi_collector_init) only fires the CSI callback on sparse
+ * management frames, so yield collapses to 0 pps under real traffic and the
+ * node looks dead. A board with no AMOLED panel has no QSPI/SPI-flash cache
+ * contention, so it can safely capture DATA frames — restoring abundant CSI.
+ * Display boards keep MGMT-only to avoid the #396 crash.
+ */
+void csi_collector_enable_data_capture(void);
+
+/**
  * Inject an NDP (Null Data Packet) frame for sensing.
  *
  * Uses esp_wifi_80211_tx() to send a preamble-only frame (~24 us airtime)

--- a/firmware/esp32-csi-node/main/display_task.c
+++ b/firmware/esp32-csi-node/main/display_task.c
@@ -9,6 +9,14 @@
 #include "display_task.h"
 #include "sdkconfig.h"
 
+/* Set true once an AMOLED panel is detected and the display task starts.
+ * Defined outside the CONFIG_DISPLAY_ENABLE guard so display_is_active()
+ * exists on headless builds too (where it stays false → CSI captures DATA
+ * frames; see RuView#893). */
+static bool s_display_active = false;
+
+bool display_is_active(void) { return s_display_active; }
+
 #if CONFIG_DISPLAY_ENABLE
 
 #include <string.h>
@@ -162,6 +170,7 @@ esp_err_t display_task_start(void)
 
     ESP_LOGI(TAG, "Display task started (Core %d, priority %d, %d fps)",
              DISP_TASK_CORE, DISP_TASK_PRIORITY, DISP_FPS_LIMIT);
+    s_display_active = true;
     return ESP_OK;
 }
 

--- a/firmware/esp32-csi-node/main/display_task.h
+++ b/firmware/esp32-csi-node/main/display_task.h
@@ -7,6 +7,7 @@
 #define DISPLAY_TASK_H
 
 #include "esp_err.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,6 +22,15 @@ extern "C" {
  * @return ESP_OK always (display is optional).
  */
 esp_err_t display_task_start(void);
+
+/**
+ * @return true once an AMOLED panel has been detected and the display task
+ * is running; false on headless boards (no panel, or built without display
+ * support). Used to choose the CSI promiscuous filter (RuView#893): a board
+ * with no display has no QSPI/SPI-flash contention, so it can safely capture
+ * DATA frames for proper CSI yield instead of starving on MGMT-only.
+ */
+bool display_is_active(void);
 
 #ifdef __cplusplus
 }

--- a/firmware/esp32-csi-node/main/main.c
+++ b/firmware/esp32-csi-node/main/main.c
@@ -410,6 +410,21 @@ void app_main(void)
     }
 #endif
 
+    /* RuView#893/#521: the MGMT-only promiscuous filter (set in
+     * csi_collector_init as the #396 display-crash workaround) starves the CSI
+     * callback on display-less boards — yield collapses to 0 pps and the node
+     * looks dead despite being on the network. Now that the display probe has
+     * run, boards with no AMOLED panel (no QSPI/SPI-flash cache contention)
+     * upgrade the filter to capture DATA frames too, restoring CSI yield. */
+#ifdef CONFIG_DISPLAY_ENABLE
+    bool has_display = display_is_active();   /* runtime panel probe result */
+#else
+    bool has_display = false;                 /* display support not compiled in */
+#endif
+    if (!has_display) {
+        csi_collector_enable_data_capture();
+    }
+
     ESP_LOGI(TAG, "CSI streaming active → %s:%d (edge_tier=%u, OTA=%s, WASM=%s, mmWave=%s, swarm=%s, adapt=%s)",
              g_nvs_config.target_ip, g_nvs_config.target_port,
              g_nvs_config.edge_tier,


### PR DESCRIPTION
## Problem — the root cause of most "can't reproduce / it's fake" reports
Multiple users (**#893**, **#866**, **#897**) flash the pre-built binaries on display-less ESP32-S3 boards (DevKitC-1, T7-S3, N8R8) and get **`yield=0pps`** — the node connects to WiFi but no CSI frames ever flow, so presence/count/pose all produce nothing. This drives the fraud accusations in **#804/#37**.

Root cause: `csi_collector.c` sets `WIFI_PROMIS_FILTER_MASK_MGMT` (MGMT-only) — the #396 workaround for the SPI-flash-cache crash that DATA-frame interrupt load triggers **on boards with a QSPI display**. But MGMT-only fires the CSI callback only on sparse management frames, so on display-less boards under real traffic CSI starves to ~0 pps (#521). #893's reporter confirmed recompiling with DATA capture fixes it and the #396 crash "does not apply" to their display-less hardware.

## Fix — runtime display-gated filter (no boot reorder)
After the boot-time display probe runs:
- **display present** → keep MGMT-only (preserve #396 crash protection)
- **no display** → upgrade the promiscuous filter to `MGMT | DATA` (restore abundant CSI)

- `display_task.c`: `s_display_active` flag + `display_is_active()` accessor (true only when an AMOLED panel is detected and the display task starts).
- `csi_collector.c`: `csi_collector_enable_data_capture()` re-sets the filter to `MGMT|DATA`.
- `main.c`: after `display_task_start()`, upgrade the filter when `!display_is_active()` (or display support isn't compiled in, e.g. ESP32-C6).

## Verification
**Build-verified on both targets** — `esp32c6` (headless `#else` path) and `esp32s3` (`display_is_active()` path, `display_task.c` compiled) — Project build complete, RC 0.

⚠️ **Needs on-hardware confirmation** before merge: on a display-less ESP32-S3, `yield` should climb from 0 to non-zero under traffic, **and** no #396 `wDev_ProcessFiq` crash over a sustained run. (I can flash + verify on the COM9 board on request.)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)