### PR TITLE
ci(v1-api): MOCK_POSE_DATA + declare psutil — green Performance Tests & API Docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,10 @@ jobs:
 
     - name: Start application
       working-directory: archive/v1
+      env:
+        # No CSI hardware in CI — serve mock pose data so the pose endpoints
+        # respond 200 under load instead of erroring "requires real CSI data".
+        MOCK_POSE_DATA: "true"
       run: |
         uvicorn src.api.main:app --host 0.0.0.0 --port 8000 &
         sleep 10
@@ -384,6 +388,8 @@ jobs:
 
     - name: Generate OpenAPI spec
       working-directory: archive/v1
+      env:
+        MOCK_POSE_DATA: "true"   # no CSI hardware in CI
       run: |
         python -c "
         from src.api.main import app

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ scikit-learn>=1.2.0
 
 # Monitoring dependencies
 prometheus-client>=0.16.0
+psutil>=5.9.0  # system metrics — imported by health.py / metrics.py / status.py / monitoring.py


### PR DESCRIPTION
Follow-up to #910 (v1 API startup crash fix). Two more reasons the main-only v1-API CI jobs failed, now fixed:

1. **API Documentation** failed with `ModuleNotFoundError: No module named 'psutil'` — psutil is imported by `health.py`/`metrics.py`/`status.py`/`monitoring.py` but was never declared; it only worked where `locust` (Performance Tests) pulled it in transitively. Declared `psutil>=5.9.0` in requirements.txt. Verified `from src.api.main import app; app.openapi()` now generates the spec (26 paths).
2. **Performance Tests** hit the pose endpoints which error without CSI hardware. Set `MOCK_POSE_DATA=true` on both jobs so they exercise the mock path.

Together with #910 these should green the v1-API CI jobs (which only run on push to main, so they'll be exercised once this merges).

> The PR-level CI red has been transient Docker Hub pull timeouts (infra), not these changes.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)