### PR TITLE
fix(display): no false display-detect on bare DevKit → CSI MGMT+DATA upgrade runs (#1000)

### DIFF
--- a/firmware/esp32-csi-node/main/display_task.c
+++ b/firmware/esp32-csi-node/main/display_task.c
@@ -114,6 +114,19 @@ esp_err_t display_task_start(void)
     /* Init touch (optional) */
     esp_err_t touch_ret = display_hal_init_touch();
 
+    /* The SH8601 QSPI panel is write-only — display_hal_init_panel() above "succeeds"
+     * even on a bare board with no panel attached, so it cannot detect absence. The
+     * FT3168 touch controller is an I2C device with readback and is always present on
+     * the Touch-AMOLED board. If touch is absent, the panel "success" was a false-
+     * positive on a display-less DevKit: bail to headless so display_is_active() stays
+     * false and CSI upgrades to MGMT+DATA capture instead of starving at MGMT-only
+     * (RuView#1000). */
+    if (touch_ret != ESP_OK) {
+        ESP_LOGW(TAG, "No FT3168 touch readback — SH8601 probe was a false-positive on a "
+                      "display-less board; running headless so CSI captures (#1000)");
+        return ESP_OK;
+    }
+
     /* Initialize LVGL */
     lv_init();
 


### PR DESCRIPTION
Fixes **cause 1** of #1000.

**Root cause:** the SH8601 AMOLED is a **write-only QSPI** panel — `display_hal_init_panel()` logs `SH8601 panel init OK` even with no panel attached (writes into the void), so it can't detect a bare board. `display_is_active()` then returned `true`, and `main.c:420` skipped the #893/#906 `MGMT → MGMT+DATA` CSI filter upgrade → `yield=0pps` permanently.

**Fix:** gate display presence on the **FT3168 touch I2C readback** (`display_hal_init_touch()`, reads chip-id 0xA8) — it's always present on the Touch-AMOLED board and absent on a bare DevKit. If touch is absent, the panel 'success' was a false-positive → **bail to headless before the display task starts**, so `display_is_active()` stays false and CSI upgrades to MGMT+DATA (0 → ~27-30 pps, matching the working in-repo `release_bins` 4MB binary).

**Cause 2 (separate):** the shipped `v0.6.7-esp32` S3 release asset predates #906 and never carried the fix. That's a **release-asset rebuild** — the S3 binaries should be rebuilt from current `main` (which has #906 + this fix) and re-published. I haven't done that blindly: firmware binaries need a real-hardware smoke test before shipping (CLAUDE.md rule), so I recommend the maintainer rebuild + validate on a bare N16R8.

Compile-validated by CI; not tested on the exact rev v0.2 rig.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)