### PR TITLE
docs(readme): fix broken no-hardware Docker quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,22 @@ RuView turns ordinary WiFi into a contactless sensor. A $9 ESP32 board reads the
 ```bash
 # Option 1: Docker (simulated data, no hardware needed)
 docker pull ruvnet/wifi-densepose:latest
-docker run -p 3000:3000 ruvnet/wifi-densepose:latest
-# Open http://localhost:3000
+
+# Two env vars are required for the no-hardware demo:
+#   CSI_SOURCE=simulated            opt into synthetic CSI — the default `auto`
+#                                   fails loud (exit 78) when no ESP32/NIC is
+#                                   detected (issue #937), so it must be explicit.
+#   RUVIEW_ALLOW_UNAUTHENTICATED=1  localhost-only demo posture — the entrypoint
+#                                   otherwise refuses to start (exit 64) on a
+#                                   0.0.0.0 bind without auth (issue #864). On a
+#                                   shared network use RUVIEW_API_TOKEN=$(openssl
+#                                   rand -hex 32) instead.
+docker run -p 3000:3000 -p 3001:3001 \
+  -e CSI_SOURCE=simulated \
+  -e RUVIEW_ALLOW_UNAUTHENTICATED=1 \
+  ruvnet/wifi-densepose:latest
+# Open http://localhost:3000/ui/index.html
+# Live sensing frames stream over ws://localhost:3001/ws/sensing
 
 # Option 2a: Live sensing with ESP32-S3 hardware ($9)
 # Flash firmware, provision WiFi, and start sensing:


### PR DESCRIPTION
## Problem

The headline **"Option 1: Docker (simulated data, no hardware needed)"** command in the README does not run on a clean machine. This appears to be the single most common "can't get it to work" complaint (#1125, #509, #951, #301).

Reproduced on a fresh pull of `ruvnet/wifi-densepose:latest`:

```
$ docker run -p 3000:3000 ruvnet/wifi-densepose:latest
[entrypoint] ERROR: refusing to start sensing-server with default posture: RUVIEW_API_TOKEN is unset AND bind is 0.0.0.0 ...
# container exits with code 64
```

Three compounding issues for a no-hardware evaluator:

1. **Auth guard (#864)** refuses a `0.0.0.0` bind without a token → **exit 64** (fires first, so the command never even starts).
2. **`CSI_SOURCE` defaults to `auto`**, which fails loud (#937) when no ESP32/NIC is detected → **exit 78**. For the simulated demo it must be set explicitly.
3. The **WebSocket port `3001` was not published**, so the live `/ws/sensing` stream is unreachable, and the UI is served at `/ui/index.html`, not `/`.

## Fix

Document the verified working invocation — both required env vars, both ports, and the correct URL — with short inline notes pointing at the relevant issues so the security/fail-loud posture is explained rather than just worked around.

## Verification

Ran the newly documented command verbatim on a fresh container:

- container `exit=0` (stays up)
- `GET /ui/index.html` → **HTTP 200**
- `GET /api/v1/sensing/latest` → `{"classification":{"presence":true,...},"estimated_persons":1,...}`
- live `sensing_update` frames stream over `ws://localhost:3001/ws/sensing`

No code changes — README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)