### PR TITLE
fix(sensing-server): canonicalize per-node CSI to 56 tones before multistatic fusion (#1170)

### DIFF
--- a/v2/crates/wifi-densepose-sensing-server/src/engine_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/engine_bridge.rs
@@ -247,7 +247,7 @@ impl EngineBridge {
 mod tests {
     use super::*;
     use std::collections::VecDeque;
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
     use wifi_densepose_bfld::PrivacyClass;
 
     fn node_state_with_history(amp: f64, n_sub: usize) -> NodeState {
@@ -402,17 +402,34 @@ mod tests {
         assert!(!bridge.suppress_raw_outputs());
     }
 
-    /// Error wiring (review finding 1a): two live nodes with mismatched
-    /// subcarrier counts make fusion return a `DimensionMismatch` →
-    /// `EngineError` — previously dropped by `if let Some(Ok(..))` at the
-    /// call sites. The counter must increment and the last good trust state
-    /// must survive a later failure.
+    /// Error wiring (review finding 1a): a fusion error must increment the
+    /// engine-error counter (previously dropped by `if let Some(Ok(..))` at the
+    /// call sites) and leave the last good trust state intact.
+    ///
+    /// The error is forced via a timestamp spread beyond the hard guard
+    /// (`MultistaticError::TimestampMismatch`). A subcarrier-count mismatch can
+    /// no longer reach the fuser — `node_frames_from_states` canonicalizes every
+    /// node onto a uniform 56-tone grid upstream — so the previous 56-vs-30
+    /// setup would now fuse cleanly.
     #[test]
     fn observe_cycle_counts_engine_errors() {
         let mut bridge = EngineBridge::new(PrivacyMode::PrivateHome, 1, "r", "R");
+        // Two fresh 56-tone nodes captured 200 ms apart → spread exceeds the
+        // 60 ms hard guard → fusion errors. Both times are derived from one
+        // base instant with node 1 offset *forward*: the bridge's frame
+        // timestamps are `last_frame_time.duration_since(EPOCH)`, and
+        // `Instant::duration_since` saturates to zero for any instant predating
+        // the lazily-initialized `EPOCH`. Offsetting forward keeps both times
+        // ≥ EPOCH, so the 200 ms spread survives regardless of EPOCH timing.
+        // Neither node is stale (< 10 s).
+        let base = Instant::now();
         let mut mismatched = HashMap::new();
-        mismatched.insert(0u8, node_state_with_history(1.0, 56));
-        mismatched.insert(1u8, node_state_with_history(1.05, 30)); // 30 ≠ 56 subcarriers
+        let mut a = node_state_with_history(1.0, 56);
+        a.last_frame_time = Some(base);
+        let mut b = node_state_with_history(1.05, 56);
+        b.last_frame_time = Some(base + Duration::from_millis(200));
+        mismatched.insert(0u8, a);
+        mismatched.insert(1u8, b);
 
         assert!(bridge.observe_cycle(&mismatched, 1_000).is_none());
         assert_eq!(bridge.engine_error_count(), 1);

--- a/v2/crates/wifi-densepose-sensing-server/src/multistatic_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/multistatic_bridge.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 
-use wifi_densepose_signal::hardware_norm::{CanonicalCsiFrame, HardwareType};
+use wifi_densepose_signal::hardware_norm::{CanonicalCsiFrame, HardwareNormalizer, HardwareType};
 use wifi_densepose_signal::ruvsense::multiband::MultiBandCsiFrame;
 use wifi_densepose_signal::ruvsense::multistatic::{FusedSensingFrame, MultistaticFuser};
 
@@ -26,6 +26,15 @@ const DEFAULT_FREQ_MHZ: u32 = 2437; // Channel 6
 /// are relative to this instant, avoiding wall-clock/monotonic mixing issues.
 static EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
 
+/// Shared normalizer used to resample every node's raw amplitude onto the
+/// canonical subcarrier grid (default 56 tones) before fusion. ESP32 nodes
+/// report heterogeneous subcarrier counts depending on capture mode (HT20 ≈ 64,
+/// HT40 ≈ 128/192 bins); the `MultistaticFuser` takes the first node's length as
+/// the expected dimension and rejects any node that differs with
+/// `MultistaticError::DimensionMismatch`. Canonicalizing here makes every node
+/// frame uniform so multistatic fusion actually runs on a mixed mesh.
+static NORMALIZER: LazyLock<HardwareNormalizer> = LazyLock::new(HardwareNormalizer::new);
+
 /// Convert a single `NodeState` into a `MultiBandCsiFrame` suitable for
 /// multistatic fusion.
 ///
@@ -38,7 +47,17 @@ pub fn node_frame_from_state(node_id: u8, ns: &NodeState) -> Option<MultiBandCsi
         return None;
     }
 
-    let amplitude: Vec<f32> = latest.iter().map(|&v| v as f32).collect();
+    // Resample the raw per-node amplitude onto the canonical 56-tone grid so
+    // heterogeneous nodes (ESP32 HT20 ≈ 64, HT40 ≈ 128/192 tones) all present
+    // the same dimension to the fuser. Resample-only (no z-score) preserves the
+    // amplitude scale that downstream person-scoring depends on. Without this,
+    // the fuser rejected every mixed-count cycle with `DimensionMismatch` and
+    // multistatic fusion silently fell back to per-node sum/dedup.
+    let amplitude: Vec<f32> = NORMALIZER
+        .resample_to_canonical(latest)
+        .iter()
+        .map(|&v| v as f32)
+        .collect();
     let n_sub = amplitude.len();
     let phase = vec![0.0_f32; n_sub];
 
@@ -201,13 +220,69 @@ mod tests {
         assert_eq!(frame.channel_frames.len(), 1);
 
         let ch = &frame.channel_frames[0];
-        assert_eq!(ch.amplitude.len(), 3);
-        assert!((ch.amplitude[0] - 10.0_f32).abs() < f32::EPSILON);
-        assert!((ch.amplitude[1] - 20.0_f32).abs() < f32::EPSILON);
-        assert!((ch.amplitude[2] - 30.5_f32).abs() < f32::EPSILON);
+        // Raw input is resampled onto the canonical 56-tone grid before fusion.
+        assert_eq!(ch.amplitude.len(), 56);
+        assert_eq!(ch.phase.len(), 56);
+        // Cubic resampling preserves the endpoints of the source vector.
+        assert!((ch.amplitude[0] - 10.0_f32).abs() < 1e-4);
+        assert!((ch.amplitude[55] - 30.5_f32).abs() < 1e-4);
         // Phase should be all zeros
         assert!(ch.phase.iter().all(|&p| p == 0.0));
         assert_eq!(ch.hardware_type, HardwareType::Esp32S3);
+    }
+
+    /// REGRESSION (engine_bridge `DimensionMismatch` flood): real ESP32 nodes
+    /// report different raw subcarrier counts depending on capture mode (HT20 ≈
+    /// 64, HT40 ≈ 128/192 bins). Before canonical resampling, the fuser took the
+    /// first node's length as "expected" and rejected every node that differed —
+    /// the live server logged an escalating `governed trust cycle failed: fusion
+    /// error: Dimension mismatch` and multistatic fusion never ran on a mixed
+    /// mesh. Every node frame must now be canonicalized to 56 tones so fusion
+    /// succeeds instead of falling back.
+    #[test]
+    fn heterogeneous_node_counts_canonicalize_and_fuse() {
+        let now = Some(Instant::now());
+        let mut states: HashMap<u8, NodeState> = HashMap::new();
+        // Node 0: 64-tone HT20-style frame.
+        states.insert(
+            0,
+            make_node_state(
+                VecDeque::from(vec![(0..64).map(|i| 1.0 + 0.1 * i as f64).collect()]),
+                now,
+                1,
+            ),
+        );
+        // Node 3: 192-tone HT40-style frame — the count that flooded the log.
+        states.insert(
+            3,
+            make_node_state(
+                VecDeque::from(vec![(0..192).map(|i| 1.0 + 0.05 * i as f64).collect()]),
+                now,
+                1,
+            ),
+        );
+
+        let frames = node_frames_from_states(&states);
+        assert_eq!(frames.len(), 2, "both active nodes contribute a frame");
+        for f in &frames {
+            assert_eq!(
+                f.channel_frames[0].amplitude.len(),
+                56,
+                "node {} must be canonicalized to 56 tones",
+                f.node_id
+            );
+        }
+
+        // Mixed 64/192 counts must now FUSE rather than DimensionMismatch →
+        // fallback. `fused` is Some and the fallback person count is None.
+        let fuser = MultistaticFuser::new();
+        let (fused, fallback) = fuse_or_fallback(&fuser, &states, 3.0);
+        assert!(
+            fused.is_some(),
+            "heterogeneous node counts must fuse after canonicalization"
+        );
+        assert!(fallback.is_none(), "no per-node fallback when fusion succeeds");
+        assert_eq!(fused.unwrap().active_nodes, 2);
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-signal/src/hardware_norm.rs
+++ b/v2/crates/wifi-densepose-signal/src/hardware_norm.rs
@@ -167,6 +167,24 @@ impl HardwareNormalizer {
             hardware_type: hw,
         })
     }
+
+    /// Resample a raw 1-D CSI vector onto the canonical subcarrier grid
+    /// **without** z-score normalization.
+    ///
+    /// [`Self::normalize`] z-scores amplitude (mean→0, std→1), which is correct
+    /// for model inference but destroys the absolute amplitude scale. The live
+    /// multistatic bridge's person-scoring uses the squared coefficient of
+    /// variation (`variance / mean²`) of the *fused* amplitude — z-scoring would
+    /// drive the mean to ~0 and saturate that score. For that path, length-only
+    /// canonicalization is exactly what's needed: it makes heterogeneous node
+    /// frames (e.g. ESP32 HT20=64, HT40=128/192 tones) fusable on a uniform grid
+    /// while preserving the amplitude statistics downstream consumers rely on.
+    ///
+    /// Identity passthrough when `raw.len()` already equals the canonical count.
+    #[must_use]
+    pub fn resample_to_canonical(&self, raw: &[f64]) -> Vec<f64> {
+        resample_cubic(raw, self.canonical_subcarriers)
+    }
 }
 
 impl Default for HardwareNormalizer {


### PR DESCRIPTION
## Summary

Fixes #1170 — the `DimensionMismatch` flood on a mixed ESP32 mesh.

`node_frame_from_state()` (`multistatic_bridge.rs`) wrapped each node's **raw**
amplitude (HT20 ≈ 64, HT40 ≈ 128/192 tones) into a `CanonicalCsiFrame` *without
ever resampling*. `MultistaticFuser::fuse()` takes the first node's length as the
expected dimension and rejects any node that differs, so on a heterogeneous mesh:

- the governed engine path logged an escalating `governed trust cycle failed …
  fusion error: Dimension mismatch` and `total_engine_errors` climbed unbounded;
- the bare path silently fell back to per-node sum/dedup — **multistatic fusion
  never actually ran**.

## Fix

Canonicalize every node frame onto the 56-tone grid in the bridge, **before**
fusion, using a **resample-only** transform (not full `normalize()` — z-scoring
drives the amplitude mean to ~0 and would saturate the downstream person-score
`variance / mean²`). This aligns the live path with the canonical-56 pipeline the
fuser already documents (ADR-154).

- **`hardware_norm.rs`** — add `HardwareNormalizer::resample_to_canonical()`:
  cubic resample to the canonical grid without z-score; identity passthrough when
  already canonical.
- **`multistatic_bridge.rs`** — resample raw amplitude to 56 tones via a shared
  `NORMALIZER` in `node_frame_from_state()`, so **both** fusion paths
  (`fuse_or_fallback` and the governed engine) see uniform dimensions.

## Safety

- No CIR estimator is attached on the server path (no `set_cir_estimator`/
  `with_cir`), so 56-tone frames cannot trip the ADR-154 `SubcarrierMismatch`
  debug-assert.
- Resampling is a pure function of the input → engine witnesses stay
  deterministic/reproducible.

## Tests

`cargo test -p wifi-densepose-signal -p wifi-densepose-sensing-server --no-default-features` — **0 failed**.

- New regression test `heterogeneous_node_counts_canonicalize_and_fuse`: a mixed
  64/192-count cycle now **fuses** (`fused.is_some()`, no fallback) instead of
  erroring.
- `hardware_norm` resample/normalize tests pass.
- Retargeted `engine_bridge::observe_cycle_counts_engine_errors`: its old 56-vs-30
  setup now canonicalizes and fuses cleanly, so it forces a `TimestampMismatch`
  (spread > hard guard) to keep exercising the engine error-counting /
  last-good-witness wiring.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
