### PR TITLE
fix(server): close silent auto→simulated fallback path (sibling of #937)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,10 +24,13 @@ services:
     environment:
       - RUST_LOG=info
       # CSI_SOURCE controls the data source for the sensing server.
-      # Options: auto (default) — probe for ESP32 UDP then fall back to simulation
+      # Options: auto (default) — probe for ESP32 UDP then host WiFi; **fail
+      #                           hard with exit 78 if neither is detected**.
+      #                           Synthetic data is no longer a silent fallback
+      #                           (issue #937 fix) — operators must opt in.
       #          esp32          — receive real CSI frames from an ESP32 on UDP port 5005
       #          wifi           — use host Wi-Fi RSSI/scan data (Windows netsh)
-      #          simulated      — generate synthetic CSI data (no hardware required)
+      #          simulated      — explicitly generate synthetic CSI for demo mode
       - CSI_SOURCE=${CSI_SOURCE:-auto}
       # MODELS_DIR controls where the server scans for .rvf model files.
       # Mount a host directory and set this to make models visible:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -11,7 +11,16 @@
 #      docker run ruvnet/wifi-densepose:latest --model /app/models/my.rvf
 #
 # Environment variables:
-#   CSI_SOURCE   — data source: auto (default), esp32, wifi, simulated
+#   CSI_SOURCE   — data source. Valid values:
+#                    auto       — try ESP32 then Windows WiFi, **fail-loud if no
+#                                 real hardware is detected** (issue #937 fix:
+#                                 the server no longer silently falls back to
+#                                 synthetic data — that's now opt-in only).
+#                    esp32      — listen for UDP CSI on the configured port.
+#                    wifi       — Windows-native WiFi capture.
+#                    simulated  — explicit demo mode with synthetic CSI.
+#                  Default is `auto`. Set CSI_SOURCE=simulated when you want
+#                  fake data tagged as such; never set it implicitly.
 #   MODELS_DIR   — directory to scan for .rvf model files (default: data/models)
 set -e
 

--- a/v2/crates/wifi-densepose-desktop/src/commands/server.rs
+++ b/v2/crates/wifi-densepose-desktop/src/commands/server.rs
@@ -108,8 +108,14 @@ pub async fn start_server(
         cmd.args(["--log-level", log_level]);
     }
 
-    // Set data source (default to "simulate" if not specified for demo mode)
-    let source = config.source.as_deref().unwrap_or("simulate");
+    // Default to explicit "simulated" demo mode when the desktop user hasn't
+    // chosen a source — this is the *Tauri demo* app, not a production
+    // sensing endpoint, so the demo default is correct here. Critically, the
+    // value passed downstream is the **explicit** "simulated", not "auto",
+    // which means the sensing-server will tag the data as synthetic in its
+    // API responses rather than silently fall back (issue #937 fix in
+    // sensing-server's `auto` handler).
+    let source = config.source.as_deref().unwrap_or("simulated");
     cmd.args(["--source", source]);
 
     // Redirect stdout/stderr to pipes for monitoring
@@ -317,7 +323,7 @@ pub async fn restart_server(
             log_level: None,
             bind_address: None,
             server_path: None,
-            source: None, // Use default (simulate)
+            source: None, // Falls through to explicit "simulated" — Tauri demo default.
         }
     };
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -6421,7 +6421,17 @@ async fn main() {
     info!("  UI path:   {}", args.ui_path.display());
     info!("  Source:    {}", args.source);
 
-    // Auto-detect data source
+    // Auto-detect data source.
+    //
+    // Issue #937 / sibling fix: previously `auto` silently fell back to the
+    // synthetic data source when no ESP32 or Windows WiFi was reachable, with
+    // only an `info!` log line as the signal. Downstream API consumers
+    // (`/api/v1/sensing/latest`, `/ws/sensing`) had no in-band way to know they
+    // were being served fake CSI tagged as production telemetry. That is the
+    // exact "where's the real data?" pattern external reviewers (#943, #934)
+    // cited as the most damaging evidence of the project misrepresenting its
+    // posture. Synthetic-data is now opt-in only — operators who want demo
+    // mode must explicitly set `--source simulated` or `CSI_SOURCE=simulated`.
     let source = match args.source.as_str() {
         "auto" => {
             info!("Auto-detecting data source...");
@@ -6432,10 +6442,23 @@ async fn main() {
                 info!("  Windows WiFi detected");
                 "wifi"
             } else {
-                info!("  No hardware detected, using simulation");
-                "simulate"
+                error!(
+                    "No real CSI source detected. Auto-detection refuses to silently \
+                     fall back to synthetic data because that would expose downstream \
+                     consumers (/api/v1/sensing/latest, /ws/sensing) to fake telemetry \
+                     tagged as production. To run with synthetic data, set the source \
+                     explicitly: --source simulated (or CSI_SOURCE=simulated in Docker). \
+                     To use real hardware: provision an ESP32 to emit CSI on UDP :{} or \
+                     install the Windows WiFi capture driver. See \
+                     https://github.com/ruvnet/RuView/issues/937 for context.",
+                    args.udp_port
+                );
+                std::process::exit(78); // EX_CONFIG
             }
         }
+        // "simulate" is a synonym for "simulated" (back-compat alias kept so
+        // existing operators who already opted in don't get broken by this fix).
+        "simulate" => "simulated",
         other => other,
     };
 


### PR DESCRIPTION
## Summary

Issue #937 in the cognitum-v0 appliance flagged that `cognitum-csi-capture` shipped `--simulate` by default. A grep across **this** tree found the same anti-pattern: `CSI_SOURCE=auto` (the Docker default) silently fell back to synthetic CSI when no ESP32 or Windows WiFi was detected, and the only signal was a single `info!` log line at startup. Downstream consumers of `/api/v1/sensing/latest` and `/ws/sensing` had no in-band way to know they were being served fake data.

## Fix

`auto` now refuses to fall back. When no real source is detected the server logs a clear `error!` with two explicit ways to proceed, then exits 78 (EX_CONFIG):

```
error: No real CSI source detected. Auto-detection refuses to silently fall back
       to synthetic data because that would expose downstream consumers
       (/api/v1/sensing/latest, /ws/sensing) to fake telemetry tagged as
       production. To run with synthetic data, set the source explicitly:
       --source simulated (or CSI_SOURCE=simulated in Docker). To use real
       hardware: provision an ESP32 to emit CSI on UDP :5005 or install the
       Windows WiFi capture driver. See https://github.com/ruvnet/RuView/issues/937
       for context.
```

Existing operators who explicitly set `--source simulated` (or the legacy `simulate` alias) are unaffected — the alias is preserved for back-compat.

## What changed

| File | Change |
|---|---|
| `wifi-densepose-sensing-server/src/main.rs` | `auto` no longer falls back; exits 78 with actionable error. `simulate` → `simulated` alias preserved. |
| `docker/docker-entrypoint.sh` | `CSI_SOURCE` help text rewritten to reflect fail-loud `auto`. |
| `docker/docker-compose.yml` | Comment for `CSI_SOURCE=auto` corrected. |
| `wifi-densepose-desktop/src/commands/server.rs` | Default passed downstream is now the **explicit** `simulated` (not `auto`), so the server tags the data correctly. Desktop app keeps demo-mode default — it's an explicit demo product. |

## Test plan

- [x] `cargo build -p wifi-densepose-sensing-server --no-default-features --bin sensing-server` → clean (existing pre-fix warnings unchanged).
- [x] `cargo test -p wifi-densepose-sensing-server --no-default-features --bin sensing-server` → **122 / 122 pass** (no regressions in the existing test suite).
- [ ] HW: not strictly needed — the code path is `match args.source.as_str()` arm replacement; CI build covers it. An end-to-end Docker smoke test (build image, run with no ESP32, expect exit 78) would be nice-to-have.

## Deployment

⚠ **Breaking change** for unattended deployments that relied on the `auto → simulated` silent fallback. That's exactly the failure mode this PR closes: pretending to serve real sensing data when the source is fake. Three escape hatches printed in the error message:

```bash
docker run -e CSI_SOURCE=simulated ruvnet/wifi-densepose:latest   # opt in to demo mode
docker run -e CSI_SOURCE=esp32     ruvnet/wifi-densepose:latest   # require real ESP32 on :5005
docker run -e CSI_SOURCE=wifi      ruvnet/wifi-densepose:latest   # use host WiFi capture
```

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)