### PR TITLE
release: patch-bump signal/sensing-server/cli for #1009+#1004 fixes (+ first-publish calibration)

### DIFF
--- a/v2/crates/wifi-densepose-cli/Cargo.toml
+++ b/v2/crates/wifi-densepose-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wifi-densepose-cli"
-version.workspace = true
+version = "0.3.1"
 edition.workspace = true
 description = "CLI for WiFi-DensePose"
 authors.workspace = true

--- a/v2/crates/wifi-densepose-sensing-server/Cargo.toml
+++ b/v2/crates/wifi-densepose-sensing-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wifi-densepose-sensing-server"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 description = "Lightweight Axum server for WiFi sensing UI with RuVector signal processing"
 license.workspace = true

--- a/v2/crates/wifi-densepose-signal/Cargo.toml
+++ b/v2/crates/wifi-densepose-signal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wifi-densepose-signal"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 description = "WiFi CSI signal processing for DensePose estimation"
 license.workspace = true


### PR DESCRIPTION
Version bumps for the crates whose behavior changed in #1038 (HE20 calibration baseline + sensing-server simulate-latch), now published to crates.io:

- `wifi-densepose-signal` 0.3.3 → **0.3.4** (HE20 `num_active` 242→256)
- `wifi-densepose-sensing-server` 0.3.2 → **0.3.3** (`--source auto` always-bind-UDP + simulate→esp32 promotion)
- `wifi-densepose-cli` 0.3.0 → **0.3.1** (ships the u16 HE20 parser + calibrate fixes)
- `wifi-densepose-calibration` **0.3.0** — first-time publish (cli's dependency; was never on crates.io)

All published in dependency order. Closes the crates.io gap so the #1009/#1004 fixes reach users.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)