### PR TITLE
fix(mmwave): no false MR60BHA2 detection on empty UART (#1107)

### DIFF
--- a/firmware/esp32-csi-node/main/mmwave_sensor.c
+++ b/firmware/esp32-csi-node/main/mmwave_sensor.c
@@ -387,11 +387,21 @@ static mmwave_type_t probe_at_baud(uint32_t baud)
         if (len <= 0) continue;
 
         for (int i = 0; i < len; i++) {
-            /* MR60BHA2: SOF = 0x01, followed by valid-looking frame_id bytes */
-            if (buf[i] == MR60_SOF && baud == MMWAVE_MR60_BAUD) {
-                mr60_sof_seen++;
+            /* MR60BHA2: require a *validated* 8-byte header — SOF (0x01) + a valid
+             * header checksum (over bytes 0..6) + a known frame type (0x0A__ or
+             * 0x0F09) — NOT a bare 0x01 byte. A floating UART1 with no sensor reads
+             * noise full of 0x01s, which the old `buf[i] == MR60_SOF` check mistook
+             * for a real sensor (false "Detected MR60BHA2", #1107). */
+            if (buf[i] == MR60_SOF && baud == MMWAVE_MR60_BAUD && i + 7 < len) {
+                const uint8_t *h = &buf[i];
+                if (mr60_calc_checksum(h, 7) == h[7]) {
+                    uint16_t type = ((uint16_t)h[5] << 8) | h[6];
+                    if ((type >> 8) == 0x0A || type == 0x0F09) {
+                        mr60_sof_seen++;
+                    }
+                }
             }
-            /* LD2410: 4-byte header 0xF4F3F2F1 */
+            /* LD2410: 4-byte header 0xF4F3F2F1 (already specific enough). */
             if (i + 3 < len && buf[i] == 0xF4 && buf[i+1] == 0xF3
                 && buf[i+2] == 0xF2 && buf[i+3] == 0xF1
                 && baud == MMWAVE_LD2410_BAUD) {
@@ -403,9 +413,8 @@ static mmwave_type_t probe_at_baud(uint32_t baud)
         if (ld2410_header_seen >= 2) return MMWAVE_TYPE_LD2410;
     }
 
-    if (mr60_sof_seen > 0) return MMWAVE_TYPE_MR60BHA2;
-    if (ld2410_header_seen > 0) return MMWAVE_TYPE_LD2410;
-
+    /* No weak single-hit fallback: line noise can produce a stray match, so a real
+     * sensor must clear the ≥3 (MR60) / ≥2 (LD2410) validated-frame thresholds. */
     return MMWAVE_TYPE_NONE;
 }
 


### PR DESCRIPTION
Fixes the false-detection half of #1107.

**Root cause:** `probe_at_baud()` counted bare `0x01` (`MR60_SOF`) bytes and declared MR60BHA2 on as little as **one** (`mr60_sof_seen > 0` fallback). A floating UART1 with no sensor reads line noise full of `0x01`s → `Detected MR60BHA2 at 115200 baud (caps=0x000f)` with no hardware.

**Fix:** a candidate must now be a **validated 8-byte header** — `0x01` + a correct header checksum over bytes 0..6 (`mr60_calc_checksum`) + a **known frame type** (`0x0A__` / `0x0F09`) — and clear the existing **≥3**-frame threshold. The weak single-hit fallback is removed. A real MR60 streams valid frames continuously, so genuine detection is unaffected; noise can no longer pass.

**Scope/honesty:** this resolves the *false-detection* (problem 1). The `sendto ENOMEM` + `yield=0pps` (problem 2) is most likely a separate network-path issue (unreachable target IP → LWIP buffer exhaustion, same signature as a dead UDP target) — I've asked the reporter to confirm target reachability on the issue. Compile-validated by CI; I could not test on the exact N16R8 rig.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)