### PR TITLE
fix(v1-api): pass required config to DensePoseHead — green main CI

### DIFF
--- a/archive/v1/src/services/pose_service.py
+++ b/archive/v1/src/services/pose_service.py
@@ -107,16 +107,25 @@ class PoseService:
     async def _initialize_models(self):
         """Initialize neural network models."""
         try:
-            # Initialize DensePose model
+            # Initialize DensePose model. DensePoseHead requires a config
+            # dict — input_channels matches the modality translator's output
+            # (256), with the standard DensePose 24 body parts and 2 (U,V)
+            # coordinates. (Previously called with no args → TypeError at
+            # startup, which broke the API service.)
+            densepose_config = {
+                'input_channels': 256,
+                'num_body_parts': 24,
+                'num_uv_coordinates': 2,
+            }
             if self.settings.pose_model_path:
-                self.densepose_model = DensePoseHead()
+                self.densepose_model = DensePoseHead(densepose_config)
                 # Load model weights if path is provided
                 # model_state = torch.load(self.settings.pose_model_path)
                 # self.densepose_model.load_state_dict(model_state)
                 self.logger.info("DensePose model loaded")
             else:
                 self.logger.warning("No pose model path provided, using default model")
-                self.densepose_model = DensePoseHead()
+                self.densepose_model = DensePoseHead(densepose_config)
             
             # Initialize modality translation
             config = {


### PR DESCRIPTION
## Problem
The **Continuous Integration** workflow (Performance Tests + API Documentation jobs) has been **failing on main** (every commit checked, #886→HEAD). Root cause is in the v1 Python API startup:

```
TypeError: DensePoseHead.__init__() missing 1 required positional argument: 'config'
  src.services.pose_service._initialize_models
uvicorn.error: Application startup failed. Exiting.
```

`pose_service.py` called `DensePoseHead()` with no args at two sites, but `DensePoseHead.__init__` requires a config dict.

## Fix
Pass a config: `input_channels=256` (matches `ModalityTranslationNetwork`'s output), `num_body_parts=24` (DensePose standard), `num_uv_coordinates=2`. Both call sites fixed.

## Verification
Locally: `DensePoseHead(config)` (423,211 params) and `ModalityTranslationNetwork(config)` both construct + `eval()` — the startup TypeError is cleared, so the API service initializes.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)