### PR TITLE
RFC feat(firmware): XIAO ESP32S3 Sense camera node — CSI + OV3660 /snap + /stream on :8081 (compile-time optional)

### DIFF
--- a/firmware/esp32-csi-node/main/CMakeLists.txt
+++ b/firmware/esp32-csi-node/main/CMakeLists.txt
@@ -62,6 +62,12 @@ if(CONFIG_WASM_ENABLE)
     list(APPEND REQUIRES wasm3)
 endif()
 
+# XIAO ESP32S3 Sense camera + HTTP snapshot/MJPEG server (compile-time optional)
+if(CONFIG_CAMERA_ENABLE)
+    list(APPEND SRCS "camera_node.c")
+    list(APPEND REQUIRES espressif__esp32-camera)
+endif()
+
 idf_component_register(
     SRCS ${SRCS}
     INCLUDE_DIRS "."

--- a/firmware/esp32-csi-node/main/Kconfig.projbuild
+++ b/firmware/esp32-csi-node/main/Kconfig.projbuild
@@ -251,6 +251,31 @@ menu "AMOLED Display (ADR-045)"
 
 endmenu
 
+menu "Camera Node (XIAO ESP32S3 Sense)"
+
+    config CAMERA_ENABLE
+        bool "Enable onboard camera + HTTP snapshot/MJPEG server"
+        default n
+        depends on IDF_TARGET_ESP32S3
+        help
+            Initialize the onboard camera (Seeed XIAO ESP32S3 Sense pin map,
+            OV3660) after WiFi is up and serve GET /snap (single JPEG) and
+            GET /stream (~5 fps MJPEG) over HTTP. Requires octal SPIRAM
+            (CONFIG_SPIRAM + CONFIG_SPIRAM_MODE_OCT) for framebuffers.
+            Camera init failure degrades gracefully — CSI streaming is
+            unaffected.
+
+    config CAMERA_HTTP_PORT
+        int "Camera HTTP server port"
+        default 8081
+        range 1024 65535
+        depends on CAMERA_ENABLE
+        help
+            TCP port for the camera HTTP server. Must not collide with the
+            OTA/WASM-upload server on 8032.
+
+endmenu
+
 menu "WASM Programmable Sensing (ADR-040)"
 
     config WASM_ENABLE

--- a/firmware/esp32-csi-node/main/camera_node.c
+++ b/firmware/esp32-csi-node/main/camera_node.c
@@ -1,0 +1,154 @@
+/**
+ * @file camera_node.c
+ * @brief Onboard camera (Seeed XIAO ESP32S3 Sense, OV3660) + HTTP server.
+ *
+ * Pin map verified on hardware by the cam-probe firmware (2026-06): the
+ * XIAO ESP32S3 Sense map succeeded with sensor PID 0x3660. QVGA JPEG with
+ * fb_count=2 + CAMERA_GRAB_LATEST in PSRAM is the proven-reliable config
+ * (SVGA with fb_count=1 overflowed: FB-OVF). JPEG quality 12 + QVGA keeps
+ * per-frame airtime bounded so the CSI promiscuous callback isn't starved.
+ *
+ * The HTTP server runs on CONFIG_CAMERA_HTTP_PORT (default 8081 — the OTA
+ * server owns 8032) with its tasks pinned to core 1, away from the WiFi/CSI
+ * work on core 0. ctrl_port is offset from the default because the OTA
+ * httpd instance already owns 32768.
+ */
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_camera.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "sdkconfig.h"
+
+#include "camera_node.h"
+
+static const char *TAG = "camera_node";
+
+static httpd_handle_t s_httpd = NULL;
+
+/* Seeed XIAO ESP32S3 Sense pin map (cam-probe verified). */
+static const camera_config_t s_cam_cfg = {
+    .pin_pwdn = -1,
+    .pin_reset = -1,
+    .pin_xclk = 10,
+    .pin_sccb_sda = 40,
+    .pin_sccb_scl = 39,
+    .pin_d7 = 48, .pin_d6 = 11, .pin_d5 = 12, .pin_d4 = 14,
+    .pin_d3 = 16, .pin_d2 = 18, .pin_d1 = 17, .pin_d0 = 15,
+    .pin_vsync = 38,
+    .pin_href = 47,
+    .pin_pclk = 13,
+    .ledc_channel = LEDC_CHANNEL_0,
+    .ledc_timer = LEDC_TIMER_0,
+    .xclk_freq_hz = 20000000,
+    .pixel_format = PIXFORMAT_JPEG,
+    .frame_size = FRAMESIZE_QVGA,
+    .jpeg_quality = 12,
+    .fb_count = 2,
+    .fb_location = CAMERA_FB_IN_PSRAM,
+    .grab_mode = CAMERA_GRAB_LATEST,
+};
+
+/* GET /snap — one fresh JPEG. Discard one (possibly stale) framebuffer
+ * first so the client always gets a current capture. */
+static esp_err_t snap_handler(httpd_req_t *req)
+{
+    camera_fb_t *fb = esp_camera_fb_get();
+    if (fb != NULL) {
+        esp_camera_fb_return(fb);   /* discard stale frame */
+    }
+    fb = esp_camera_fb_get();
+    if (fb == NULL) {
+        ESP_LOGW(TAG, "/snap: capture failed");
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "camera capture failed");
+        return ESP_FAIL;
+    }
+
+    httpd_resp_set_type(req, "image/jpeg");
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store, no-cache, must-revalidate");
+    httpd_resp_set_hdr(req, "Pragma", "no-cache");
+    esp_err_t err = httpd_resp_send(req, (const char *)fb->buf, fb->len);
+    esp_camera_fb_return(fb);
+    return err;
+}
+
+/* GET /stream — multipart MJPEG at ~5 fps (200 ms inter-frame delay).
+ * Loops until the client disconnects (chunk send fails). */
+#define STREAM_BOUNDARY "ruviewcamframe"
+
+static esp_err_t stream_handler(httpd_req_t *req)
+{
+    httpd_resp_set_type(req, "multipart/x-mixed-replace;boundary=" STREAM_BOUNDARY);
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store");
+
+    while (true) {
+        camera_fb_t *fb = esp_camera_fb_get();
+        if (fb == NULL) {
+            ESP_LOGW(TAG, "/stream: capture failed — closing stream");
+            break;
+        }
+
+        char part_hdr[96];
+        int hdr_len = snprintf(part_hdr, sizeof(part_hdr),
+                               "\r\n--" STREAM_BOUNDARY "\r\n"
+                               "Content-Type: image/jpeg\r\n"
+                               "Content-Length: %u\r\n\r\n",
+                               (unsigned)fb->len);
+
+        esp_err_t err = httpd_resp_send_chunk(req, part_hdr, hdr_len);
+        if (err == ESP_OK) {
+            err = httpd_resp_send_chunk(req, (const char *)fb->buf, fb->len);
+        }
+        esp_camera_fb_return(fb);
+
+        if (err != ESP_OK) {
+            break;   /* client disconnected */
+        }
+        vTaskDelay(pdMS_TO_TICKS(200));   /* ~5 fps */
+    }
+
+    httpd_resp_send_chunk(req, NULL, 0);   /* terminate chunked response */
+    return ESP_OK;
+}
+
+esp_err_t camera_node_start(void)
+{
+    esp_err_t err = esp_camera_init(&s_cam_cfg);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "camera init failed: %s — camera disabled, CSI unaffected",
+                 esp_err_to_name(err));
+        return err;
+    }
+
+    sensor_t *sensor = esp_camera_sensor_get();
+    ESP_LOGI(TAG, "camera up: sensor PID=0x%04x (QVGA JPEG, fb_count=2, PSRAM)",
+             (sensor != NULL) ? sensor->id.PID : 0);
+
+    httpd_config_t cfg = HTTPD_DEFAULT_CONFIG();
+    cfg.server_port = CONFIG_CAMERA_HTTP_PORT;
+    cfg.ctrl_port = 32769;        /* OTA httpd owns the default 32768 */
+    cfg.core_id = 1;              /* keep capture/serve off core 0 (WiFi/CSI) */
+    cfg.lru_purge_enable = true;
+
+    err = httpd_start(&s_httpd, &cfg);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "camera httpd start failed: %s — camera disabled",
+                 esp_err_to_name(err));
+        esp_camera_deinit();
+        return err;
+    }
+
+    const httpd_uri_t snap_uri = {
+        .uri = "/snap", .method = HTTP_GET, .handler = snap_handler,
+    };
+    const httpd_uri_t stream_uri = {
+        .uri = "/stream", .method = HTTP_GET, .handler = stream_handler,
+    };
+    httpd_register_uri_handler(s_httpd, &snap_uri);
+    httpd_register_uri_handler(s_httpd, &stream_uri);
+
+    ESP_LOGI(TAG, "camera HTTP server on port %d (/snap, /stream)",
+             CONFIG_CAMERA_HTTP_PORT);
+    return ESP_OK;
+}

--- a/firmware/esp32-csi-node/main/camera_node.h
+++ b/firmware/esp32-csi-node/main/camera_node.h
@@ -1,0 +1,35 @@
+/**
+ * @file camera_node.h
+ * @brief Onboard camera (XIAO ESP32S3 Sense, OV3660) + HTTP snapshot/MJPEG server.
+ *
+ * Compiled only when CONFIG_CAMERA_ENABLE=y (see main/CMakeLists.txt).
+ * Call camera_node_start() AFTER the network is up. A camera failure is
+ * non-fatal: the function logs and returns an error, CSI streaming continues.
+ */
+
+#ifndef CAMERA_NODE_H
+#define CAMERA_NODE_H
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize the camera and start the HTTP server.
+ *
+ * Endpoints (port CONFIG_CAMERA_HTTP_PORT, default 8081):
+ *   GET /snap   — one fresh JPEG (stale framebuffer discarded first)
+ *   GET /stream — multipart/x-mixed-replace MJPEG at ~5 fps
+ *
+ * @return ESP_OK on success; error code if camera init or httpd start failed
+ *         (caller should log and continue — CSI operation is unaffected).
+ */
+esp_err_t camera_node_start(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CAMERA_NODE_H */

--- a/firmware/esp32-csi-node/main/idf_component.yml
+++ b/firmware/esp32-csi-node/main/idf_component.yml
@@ -11,3 +11,10 @@ dependencies:
 
   ## Onboard WS2812 LED Disabling
   espressif/led_strip: "^3.0.0"
+
+  ## XIAO ESP32S3 Sense camera (camera_node.c — only used when
+  ## CONFIG_CAMERA_ENABLE=y; rule keeps it out of non-S3 builds)
+  espressif/esp32-camera:
+    version: "^2.0.0"
+    rules:
+      - if: "target == esp32s3"

--- a/firmware/esp32-csi-node/main/main.c
+++ b/firmware/esp32-csi-node/main/main.c
@@ -38,6 +38,9 @@
 #include "c6_lp_core.h"            /* ADR-110: LP-core hibernation (no-op on S3) */
 #include "c6_sync_espnow.h"        /* ADR-110 D1 workaround: ESP-NOW sync */
 #include "c6_softap_he.h"          /* ADR-110 B1/B2: HE/TWT soft-AP (no-op when disabled) */
+#ifdef CONFIG_CAMERA_ENABLE
+#include "camera_node.h"           /* XIAO S3 Sense camera + HTTP server */
+#endif
 #ifdef CONFIG_CSI_MOCK_ENABLED
 #include "mock_csi.h"
 #endif
@@ -305,6 +308,15 @@ void app_main(void)
 #else
     esp_err_t ota_ret = ESP_ERR_NOT_SUPPORTED;
     ESP_LOGI(TAG, "Mock CSI mode: skipping OTA server (no network)");
+#endif
+
+    /* Camera node (XIAO ESP32S3 Sense): init AFTER WiFi/network is up.
+     * Failure is non-fatal by design — camera_node_start() logs and returns,
+     * CSI streaming continues unaffected. */
+#if defined(CONFIG_CAMERA_ENABLE) && !defined(CONFIG_CSI_MOCK_SKIP_WIFI_CONNECT)
+    if (camera_node_start() != ESP_OK) {
+        ESP_LOGW(TAG, "camera disabled (init failed) — CSI streaming unaffected");
+    }
 #endif
 
     /* ADR-040: Initialize WASM programmable sensing runtime. */

--- a/firmware/esp32-csi-node/sdkconfig.defaults.s3cam
+++ b/firmware/esp32-csi-node/sdkconfig.defaults.s3cam
@@ -1,0 +1,30 @@
+# Seeed XIAO ESP32S3 Sense — CSI + camera build overlay.
+# Feature set = sdkconfig.defaults.s3-fair (no display, no WASM — those pins
+# collide with the camera and the XIAO has neither peripheral) PLUS the
+# onboard OV3660 camera and the 8MB octal PSRAM it needs for framebuffers.
+#
+# Unlike s3-fair (which forces 4MB flash for the apples-to-apples C6 size
+# comparison), this overlay keeps the base 8MB flash + partitions_display.csv
+# from sdkconfig.defaults — the XIAO Sense has 8MB flash.
+#
+# Build (separate build dir — do NOT touch the C6 build/):
+#   idf.py -B build-s3cam -D SDKCONFIG=sdkconfig.s3cam \
+#       -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.s3cam" \
+#       set-target esp32s3
+#   idf.py -B build-s3cam -D SDKCONFIG=sdkconfig.s3cam \
+#       -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.s3cam" build
+
+CONFIG_IDF_TARGET="esp32s3"
+
+# Camera node (main/camera_node.c) — HTTP on 8081 (OTA owns 8032)
+CONFIG_CAMERA_ENABLE=y
+CONFIG_CAMERA_HTTP_PORT=8081
+
+# 8MB octal PSRAM @ 80MHz — required for camera framebuffers
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_OCT=y
+CONFIG_SPIRAM_SPEED_80M=y
+
+# s3-fair feature trims: no AMOLED display, no WASM3 runtime
+# CONFIG_DISPLAY_ENABLE is not set
+# CONFIG_WASM_ENABLE is not set


### PR DESCRIPTION
## RFC: optional onboard camera for the S3 CSI node (XIAO ESP32S3 Sense)

Feature proposal — marked RFC because it adds a new hardware capability rather than fixing a defect. Happy to adjust scope/naming to taste.

## Motivation

The Seeed XIAO ESP32S3 Sense is an S3 CSI node with a free OV3660 camera on board. Having the same node serve ground-truth snapshots/video alongside its CSI stream is directly useful for labeling and sanity-checking pose/presence work (e.g. ADR-150-style training captures) without adding a second device to the rig.

## What this adds

- `main/camera_node.c` / `camera_node.h` (~190 lines): OV3660 init with the hardware-verified XIAO ESP32S3 Sense pin map (sensor PID 0x3660), plus an HTTP server with
  - `GET /snap` — single fresh JPEG (one stale framebuffer discarded first)
  - `GET /stream` — multipart MJPEG at ~5 fps
- Kconfig menu: `CONFIG_CAMERA_ENABLE` (default **n**, `depends on IDF_TARGET_ESP32S3`) and `CONFIG_CAMERA_HTTP_PORT` (default 8081 — the OTA/WASM server owns 8032; httpd `ctrl_port` offset to 32769 since the OTA instance owns 32768)
- `idf_component.yml`: `espressif/esp32-camera ^2.0.0` with `rules: if target == esp32s3`, so non-S3 builds never fetch it
- `sdkconfig.defaults.s3cam` build overlay: octal PSRAM (required for framebuffers), display/WASM trimmed (those pins collide with the camera on the XIAO)
- `main.c`: starts the camera after WiFi is up; **init failure is non-fatal by design** — logs a warning and CSI streaming continues unaffected

## CSI-coexistence design notes

- QVGA JPEG, `fb_count=2`, `CAMERA_GRAB_LATEST`, quality 12 in PSRAM is the proven-reliable config from a probe firmware (SVGA with `fb_count=1` overflowed: FB-OVF); bounded per-frame airtime keeps the CSI promiscuous callback from being starved
- httpd tasks pinned to core 1, away from WiFi/CSI work on core 0
- Zero impact when disabled: `camera_node.c` is only compiled under `CONFIG_CAMERA_ENABLE`, and the default for every existing target/overlay is off — the C6 and stock S3 builds are byte-identical to main

## Hardware/test evidence

- Built clean on ESP-IDF v5.5.2, target esp32s3, using the documented two-step `idf.py -B build-s3cam` overlay invocation (no host-side Rust changes in this PR)
- Flashed and exercised on a XIAO ESP32S3 Sense: camera comes up with PID 0x3660, `/snap` returns fresh JPEGs and `/stream` sustains ~5 fps while the node keeps streaming CSI
- Companion context: this node fed the live HE20 capture/training work referenced in #1009 / #1010

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
