### PR TITLE
fix(auth): match the Bearer scheme case-insensitively (RFC 6750)

### DIFF
--- a/v2/crates/wifi-densepose-sensing-server/src/bearer_auth.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/bearer_auth.rs
@@ -100,7 +100,17 @@ pub async fn require_bearer(
         .headers()
         .get(AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.strip_prefix("Bearer "));
+        // RFC 6750 §2.1 / RFC 7235 §2.1: the auth-scheme ("Bearer") is
+        // case-insensitive. Match it as such (and tolerate extra leading
+        // whitespace before the token) so a correct token isn't rejected
+        // just because a client sent `bearer`/`BEARER`. The token compare
+        // below stays exact + constant-time.
+        .and_then(|s| {
+            let (scheme, token) = s.split_once(' ')?;
+            scheme
+                .eq_ignore_ascii_case("Bearer")
+                .then(|| token.trim_start())
+        });
     let ok = supplied
         .map(|s| ct_eq(s.as_bytes(), expected.as_bytes()))
         .unwrap_or(false);
@@ -183,6 +193,31 @@ mod tests {
             status(r, "POST", "/api/v1/sensitive", None).await,
             StatusCode::UNAUTHORIZED
         );
+    }
+
+    #[tokio::test]
+    async fn accepts_case_insensitive_bearer_scheme() {
+        // RFC 6750 §2.1 / RFC 7235 §2.1: the auth-scheme is case-insensitive.
+        // A correct token must authenticate regardless of scheme casing or
+        // extra whitespace; a wrong token must still be rejected.
+        async fn req_status(auth_value: &str) -> StatusCode {
+            let r = wrap(AuthState::from_token("s3cr3t"));
+            let mut req = Request::builder()
+                .method("GET")
+                .uri("/api/v1/info")
+                .body(Body::empty())
+                .unwrap();
+            req.headers_mut()
+                .insert(AUTHORIZATION, auth_value.parse().unwrap());
+            r.oneshot(req).await.unwrap().status()
+        }
+        assert_eq!(req_status("Bearer s3cr3t").await, StatusCode::OK);
+        assert_eq!(req_status("bearer s3cr3t").await, StatusCode::OK);
+        assert_eq!(req_status("BEARER s3cr3t").await, StatusCode::OK);
+        assert_eq!(req_status("Bearer  s3cr3t").await, StatusCode::OK); // extra space
+        // Scheme leniency must NOT weaken the token check.
+        assert_eq!(req_status("bearer nope").await, StatusCode::UNAUTHORIZED);
+        assert_eq!(req_status("Basic s3cr3t").await, StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
`require_bearer` parsed the `Authorization` header with `strip_prefix("Bearer ")` — **case-sensitive**. Per **RFC 6750 §2.1 / RFC 7235 §2.1** the auth-scheme is case-insensitive, so a *correct* token sent as `Authorization: bearer <token>` (or `BEARER`, or with extra whitespace) was rejected with a confusing `invalid bearer token` 401.

That's needless friction in the **active auth-setup theme** (#864 secure-by-default, #924 ngrok demo) — someone configuring `RUVIEW_API_TOKEN` whose client lowercases the scheme would see a 401 with a correct token.

## How
Match the scheme with `eq_ignore_ascii_case("Bearer")` and trim leading token whitespace. The **token comparison is unchanged** — still exact and constant-time (`ct_eq`). So this does not weaken auth:

```
bearer  s3cr3t  → 200   (case-insensitive scheme, extra space)
BEARER  s3cr3t  → 200
bearer  nope    → 401   (wrong token still rejected)
Basic   s3cr3t  → 401   (non-Bearer scheme still rejected)
```

## Tests
New `accepts_case_insensitive_bearer_scheme` asserts all of the above. Full `bearer_auth` suite: **9 passed**.

Audited the surrounding auth code while here — `ct_eq` correctly rejects length mismatch (no prefix-auth bypass) and is constant-time; the middleware fails closed. No security bug; this is purely an RFC-compliance/robustness fix.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)