### PR TITLE
fix(firmware): clear onboard WS2812 LED on GPIO 48 (DevKitC-1 v1.1 / N16R8)

### DIFF
--- a/firmware/esp32-csi-node/main/main.c
+++ b/firmware/esp32-csi-node/main/main.c
@@ -174,27 +174,34 @@ void app_main(void)
              target_name, app_desc->version, g_nvs_config.node_id);
 
     /* Turn off onboard WS2812 LED.
-     * S3 dev boards put the LED on GPIO 38; C6 dev boards on GPIO 8.
-     * On C6, GPIO 38 doesn't exist (only 0-30) — gate the init by target. */
+     * S3 dev boards put the LED on GPIO 38 (DevKitC-1 v1.0) or GPIO 48
+     * (DevKitC-1 v1.1 / N16R8 / generic YD-ESP32-S3 clones); C6 dev boards
+     * on GPIO 8. Clear every candidate pin — pulsing a pin with no LED
+     * attached is harmless, and each handle is deleted after clear to free
+     * its RMT channel. On C6, GPIO 38/48 don't exist (only 0-30) — gate by
+     * target. */
 #if defined(CONFIG_IDF_TARGET_ESP32C6)
-    const int led_gpio = 8;
+    const int led_gpios[] = {8};
 #else
-    const int led_gpio = 38;
+    const int led_gpios[] = {38, 48};
 #endif
-    led_strip_handle_t led_strip;
-    led_strip_config_t strip_config = {
-        .strip_gpio_num = led_gpio,
-        .max_leds = 1,
-        .led_model = LED_MODEL_WS2812,
-        .color_component_format = LED_STRIP_COLOR_COMPONENT_FMT_GRB,
-        .flags.invert_out = false,
-    };
-    led_strip_rmt_config_t rmt_config = {
-        .resolution_hz = 10 * 1000 * 1000, // 10MHz
-        .flags.with_dma = false,
-    };
-    if (led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip) == ESP_OK) {
-        led_strip_clear(led_strip);
+    for (int i = 0; i < (int)(sizeof(led_gpios) / sizeof(led_gpios[0])); i++) {
+        led_strip_handle_t led_strip;
+        led_strip_config_t strip_config = {
+            .strip_gpio_num = led_gpios[i],
+            .max_leds = 1,
+            .led_model = LED_MODEL_WS2812,
+            .color_component_format = LED_STRIP_COLOR_COMPONENT_FMT_GRB,
+            .flags.invert_out = false,
+        };
+        led_strip_rmt_config_t rmt_config = {
+            .resolution_hz = 10 * 1000 * 1000, // 10MHz
+            .flags.with_dma = false,
+        };
+        if (led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip) == ESP_OK) {
+            led_strip_clear(led_strip);
+            led_strip_del(led_strip);
+        }
     }
 
     /* ADR-110 P4: 802.15.4 mesh time-sync (C6 only).


### PR DESCRIPTION
## Problem
On ESP32-S3 DevKitC-1 v1.1 / N16R8 modules / generic YD-ESP32-S3 clones, the onboard RGB (WS2812) LED stays lit at a bright color after flashing — the firmware never turns it off.

## Root Cause
`app_main()` clears the onboard WS2812 on a single GPIO: **38** on S3, 8 on C6. But many S3 boards (DevKitC-1 **v1.1**, N16R8 modules, YD-ESP32-S3 clones) wire the WS2812 to **GPIO 48**, not 38. The clear targets the wrong pin, so the LED is left in its power-on state.

## Fix
Clear every candidate LED GPIO on S3 — both **38 and 48** (C6 unchanged at 8). Each `led_strip` handle is created → `led_strip_clear()` → `led_strip_del()` so the RMT channel is freed. Driving a pin with no LED attached is a harmless reset pulse, and clearing 48 is a no-op on GPIO-38 boards.

## Verification
- **Device:** ESP32-S3 N16R8 (16 MB flash, 8 MB PSRAM, QFN56 rev v0.2)
- **AP:** 2.4 GHz WPA2 (bgn)
- **Result:** bright RGB LED → **off** after flashing this build (visually confirmed). Same firmware flashed to 4 such boards. No regression expected on GPIO-38 boards (clearing 48 is a no-op there).

## Risk
Minimal. One extra RMT create/clear/del on GPIO 48 at boot (~microseconds), then the handle is freed. No runtime cost after boot; no behavior change on boards whose LED is already on GPIO 38.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
