### PR TITLE
fix(ci): perf tests — `python -m pytest` so `src` import resolves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,11 @@ jobs:
         # command always failed with "Could not find ...". Run the real suite.
         # -o addopts="" drops the root pyproject's --cov/--cov-fail-under=100
         # flags (pytest-cov isn't installed here and 100% cov is for unit tests).
-        pytest tests/performance/ -o addopts="" -v --junitxml=perf-junit.xml
+        # `python -m pytest` (not the bare `pytest` script) puts the cwd
+        # (archive/v1) on sys.path so test_frame_budget.py's `from src.core...`
+        # import resolves — the bare script omits cwd and raises
+        # ModuleNotFoundError: No module named 'src'.
+        python -m pytest tests/performance/ -o addopts="" -v --junitxml=perf-junit.xml
 
     - name: Upload performance results
       if: always()


### PR DESCRIPTION
## Problem
The **Performance Tests** job (main CI) collected 26 items then aborted:

```
ImportError while importing test module '.../tests/performance/test_frame_budget.py'.
E   ModuleNotFoundError: No module named 'src'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
##[error]Process completed with exit code 2.
```

`test_frame_budget.py` does `from src.core.csi_processor import CSIProcessor`. The bare `pytest` console script does **not** add the cwd (`archive/v1`) to `sys.path`; `python -m pytest` does. Because pytest aborts the whole session on any collection error, this single import masked the entire — otherwise self-contained, mock-based — perf suite.

## Fix
One line: `pytest …` → `python -m pytest …` in the Run-performance-tests step.

## Verification (local)
- Bare-`pytest` path reproduces the exact `No module named 'src'` error.
- `python -m pytest` resolves the import; `test_frame_budget.py` passes **3/3**.
- `test_api_throughput.py` (mock server) and `test_inference_speed.py` (`MockPoseModel` + `psutil`) are fully self-contained — `grep` confirms **no perf test hits the running uvicorn server** (no `ClientSession`/`localhost:8000`/`httpx`), so the hardware-less router log noise is irrelevant.

## Context
Final layer of the v1-API CI repair chain (#910 DensePoseHead → #911 psutil/mock → #913 gh-pages-perms/locust). Main CI is already green (perf job was `continue-on-error`); this makes the perf job itself pass instead of being masked.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)