### PR TITLE
fix(firmware): stop ESP32-S3 sendto ENOMEM tight loop - 10 Hz self-ping, 300 ms backoff, 128 TX buffers (#1135)

### DIFF
--- a/firmware/esp32-csi-node/main/adaptive_controller.c
+++ b/firmware/esp32-csi-node/main/adaptive_controller.c
@@ -225,7 +225,7 @@ static void fast_loop_cb(TimerHandle_t t)
      * the default 200 ms fast period), which combined with CSI promiscuous
      * RX saturated the WiFi TX airtime — measured live on COM8 (S3) and
      * COM9 (C6): every adaptive cycle showed `sendto ENOMEM — backing off
-     * for 100 ms`, and bumping LWIP/WiFi buffer pools to 4× had no effect
+     * for the ENOMEM cooldown`, and bumping LWIP/WiFi buffer pools to 4× had no effect
      * on the rate because the bottleneck was radio TX time, not pool size.
      * Dropping to 1 Hz (5× less feature_state traffic) frees the TX queue
      * for CSI sends and lands well within the spec. */

--- a/firmware/esp32-csi-node/main/csi_collector.c
+++ b/firmware/esp32-csi-node/main/csi_collector.c
@@ -376,7 +376,7 @@ static void wifi_promiscuous_cb(void *buf, wifi_promiscuous_pkt_type_t type)
  * are sparse beacons (often non-OFDM DSSS), so wifi_csi_callback can starve to
  * yield=0pps -> DEGRADED -> motion/presence=0 (#521, #954).
  *
- * This guarantees a ~50 Hz OFDM unicast floor by pinging the STA's own gateway:
+ * This guarantees a ~10 Hz OFDM unicast floor by pinging the STA's own gateway:
  * the router's ICMP echo replies are OFDM frames destined to this station, which
  * drive the CSI engine regardless of promiscuous filter state or ambient traffic.
  * It is ADDITIVE — promiscuous capture (#396/#893) is left fully intact so
@@ -409,7 +409,9 @@ static void csi_start_self_ping(void)
     esp_ping_config_t cfg = ESP_PING_DEFAULT_CONFIG();
     cfg.target_addr     = target;
     cfg.count           = ESP_PING_COUNT_INFINITE;
-    cfg.interval_ms     = 20;     /* 50 Hz -> ~50 received OFDM replies/sec */
+    cfg.interval_ms     = 100;    /* 10 Hz: cut self-ping TX flood that exhausts
+                                     S3 WiFi TX buffers -> sendto ENOMEM (#1135).
+                                     10 Hz still keeps the CSI OFDM source alive. */
     cfg.data_size       = 1;
     cfg.task_stack_size = 4096;
 
@@ -422,7 +424,7 @@ static void csi_start_self_ping(void)
 
     if (esp_ping_new_session(&cfg, &cbs, &s_self_ping) == ESP_OK && s_self_ping != NULL) {
         esp_ping_start(s_self_ping);
-        ESP_LOGI(TAG, "self-ping started -> %s @50Hz (CSI OFDM source, fix #521/#954)", gw_str);
+        ESP_LOGI(TAG, "self-ping started -> %s @10Hz (CSI OFDM source, fix #521/#954, S3 ENOMEM #1135)", gw_str);
     } else {
         ESP_LOGW(TAG, "self-ping: esp_ping_new_session failed");
         s_self_ping = NULL;

--- a/firmware/esp32-csi-node/main/stream_sender.c
+++ b/firmware/esp32-csi-node/main/stream_sender.c
@@ -26,7 +26,8 @@ static struct sockaddr_in s_dest_addr;
  * rapid-fire CSI callbacks can exhaust the pbuf pool and crash the device.
  */
 static int64_t s_backoff_until_us = 0;       /* esp_timer timestamp to resume */
-#define ENOMEM_COOLDOWN_MS  100              /* suppress sends for 100 ms */
+#define ENOMEM_COOLDOWN_MS  300              /* suppress sends for 300 ms — 100 ms
+                                              * was too short to drain on S3 (#1135) */
 #define ENOMEM_LOG_INTERVAL 50               /* log every Nth suppressed send */
 static uint32_t s_enomem_suppressed = 0;
 

--- a/firmware/esp32-csi-node/sdkconfig.defaults
+++ b/firmware/esp32-csi-node/sdkconfig.defaults
@@ -41,7 +41,7 @@ CONFIG_LWIP_SO_RCVBUF=y
 # ~3 KB extra heap cost, measured live on both targets Jun 8 2026.
 CONFIG_LWIP_UDP_RECVMBOX_SIZE=32
 CONFIG_LWIP_TCPIP_RECVMBOX_SIZE=64
-CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=64
+CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=128
 # NOTE: Empirical 25 s measurements on the S3 at COM8 showed these bumps
 # eliminate the csi_collector.sendto failure path (`fail #1..5` →
 # `fail #0`) — real improvement — but do NOT eliminate the broader

--- a/firmware/esp32-csi-node/sdkconfig.defaults.esp32c6
+++ b/firmware/esp32-csi-node/sdkconfig.defaults.esp32c6
@@ -70,6 +70,13 @@ CONFIG_LWIP_SO_RCVBUF=y
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
 CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=8192
 
+# ── Wi-Fi dynamic TX buffers: pin to the C6's verified value ──
+# The S3 ENOMEM fix (#1135) raises CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM to 128
+# in the base sdkconfig.defaults. That fix was hardware-verified on the S3 only,
+# so keep the C6 build at its previously-shipping 64 rather than silently
+# inheriting 128 on an untested target. Re-tune here if the C6 ever needs it.
+CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=64
+
 # ── Power: keep CPU at max 160 MHz (C6 ceiling) for DSP throughput ──
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_160=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=160


### PR DESCRIPTION
A fresh ESP32-S3 node enters a permanent `sendto ENOMEM` loop and never emits a single UDP frame. This applies the three mitigations proposed in #1135 and gets the egress path back to **9–13 pps / 300+ CSI frames/min**, measured end-to-end on real S3 hardware.

**Addresses #1135** — fixes bug #1 (egress ENOMEM) only; bug #2 (phantom LD2410 on a floating UART) is intentionally out of scope (see *Testing & scope*).

## Problem

On a fresh ESP32-S3, from the second CSI callback onward the node spins in a permanent `sendto ENOMEM` loop and **zero UDP frames ever leave the device** — the aggregator stays `esp32:offline` — even though Wi-Fi, DHCP and ICMP are all healthy. `pkt_yield_per_sec` sits at **0 pps**.

This matches the earlier S3 report in #1107, whose ENOMEM/yield-0 half #1119 explicitly deferred as "most likely a separate network-path issue." #1135 pins that separate egress issue down.

## Root cause

Per the analysis in #1135: during the first ~1 s after boot, the **50 Hz self-ping** + mmWave UART probe + ESPNOW init + promiscuous sniffer all contend for the same lwIP pbuf / Wi-Fi dynamic-TX pools. `sendto` returns `ENOMEM`, and the fixed **100 ms** backoff introduced in #132 is too short to let the pools drain, so the backoff re-fires into a still-full pool every cycle and loops forever. The S3 contends harder for these buffers than the C6 the original 0.6.x/0.7.0 tuning was verified against, which is why it surfaces there.

## The fix — the three mitigations proposed in #1135

1. **`main/csi_collector.c` — self-ping cadence 50 Hz → 10 Hz** (`cfg.interval_ms` 20 → 100). Removes ~52 back-to-back boot-time datagrams/s of TX flood while keeping the CSI OFDM source alive. Interval comment, block-header comment, and the `ESP_LOGI` startup string updated to `@10Hz`.
2. **`main/stream_sender.c` — `ENOMEM_COOLDOWN_MS` 100 → 300.** The backoff now outlasts the pbuf/mbox pressure instead of re-firing into a still-full pool. (Flat, not exponential — see *Testing & scope*.)
3. **`sdkconfig.defaults` — `CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM` 64 → 128.** TX headroom for the boot contention window. `128` is the max of the Kconfig `range 1 128` on ESP-IDF v5.4; the project has `CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER=y` (no PSRAM → dynamic TX), so the value is actually applied, not silently dropped.

**Scoped to the S3.** Because the bump lives in the base `sdkconfig.defaults`, the C6 build would inherit it through the overlay chain. Since this was hardware-tested on the S3 only, I pinned `CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=64` in `sdkconfig.defaults.esp32c6`, so the C6 build is byte-identical to today. Happy to drop that pin if you'd rather the C6 take the bump too.

These are conservative, reversible tunings: two constants, one buffer-count bump (~few KB heap), one C6 pin, and two stale-comment fixes. No API, protocol, or dependency change.

## Measured results

Built and flashed with **ESP-IDF v5.4** on an **ESP32-S3-DevKitC-1-class board** (QFN56 rev v0.2, 16 MB flash / 8 MB PSRAM, native USB-Serial/JTAG; WPA2 2.4 GHz). Aggregator = a stdlib UDP listener on `:5005` (macOS).

| Metric | Before | After |
|---|---|---|
| `sendto` ENOMEM | tight loop, never drains | none observed |
| `pkt_yield_per_sec` | 0 pps | 9–13 pps |
| CSI frames reaching host | 0 | 300+ / min |
| Vitals packets | none | parsing on host |

The ~10 pps floor stays comfortably above the `min_pkt_yield = 5 pps` DEGRADED gate, so no flapping. The edge pipeline measures its true sample rate from inter-frame timestamps and re-tunes (#987), so dropping the self-ping 5× does not break the vitals/BPM math; 10 Hz is still >5× Nyquist for HR.

## Testing & scope (honesty)

- **S3 only, not C6.** Verified end-to-end on ESP32-S3 hardware only (no C6 board on hand). This inverts RuView's usual C6-first coverage, so I'm flagging it plainly. The C6 build is left unchanged by this PR (the TX-buffer pin above).
- **Flat 300 ms backoff, not exponential.** #1135 also suggested an exponential schedule; I kept it flat because only the flat build was hardware-verified, and with the self-ping flood cut + 128 buffers the backoff now rarely fires (0 ENOMEM observed). Exponential under sustained pressure could grow the cooldown enough to starve CSI sends below the `min_pkt_yield = 5` DEGRADED threshold, and it needs added state — better as its own hardware-tested follow-up with a capped max.
- **Version-tree caveat.** The patched tree is v0.7.0 (`version.txt`); #1135 was filed against v0.8.1-esp32. The egress root cause and the 100 ms backoff are identical in both, but please confirm it lands cleanly on the current v0.8.x branch.
- **Not a total ENOMEM elimination.** This kills the boot-time loop. A residual airtime-bound `feature_state`-emit ENOMEM under load (noted in the in-tree `sdkconfig.defaults` comment block) is a separate adaptive-controller emit-cadence follow-up; the 300 ms backoff likely masks part of it but does not address it.
- **Single board, single network, no long soak.** @Gelsoluis offered to test patches on the v0.8.1-esp32 S3 + Docker rig — that validation before merge would de-risk the version-tree and single-board caveats.
- No CHANGELOG entry is included (the repo CHANGELOG looks release-automated); happy to add one if you'd like.

## Refs

#132 (the original ENOMEM backoff this extends — the 100 ms value #1135 says is too short on S3), #521 / #954 (self-ping CSI source), #1107 / #1119 (the mmwave-validation cluster + the deferred separate egress half this resolves).
