### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/archive/v1/docs/user_guide.md
+++ b/archive/v1/docs/user_guide.md
@@ -50,7 +50,7 @@ WiFi Routers → CSI Data → Signal Processing → Neural Network → Pose Esti
 pip install wifi-densepose
 
 # Install with optional dependencies
-pip install wifi-densepose[gpu,monitoring,deployment]
+pip install 'wifi-densepose[gpu,monitoring,deployment]'
 
 # Verify installation
 wifi-densepose --version

--- a/docs/readme-details.md
+++ b/docs/readme-details.md
@@ -384,8 +384,8 @@ pip install -e .
 
 # Or via pip
 pip install wifi-densepose
-pip install wifi-densepose[gpu]   # GPU acceleration
-pip install wifi-densepose[all]   # All optional deps
+pip install 'wifi-densepose[gpu]'   # GPU acceleration
+pip install 'wifi-densepose[all]'   # All optional deps
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `archive/v1/docs/user_guide.md`
- `docs/readme-details.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`