### PR TITLE
perf(ci): drop dead uvicorn start from perf job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,20 +267,15 @@ jobs:
         pip install -r requirements.txt
         pip install pytest   # the perf suite is pytest, not locust
 
-    - name: Start application
-      working-directory: archive/v1
-      env:
-        # No CSI hardware in CI — serve mock pose data so the pose endpoints
-        # respond 200 under load instead of erroring "requires real CSI data".
-        MOCK_POSE_DATA: "true"
-      run: |
-        uvicorn src.api.main:app --host 0.0.0.0 --port 8000 &
-        sleep 10
+    # No "Start application" step: the gated test (test_frame_budget.py) drives
+    # the CSIProcessor pipeline in-process and makes no HTTP calls, so the old
+    # uvicorn server + `sleep 10` were dead weight — they only existed for the
+    # now-excluded api_throughput/inference_speed tests, and on every run dumped
+    # ~50 misleading "router requires hardware setup" ERROR lines for a server
+    # no test touched. MOCK_POSE_DATA is server-only and unused here.
 
     - name: Run performance tests
       working-directory: archive/v1
-      env:
-        MOCK_POSE_DATA: "true"
       run: |
         # Gate only on the genuine, deterministic perf guard:
         # test_frame_budget.py times the *real* CSIProcessor pipeline against


### PR DESCRIPTION
## Why
After #915, the Performance Tests job gates only on `test_frame_budget.py`, which drives the **`CSIProcessor` pipeline in-process** and makes **no HTTP calls** (`grep` confirms no `ClientSession`/`localhost:8000`/`httpx` in the gated test).

That makes the **"Start application"** step (`uvicorn src.api.main:app … & sleep 10`) pure dead weight:
- it only ever served the now-excluded `api_throughput`/`inference_speed` mock tests;
- it wastes ~10–15 s on every main-push run;
- it dumps **~50 misleading `ERROR … router requires hardware setup` lines** into every CI log, for a server no test touches — making a green job *look* broken.

## Change
Remove the `Start application` step and the vestigial `MOCK_POSE_DATA` env (server-only; unused by `CSIProcessor`/`test_frame_budget.py`). `Install dependencies` is untouched (the test still needs `src.core` deps).

## Verification
- `test_frame_budget.py` passes 3/3 locally, independent of the server.
- `ci.yml` re-validated as YAML.

Docs/CI-only; no application code touched.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)