### PR TITLE
docs(#882): complete the "100% presence" retraction across all docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,7 +430,7 @@ Model release (no new firmware binary). Firmware remains at v0.6.0-esp32.
 - Security fix merged via PR #310.
 
 ### Performance
-- Presence detection: 100% accuracy on 60,630 overnight samples.
+- Presence detection: 100% accuracy on 60,630 overnight samples. *(Retracted — that recording was single-class (one sleeping person, 6,062/6,063 frames "present"), so a constant "yes" scores ~99.98%. Superseded by the honest 82.3% held-out temporal-triplet metric; see [#882](https://github.com/ruvnet/RuView/issues/882). Kept here as the in-place public record.)*
 - Inference: 0.008 ms per sample, 164K embeddings/sec.
 - Contrastive self-supervised training: 51.6% improvement over baseline.
 

--- a/docs/readme-details.md
+++ b/docs/readme-details.md
@@ -122,7 +122,7 @@ node scripts/benchmark-ruvllm.js --model models/csi-ruvllm       # benchmark
 
 | What we measured | Result | Why it matters |
 |-----------------|--------|---------------|
-| **Presence detection** | **100% accuracy** | Never misses a person, never false alarms |
+| **CSI embedding quality** | **82.3% held-out temporal-triplet** | Honest label-free metric on the last 20% by time (v1's "100% presence" was a single-class recording — retracted, [#882](https://github.com/ruvnet/RuView/issues/882)) |
 | **Inference speed** | **0.008 ms** per embedding | 125,000x faster than real-time |
 | **Throughput** | **164,183 embeddings/sec** | One Mac Mini handles 1,600+ ESP32 nodes |
 | **Contrastive learning** | **51.6% improvement** | Strong pattern learning from real overnight data |
@@ -233,7 +233,7 @@ python firmware/esp32-csi-node/provision.py --port COM9 --hop-channels "1,6,11"
 | **kNN similarity search** | "Find the 10 most similar states to right now" — anomaly detection, fingerprinting | Cognitum Seed |
 | **Witness chain** | SHA-256 tamper-evident audit trail for every measurement (1,747 entries validated) | Cognitum Seed |
 | **Camera-free pose training** | 17 COCO keypoints from 10 sensor signals — PIR, RSSI triangulation, subcarrier asymmetry, vibration, BME280 | 2x ESP32 + Seed |
-| **Pre-trained model** | 82.8 KB (8 KB at 4-bit quantization), 100% presence accuracy, 0 skeleton violations | Download from release |
+| **Pre-trained model** | 82.8 KB (8 KB at 4-bit quantization), 82.3% held-out temporal-triplet accuracy (v1's "100% presence" was single-class — retracted, [#882](https://github.com/ruvnet/RuView/issues/882)) | Download from release |
 | **Sub-ms inference** | 0.012 ms latency, 171,472 embeddings/sec on M4 Pro | Any machine with Node.js |
 | **SONA adaptation** | Adapts to new rooms in <1ms without retraining | ruvllm runtime |
 | **LoRA room adapters** | Per-node fine-tuning with 2,048 parameters per adapter | Automatic |
@@ -262,7 +262,7 @@ node scripts/benchmark-ruvllm.js --model models/csi-ruvllm
 
 | What we measured | Result | Why it matters |
 |-----------------|--------|---------------|
-| **Presence detection** | **100% accuracy** | Never misses a person, never false alarms |
+| **CSI embedding quality** | **82.3% held-out temporal-triplet** | Honest label-free metric (v1's "100% presence" was single-class — retracted, [#882](https://github.com/ruvnet/RuView/issues/882)) |
 | **Person counting** | **24/24 correct** (MinCut) | Fixed the #1 user-reported issue |
 | **Inference speed** | **0.012 ms** per embedding | 83,000x faster than real-time |
 | **Throughput** | **171,472 embeddings/sec** | One Mac Mini handles 1,700+ ESP32 nodes |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1119,7 +1119,7 @@ What it ships (and what it does not):
 
 | Capability | Status |
 |------------|--------|
-| Presence detection (occupied / empty) | ✅ Trained head — 100% accuracy on validation |
+| Presence detection (occupied / empty) | ✅ Trained head — v2 encoder reports 82.3% held-out temporal-triplet acc (v1's "100% on validation" was a single-class recording — retracted, [#882](https://github.com/ruvnet/RuView/issues/882)) |
 | 128-dim CSI embeddings (re-ID, similarity, downstream training) | ✅ Trained encoder |
 | Single-person breathing / heart-rate | ⚠️ Server still uses heuristic DSP — model does not replace this yet |
 | 17-keypoint full-body pose | 🔬 No keypoint weights shipped yet — pose pipeline runs but without a learned head |
@@ -1824,7 +1824,7 @@ huggingface-cli download ruvnet/wifi-densepose-pretrained --local-dir models/pre
 #   model.safetensors    — 48 KB contrastive encoder
 #   model-q4.bin         — 8 KB quantized (recommended)
 #   model-q2.bin         — 4 KB ultra-compact (ESP32 edge)
-#   presence-head.json   — presence detection head (100% accuracy)
+#   presence-head.json   — presence detection head (v2 encoder: 82.3% held-out triplet acc)
 #   node-1.json          — LoRA adapter for room 1
 #   node-2.json          — LoRA adapter for room 2
 ```
@@ -1833,7 +1833,7 @@ huggingface-cli download ruvnet/wifi-densepose-pretrained --local-dir models/pre
 
 The pre-trained encoder converts 8-dim CSI feature vectors into 128-dim embeddings. These embeddings power all 17 sensing applications:
 
-- **Presence detection** — 100% accuracy, never misses, never false alarms
+- **Presence detection** — v2 encoder: 82.3% held-out temporal-triplet accuracy (v1's "100%" was a single-class recording — retracted, [#882](https://github.com/ruvnet/RuView/issues/882))
 - **Environment fingerprinting** — kNN search finds "states like this one"
 - **Anomaly detection** — embeddings that don't match known clusters = anomaly
 - **Activity classification** — different activities cluster in embedding space


### PR DESCRIPTION
## Why
#882 retracted the v1 **"100% presence accuracy"** headline (it was measured on a single-class overnight recording — 6,062/6,063 frames "present", so a constant "yes" predictor scores ~99.98%) in favor of an honest **82.3% held-out temporal-triplet** metric.

That retraction was applied to the README intro, the user-guide intro, and `docs/proof-of-capabilities.md` — but a grep found **6 secondary locations still flatly claiming "100% accuracy, never false alarms."** That made this line in `proof-of-capabilities.md` literally untrue:

> "It's replaced **everywhere** by an honest 82.3% held-out temporal-triplet accuracy."

## What changed
Completed the in-place retraction at every remaining site:

| File | Spots |
|------|-------|
| `docs/readme-details.md` | 2 benchmark tables + the pre-trained-model row |
| `docs/user-guide.md` | capability table, model-file comment, applications list |
| `CHANGELOG.md` | historical entry **annotated in-place** (kept as the public record per the built-in-public ethos — not rewritten) |

Each now states the honest 82.3% held-out temporal-triplet figure with a one-line retraction note linking #882.

## Verification
```
git grep -niE "100% (presence|accuracy)" -- '*.md' | grep -v retract|82.3%|#882
→ only proof-of-capabilities.md:22, which *describes* the retraction (intentional)
```
`proof-of-capabilities.md`'s "replaced everywhere" is now accurate. Docs-only; no code paths touched.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)