### PR TITLE
fix(firmware): normalize presence_score and motion_score before transmit

### DIFF
--- a/firmware/esp32-csi-node/main/Kconfig.projbuild
+++ b/firmware/esp32-csi-node/main/Kconfig.projbuild
@@ -487,10 +487,18 @@ menu "Onboard LED (ADR-183)"
     config LED_MOTION_FULLSCALE_MILLI
         int "Motion value (x1000) that saturates the colormap to yellow"
         depends on LED_GAMMA_VIZ
-        default 250
+        default 10000
         range 1 100000
         help
             edge motion_energy that maps to the top (yellow) of the viridis
-            colormap, in milli-units (250 = 0.25). Lower = more sensitive
+            colormap, in milli-units (10000 = 10.0). Lower = more sensitive
             (reaches yellow with less motion).
+
+            10.0 matches the saturation point adaptive_controller.c's
+            collect_observation() uses to normalize this same raw
+            motion_energy/presence_score value into motion_score/presence_score
+            (RuView#1286) — yellow now means the same "fully saturated motion"
+            as motion_score == 1.0 elsewhere in the system, instead of an
+            unrelated 0.25 threshold that saturated to yellow almost
+            immediately given real-world motion_energy commonly runs 4-14.
 endmenu

--- a/firmware/esp32-csi-node/main/adaptive_controller.c
+++ b/firmware/esp32-csi-node/main/adaptive_controller.c
@@ -116,18 +116,24 @@ static void collect_observation(adapt_observation_t *out)
         }
     }
 
-    /* Edge-derived state. The ADR-039 vitals packet exposes presence_score
-     * and motion_energy directly; we treat motion_energy as a proxy for
-     * motion_score by clamping to [0,1]. anomaly_score and node_coherence
-     * are not yet emitted by edge_processing — placeholder until Layer 4
-     * extraction lands. */
+    /* Edge-derived state. The ADR-039 vitals packet's presence_score and
+     * motion_energy are the same raw, unbounded phase-variance quantity
+     * (edge_processing.c sets s_presence_score = s_motion_energy directly),
+     * so both must go through the same scale-then-clamp normalization
+     * send_feature_vector() already uses (divide by 10, clamp to [0,1]).
+     * A bare [0,1] clamp on either field saturates at 1.0 almost
+     * unconditionally, since raw values routinely exceed 1.0 — this is
+     * what caused presence/motion to read "detected" regardless of actual
+     * occupancy. anomaly_score and node_coherence are not yet emitted by
+     * edge_processing — placeholder until Layer 4 extraction lands. */
     edge_vitals_pkt_t vitals;
     if (edge_get_vitals(&vitals)) {
-        out->presence_score = vitals.presence_score;
+        float p = vitals.presence_score;
+        if (p < 0.0f) p = 0.0f;
+        out->presence_score = (p > 10.0f) ? 1.0f : (p / 10.0f);
         float m = vitals.motion_energy;
         if (m < 0.0f) m = 0.0f;
-        if (m > 1.0f) m = 1.0f;
-        out->motion_score   = m;
+        out->motion_score   = (m > 10.0f) ? 1.0f : (m / 10.0f);
     }
     out->anomaly_score  = 0.0f;
     out->node_coherence = 1.0f;

--- a/scripts/c6-presence-watcher.py
+++ b/scripts/c6-presence-watcher.py
@@ -317,53 +317,63 @@ def main() -> int:
                     # ADR-118 PrivacyGate: classify + redact before the
                     # HAP boundary. Returns None for non-eligible classes.
                     gated = apply_privacy_gate(pkt, privacy_class)
-                    if gated is not None and gated["presence_valid"]:
-                        n_valid += 1
-                        presence_sum += gated["presence"]
-                        motion_sum += gated["motion"]
-                        last_packet_ts = now
-                        # MotionDetected — short-window (each packet)
+                    if gated is not None:
                         prev_motion = motion
-                        if not motion and gated["presence"] >= PRESENCE_ON_THRESHOLD:
-                            motion = set_motion(args.toggle, True, motion)
-                        elif motion and gated["presence"] <= PRESENCE_OFF_THRESHOLD:
-                            motion = set_motion(args.toggle, False, motion)
+                        if gated["presence_valid"]:
+                            n_valid += 1
+                            presence_sum += gated["presence"]
+                            motion_sum += gated["motion"]
+                            last_packet_ts = now
+                            # MotionDetected — short-window (each packet)
+                            if not motion and gated["presence"] >= PRESENCE_ON_THRESHOLD:
+                                motion = set_motion(args.toggle, True, motion)
+                            elif motion and gated["presence"] <= PRESENCE_OFF_THRESHOLD:
+                                motion = set_motion(args.toggle, False, motion)
 
-                        # OccupancyDetected — rolling-window avg (§2.1.d
-                        # "Unexpected Occupancy" is a future iter; for now
-                        # we expose Occupancy as sustained presence).
-                        occ_window.append((now, gated["presence"]))
-                        cutoff = now - args.occupancy_window
-                        while occ_window and occ_window[0][0] < cutoff:
-                            occ_window.popleft()
-                        if occ_window:
-                            occ_avg = (sum(p for _, p in occ_window)
-                                       / len(occ_window))
-                            if not occupancy and occ_avg >= OCC_ON_THRESH:
-                                occupancy = True
+                            # OccupancyDetected — rolling-window avg (§2.1.d
+                            # "Unexpected Occupancy" is a future iter; for now
+                            # we expose Occupancy as sustained presence).
+                            occ_window.append((now, gated["presence"]))
+                            cutoff = now - args.occupancy_window
+                            while occ_window and occ_window[0][0] < cutoff:
+                                occ_window.popleft()
+                            if occ_window:
+                                occ_avg = (sum(p for _, p in occ_window)
+                                           / len(occ_window))
+                                if not occupancy and occ_avg >= OCC_ON_THRESH:
+                                    occupancy = True
+                                    print(f"[{time.strftime('%H:%M:%S')}] "
+                                          f"Unknown Presence — Occupancy ON "
+                                          f"(rolling_avg={occ_avg:.2f})",
+                                          flush=True)
+                                elif occupancy and occ_avg <= OCC_OFF_THRESH:
+                                    occupancy = False
+                                    print(f"[{time.strftime('%H:%M:%S')}] "
+                                          f"Occupancy OFF "
+                                          f"(rolling_avg={occ_avg:.2f})",
+                                          flush=True)
+
+                            # Anomaly — only when class allows (Restricted
+                            # gate drops anomaly_score entirely; the dict
+                            # missing the key is the type-level enforcement).
+                            if ("anomaly" in gated
+                                    and gated["anomaly"] >= args.anomaly_threshold):
+                                last_anomaly_ts = now
+                                n_anomaly_fires += 1
                                 print(f"[{time.strftime('%H:%M:%S')}] "
-                                      f"Unknown Presence — Occupancy ON "
-                                      f"(rolling_avg={occ_avg:.2f})",
-                                      flush=True)
-                            elif occupancy and occ_avg <= OCC_OFF_THRESH:
-                                occupancy = False
-                                print(f"[{time.strftime('%H:%M:%S')}] "
-                                      f"Occupancy OFF "
-                                      f"(rolling_avg={occ_avg:.2f})",
+                                      f"Unrecognized Activity Pattern "
+                                      f"(anomaly={gated['anomaly']:.2f})",
                                       flush=True)
 
-                        # Anomaly — only when class allows (Restricted
-                        # gate drops anomaly_score entirely; the dict
-                        # missing the key is the type-level enforcement).
-                        if ("anomaly" in gated
-                                and gated["anomaly"] >= args.anomaly_threshold):
-                            last_anomaly_ts = now
-                            n_anomaly_fires += 1
-                            print(f"[{time.strftime('%H:%M:%S')}] "
-                                  f"Unrecognized Activity Pattern "
-                                  f"(anomaly={gated['anomaly']:.2f})",
-                                  flush=True)
-
+                        # Write on every privacy-eligible packet, not just
+                        # presence_valid ones — otherwise the feature file's
+                        # `ts` only advances during "confident" readings, and
+                        # goes stale (per ruview-sensing-server.py's 10s
+                        # staleness gate) during perfectly normal stretches
+                        # where the room is calm/empty and presence_score
+                        # legitimately sits below the firmware's 0.5 quality
+                        # threshold. That previously read as "watcher/device
+                        # dead" to consumers when it was actually just quiet.
                         if (motion != prev_motion
                                 or not state_path.endswith(".disabled")):
                             write_state(motion, occupancy, last_anomaly_ts)

--- a/scripts/ruview-sensing-server.py
+++ b/scripts/ruview-sensing-server.py
@@ -19,6 +19,20 @@ Endpoints (matched against tools/ruview-mcp/src/tools/*.ts):
   GET  /api/v1/edge/registry                   — node enumeration
   GET  /api/v1/vitals/<node_id>/latest         — EdgeVitalsMessage
   GET  /api/v1/bfld/<node_id>/last_scan        — BfldScanResponse
+  GET  /api/v1/sensing/history/<node_id>?hours=24&bucket_min=10
+                                                — bucketed presence history
+                                                  + exact state-change events,
+                                                  for the ui/live-status.html
+                                                  24h chart. A background
+                                                  thread samples the feature
+                                                  file every HISTORY_SAMPLE_S
+                                                  and appends to a per-node
+                                                  JSONL file so history
+                                                  survives server restarts.
+                                                  There is no backfill: the
+                                                  window only has real data
+                                                  from whenever this sampler
+                                                  was first started.
   POST /api/v1/bfld/<node_id>/subscribe?duration_s=N — { subscription_id }
 
 The source-of-truth file is `/tmp/ruview-last-feature.json` written
@@ -35,7 +49,9 @@ import json
 import os
 import re
 import sys
+import threading
 import time
+from collections import deque
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
 
@@ -43,6 +59,134 @@ FEATURE_FILE = os.environ.get("RUVIEW_FEATURE_JSON",
                               "/tmp/ruview-last-feature.json")
 STALENESS_S = 10.0
 DEFAULT_PORT = int(os.environ.get("PORT", "3000"))
+
+# --- Presence history (for the 24h chart) -----------------------------------
+# The feature file only ever holds the latest sample, so a background thread
+# samples it every HISTORY_SAMPLE_S and keeps a rolling HISTORY_WINDOW_S of
+# (timestamp, presence) pairs in memory, persisted to a per-node JSONL file
+# so history survives a server restart. No backfill — a freshly started
+# sampler has no history before its own start time.
+HISTORY_DIR = os.environ.get("RUVIEW_HISTORY_DIR", "/tmp")
+HISTORY_SAMPLE_S = 30.0
+HISTORY_WINDOW_S = 24 * 3600.0
+_history_lock = threading.Lock()
+_history: dict[str, deque] = {}
+
+
+def _history_file(node_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", node_id)
+    return os.path.join(HISTORY_DIR, f"ruview-history-{safe}.jsonl")
+
+
+def _load_history_from_disk(node_id: str) -> deque:
+    dq: deque = deque()
+    cutoff = time.time() - HISTORY_WINDOW_S
+    try:
+        with open(_history_file(node_id), "r") as fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ts = rec.get("ts")
+                if ts is not None and ts >= cutoff:
+                    dq.append((ts, bool(rec.get("presence"))))
+    except OSError:
+        pass
+    return dq
+
+
+def _history_get(node_id: str) -> deque:
+    with _history_lock:
+        if node_id not in _history:
+            _history[node_id] = _load_history_from_disk(node_id)
+        return _history[node_id]
+
+
+def _append_history_disk(node_id: str, ts: float, presence: bool) -> None:
+    try:
+        with open(_history_file(node_id), "a") as fh:
+            fh.write(json.dumps({"ts": ts, "presence": presence}) + "\n")
+    except OSError as e:
+        print(f"[sensing-server] history write error: {e}", flush=True)
+
+
+def _prune_history_disk(node_id: str) -> None:
+    """Rewrite the history file from the in-memory window, bounding growth."""
+    with _history_lock:
+        records = list(_history.get(node_id, ()))
+    path = _history_file(node_id)
+    tmp = path + ".tmp"
+    try:
+        with open(tmp, "w") as fh:
+            for ts, presence in records:
+                fh.write(json.dumps({"ts": ts, "presence": presence}) + "\n")
+        os.replace(tmp, path)
+    except OSError as e:
+        print(f"[sensing-server] history prune error: {e}", flush=True)
+
+
+def _history_sampler_loop() -> None:
+    prune_countdown = {}
+    while True:
+        time.sleep(HISTORY_SAMPLE_S)
+        f = _load_feature()
+        if f is None:
+            continue
+        node_id = f["node_id"]
+        presence = bool(f.get("presence", False))
+        now = time.time()
+        dq = _history_get(node_id)
+        with _history_lock:
+            dq.append((now, presence))
+            cutoff = now - HISTORY_WINDOW_S
+            while dq and dq[0][0] < cutoff:
+                dq.popleft()
+        _append_history_disk(node_id, now, presence)
+        prune_countdown[node_id] = prune_countdown.get(node_id, 0) + 1
+        if prune_countdown[node_id] >= 200:  # ~100 min at 30s cadence
+            _prune_history_disk(node_id)
+            prune_countdown[node_id] = 0
+
+
+def history_for(node_id: str, hours: float, bucket_min: float) -> dict:
+    now = time.time()
+    bucket_s = max(1.0, bucket_min * 60.0)
+    n_buckets = max(1, int((hours * 3600.0) // bucket_s))
+    start = now - n_buckets * bucket_s
+
+    dq = _history_get(node_id)
+    with _history_lock:
+        samples = sorted((ts, p) for ts, p in dq if ts >= start)
+
+    changes = []
+    prev = None
+    for ts, presence in samples:
+        if prev is not None and presence != prev:
+            changes.append({"ts": ts, "presence": presence})
+        prev = presence
+
+    buckets = []
+    for i in range(n_buckets):
+        b_start = start + i * bucket_s
+        b_end = b_start + bucket_s
+        in_bucket = [p for ts, p in samples if b_start <= ts < b_end]
+        buckets.append({
+            "ts_start": b_start,
+            "ts_end": b_end,
+            "has_data": bool(in_bucket),
+            "presence_frac": (sum(in_bucket) / len(in_bucket)
+                               if in_bucket else None),
+        })
+
+    return {
+        "node_id": node_id,
+        "window_hours": hours,
+        "bucket_minutes": bucket_min,
+        "sample_interval_s": HISTORY_SAMPLE_S,
+        "buckets": buckets,
+        "changes": changes,
+    }
 
 
 def _load_feature() -> dict | None:
@@ -100,6 +244,7 @@ _PATH_VITALS = re.compile(r"^/api/v1/vitals/([^/]+)/latest$")
 _PATH_BFLD_SCAN = re.compile(r"^/api/v1/bfld/([^/]+)/last_scan$")
 _PATH_BFLD_SUBSCRIBE = re.compile(r"^/api/v1/bfld/([^/]+)/subscribe$")
 _PATH_SEMANTIC = re.compile(r"^/api/v1/semantic-events/([^/]+)/latest$")
+_PATH_HISTORY = re.compile(r"^/api/v1/sensing/history/([^/]+)$")
 
 
 def semantic_events_for(node_id: str) -> dict | None:
@@ -244,6 +389,15 @@ class Handler(BaseHTTPRequestHandler):
             self._json(200, r)
             return
 
+        m = _PATH_HISTORY.match(path)
+        if m:
+            node_id = m.group(1)
+            qs = parse_qs(parsed.query)
+            hours = float(qs.get("hours", ["24"])[0])
+            bucket_min = float(qs.get("bucket_min", ["10"])[0])
+            self._json(200, history_for(node_id, hours, bucket_min))
+            return
+
         self._json(404, {"error": "not found", "path": path})
 
     def do_POST(self) -> None:
@@ -267,9 +421,12 @@ class Handler(BaseHTTPRequestHandler):
 def main() -> int:
     port = DEFAULT_PORT
     server = HTTPServer(("0.0.0.0", port), Handler)
+    threading.Thread(target=_history_sampler_loop, daemon=True).start()
     print(f"[sensing-server] listening on 0.0.0.0:{port}", flush=True)
     print(f"[sensing-server] feature source: {FEATURE_FILE}", flush=True)
     print(f"[sensing-server] staleness limit: {STALENESS_S} s", flush=True)
+    print(f"[sensing-server] history sampler: every {HISTORY_SAMPLE_S}s, "
+          f"{HISTORY_WINDOW_S/3600:.0f}h window, dir={HISTORY_DIR}", flush=True)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/scripts/ruview-sensing-server.py
+++ b/scripts/ruview-sensing-server.py
@@ -164,6 +164,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(payload)
 

--- a/ui/live-status.html
+++ b/ui/live-status.html
@@ -133,6 +133,44 @@
     color: #6b7280;
     text-align: right;
   }
+  .chart-wrap { margin-top: 1.1rem; }
+  .chart-title {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #9aa0aa;
+    margin-bottom: 0.4rem;
+  }
+  .chart {
+    width: 100%;
+    height: 44px;
+    display: block;
+    border-radius: 6px;
+    background: #20242c;
+  }
+  .chart-axis {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.6rem;
+    color: #6b7280;
+    margin-top: 0.3rem;
+  }
+  .chart-legend {
+    display: flex;
+    gap: 0.9rem;
+    flex-wrap: wrap;
+    font-size: 0.62rem;
+    color: #9aa0aa;
+    margin-top: 0.5rem;
+  }
+  .chart-legend .swatch {
+    display: inline-block;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 2px;
+    margin-right: 0.3rem;
+    vertical-align: middle;
+  }
   #empty-state {
     color: #6b7280;
     font-size: 0.9rem;
@@ -158,6 +196,7 @@
 <script>
   const API_BASE = "http://localhost:3000";
   const POLL_MS = 1000;
+  const HISTORY_POLL_MS = 30000;
   const STALE_S = 10;
   const LABEL_KEY = "ruview-floor-labels";
 
@@ -214,6 +253,19 @@
         <div class="card"><div class="label">Confidence</div><div class="value" data-el="confidence">—</div></div>
       </div>
       <div class="node-footer" data-el="footer">waiting for data…</div>
+
+      <div class="chart-wrap">
+        <div class="chart-title">Presence — last 24h (10 min buckets)</div>
+        <svg class="chart" data-el="chart" viewBox="0 0 720 60" preserveAspectRatio="none"></svg>
+        <div class="chart-axis" data-el="chartAxis"></div>
+        <div class="chart-legend">
+          <span><span class="swatch" style="background:#20242c;border:1px solid #33394a;"></span>no data</span>
+          <span><span class="swatch" style="background:#2a2e37;"></span>empty</span>
+          <span><span class="swatch" style="background:rgba(74,222,128,0.85);"></span>occupied</span>
+          <span><span class="swatch" style="background:#4ade80;"></span>| became present</span>
+          <span><span class="swatch" style="background:#94a3b8;"></span>| became absent</span>
+        </div>
+      </div>
     `;
     nodesEl.appendChild(card);
 
@@ -228,6 +280,8 @@
       heart: card.querySelector('[data-el="heart"]'),
       confidence: card.querySelector('[data-el="confidence"]'),
       footer: card.querySelector('[data-el="footer"]'),
+      chart: card.querySelector('[data-el="chart"]'),
+      chartAxis: card.querySelector('[data-el="chartAxis"]'),
     };
     refs.label.addEventListener("change", () => saveLabel(nodeId, refs.label.value.trim() || ("Node " + nodeId)));
     cardEls.set(nodeId, refs);
@@ -248,6 +302,68 @@
     if (res.status === 503) return null;
     if (!res.ok) throw new Error(`HTTP ${res.status} for node ${nodeId}`);
     return res.json();
+  }
+
+  async function fetchHistory(nodeId) {
+    const res = await fetch(
+      `${API_BASE}/api/v1/sensing/history/${encodeURIComponent(nodeId)}?hours=24&bucket_min=10`,
+      { cache: "no-store" }
+    );
+    if (!res.ok) throw new Error(`HTTP ${res.status} for node ${nodeId} history`);
+    return res.json();
+  }
+
+  function bucketColor(b) {
+    if (!b.has_data) return "#20242c";
+    if (!b.presence_frac) return "#2a2e37";
+    const alpha = (0.35 + b.presence_frac * 0.65).toFixed(2);
+    return `rgba(74, 222, 128, ${alpha})`;
+  }
+
+  function fmtTime(ts) {
+    return new Date(ts * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+
+  function renderHistory(refs, hist) {
+    const buckets = hist.buckets;
+    const n = buckets.length;
+    if (n === 0) { refs.chart.innerHTML = ""; refs.chartAxis.innerHTML = ""; return; }
+
+    const W = 720, H = 60;
+    const barW = W / n;
+    const t0 = buckets[0].ts_start;
+    const t1 = buckets[n - 1].ts_end;
+    const total = Math.max(1, t1 - t0);
+    const tToX = (ts) => ((ts - t0) / total) * W;
+
+    let svg = "";
+    for (let i = 0; i < n; i++) {
+      const b = buckets[i];
+      const x = i * barW;
+      const w = Math.max(barW - 0.4, 0.6);
+      const desc = !b.has_data
+        ? `${fmtTime(b.ts_start)} — no data`
+        : (b.presence_frac > 0
+            ? `${fmtTime(b.ts_start)} — ${Math.round(b.presence_frac * 100)}% occupied`
+            : `${fmtTime(b.ts_start)} — empty`);
+      svg += `<rect x="${x.toFixed(2)}" y="0" width="${w.toFixed(2)}" height="${H}" fill="${bucketColor(b)}"><title>${desc}</title></rect>`;
+    }
+    for (const ch of hist.changes) {
+      const x = tToX(ch.ts).toFixed(2);
+      const color = ch.presence ? "#4ade80" : "#94a3b8";
+      const label = `${fmtTime(ch.ts)} — ${ch.presence ? "became present" : "became absent"}`;
+      svg += `<line x1="${x}" y1="0" x2="${x}" y2="${H}" stroke="${color}" stroke-width="1.5"><title>${label}</title></line>`;
+    }
+    refs.chart.innerHTML = svg;
+
+    // Axis labels every ~3h (18 buckets at 10-min resolution).
+    const step = Math.max(1, Math.round(n / 8));
+    const axisLabels = [];
+    for (let i = 0; i < n; i += step) {
+      axisLabels.push(`<span>${fmtTime(buckets[i].ts_start)}</span>`);
+    }
+    axisLabels.push(`<span>now</span>`);
+    refs.chartAxis.innerHTML = axisLabels.join("");
   }
 
   function renderVitals(refs, d) {
@@ -297,8 +413,22 @@
     }
   }
 
+  async function pollHistory() {
+    for (const [nodeId, refs] of cardEls) {
+      try {
+        const hist = await fetchHistory(nodeId);
+        renderHistory(refs, hist);
+      } catch (e) {
+        // Leave the last-rendered chart in place; vitals polling already
+        // surfaces connectivity errors via the status badge.
+      }
+    }
+  }
+
   poll();
   setInterval(poll, POLL_MS);
+  pollHistory();
+  setInterval(pollHistory, HISTORY_POLL_MS);
 </script>
 </body>
 </html>

--- a/ui/live-status.html
+++ b/ui/live-status.html
@@ -5,6 +5,7 @@
 <title>RuView — Live Status</title>
 <style>
   :root { color-scheme: dark light; }
+  * { box-sizing: border-box; }
   body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     background: #0f1115;
@@ -16,112 +17,172 @@
     align-items: center;
     gap: 1.5rem;
   }
+  header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
   h1 { margin: 0; font-size: 1.4rem; font-weight: 600; }
   #status-badge {
-    font-size: 0.85rem;
+    font-size: 0.8rem;
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
     font-weight: 600;
   }
   .badge-ok { background: #103b23; color: #4ade80; }
   .badge-stale { background: #3b1010; color: #f87171; }
-  .grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 1rem;
-    width: 100%;
-    max-width: 900px;
-  }
-  .card {
-    background: #1a1d24;
-    border: 1px solid #2a2e37;
-    border-radius: 12px;
-    padding: 1.25rem;
-    text-align: center;
-  }
-  .card .label {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: #9aa0aa;
-    margin-bottom: 0.5rem;
-  }
-  .card .value {
-    font-size: 2rem;
-    font-weight: 700;
-  }
-  .card .unit {
-    font-size: 0.9rem;
-    color: #9aa0aa;
-    margin-left: 0.25rem;
-  }
-  .presence-on { color: #4ade80; }
-  .presence-off { color: #6b7280; }
-  #last-updated {
-    font-size: 0.8rem;
-    color: #6b7280;
-  }
   #error-banner {
     display: none;
     background: #3b1010;
     color: #f87171;
     padding: 0.75rem 1.25rem;
     border-radius: 8px;
-    max-width: 900px;
+    max-width: 960px;
     width: 100%;
-    box-sizing: border-box;
     font-size: 0.9rem;
+  }
+  #nodes {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.25rem;
+    width: 100%;
+    max-width: 960px;
+  }
+  .node-card {
+    background: #161920;
+    border: 1px solid #262b35;
+    border-radius: 16px;
+    padding: 1.25rem 1.25rem 1.5rem;
+  }
+  .node-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+    gap: 0.5rem;
+  }
+  .node-title {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+  .floor-label {
+    font-size: 1.05rem;
+    font-weight: 700;
+    background: transparent;
+    border: none;
+    color: #e8eaed;
+    border-bottom: 1px dashed transparent;
+    padding: 0 0.15rem;
+    min-width: 4ch;
+    max-width: 16ch;
+  }
+  .floor-label:hover, .floor-label:focus {
+    border-bottom-color: #4b5563;
+    outline: none;
+  }
+  .node-id {
+    font-size: 0.7rem;
+    color: #6b7280;
+    white-space: nowrap;
+  }
+  .node-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 999px;
+    flex-shrink: 0;
+  }
+  .dot-online { background: #4ade80; box-shadow: 0 0 6px #4ade8090; }
+  .dot-stale { background: #f87171; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.75rem;
+  }
+  .card {
+    background: #1a1d24;
+    border: 1px solid #2a2e37;
+    border-radius: 12px;
+    padding: 0.9rem 0.6rem;
+    text-align: center;
+  }
+  .card .label {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #9aa0aa;
+    margin-bottom: 0.35rem;
+  }
+  .card .value {
+    font-size: 1.5rem;
+    font-weight: 700;
+  }
+  .card .unit {
+    font-size: 0.75rem;
+    color: #9aa0aa;
+    margin-left: 0.2rem;
+  }
+  .presence-on { color: #4ade80; }
+  .presence-off { color: #6b7280; }
+  .node-footer {
+    margin-top: 0.75rem;
+    font-size: 0.7rem;
+    color: #6b7280;
+    text-align: right;
+  }
+  #empty-state {
+    color: #6b7280;
+    font-size: 0.9rem;
+    text-align: center;
+    max-width: 500px;
   }
 </style>
 </head>
 <body>
-  <h1>RuView — Live Sensing Status</h1>
-  <span id="status-badge" class="badge-stale">connecting…</span>
+  <header>
+    <h1>RuView — Live Sensing Status</h1>
+    <span id="status-badge" class="badge-stale">connecting…</span>
+  </header>
 
   <div id="error-banner"></div>
 
-  <div class="grid">
-    <div class="card">
-      <div class="label">Presence</div>
-      <div class="value" id="v-presence">—</div>
-    </div>
-    <div class="card">
-      <div class="label">People Detected</div>
-      <div class="value" id="v-persons">—</div>
-    </div>
-    <div class="card">
-      <div class="label">Motion</div>
-      <div class="value" id="v-motion">—</div>
-    </div>
-    <div class="card">
-      <div class="label">Breathing Rate</div>
-      <div class="value" id="v-breathing">—<span class="unit">bpm</span></div>
-    </div>
-    <div class="card">
-      <div class="label">Heart Rate</div>
-      <div class="value" id="v-heart">—<span class="unit">bpm</span></div>
-    </div>
-    <div class="card">
-      <div class="label">Confidence</div>
-      <div class="value" id="v-confidence">—</div>
-    </div>
+  <div id="nodes"></div>
+  <div id="empty-state" style="display:none;">
+    No nodes registered at <code id="api-base-echo"></code>/api/v1/edge/registry —
+    is c6-presence-watcher.py running for at least one device?
   </div>
 
-  <div id="last-updated">waiting for first update…</div>
-
 <script>
-  const API_URL = "http://localhost:3000/api/v1/sensing/latest";
+  const API_BASE = "http://localhost:3000";
   const POLL_MS = 1000;
+  const STALE_S = 10;
+  const LABEL_KEY = "ruview-floor-labels";
 
   const badge = document.getElementById("status-badge");
   const errBanner = document.getElementById("error-banner");
-  const lastUpdated = document.getElementById("last-updated");
+  const nodesEl = document.getElementById("nodes");
+  const emptyState = document.getElementById("empty-state");
+  document.getElementById("api-base-echo").textContent = API_BASE;
+
+  const cardEls = new Map(); // node_id -> element refs
+
+  function loadLabels() {
+    try { return JSON.parse(localStorage.getItem(LABEL_KEY)) || {}; }
+    catch { return {}; }
+  }
+  function saveLabel(nodeId, label) {
+    const labels = loadLabels();
+    labels[nodeId] = label;
+    localStorage.setItem(LABEL_KEY, JSON.stringify(labels));
+  }
 
   function setBadge(ok, text) {
     badge.textContent = text;
     badge.className = ok ? "badge-ok" : "badge-stale";
   }
-
   function showError(msg) {
     errBanner.style.display = "block";
     errBanner.textContent = msg;
@@ -130,31 +191,109 @@
     errBanner.style.display = "none";
   }
 
+  function buildCard(nodeId) {
+    const labels = loadLabels();
+    const defaultLabel = labels[nodeId] || ("Node " + nodeId);
+
+    const card = document.createElement("div");
+    card.className = "node-card";
+    card.innerHTML = `
+      <div class="node-header">
+        <div class="node-title">
+          <span class="node-dot dot-stale" data-el="dot"></span>
+          <input class="floor-label" data-el="label" value="${defaultLabel.replace(/"/g, "&quot;")}" spellcheck="false">
+        </div>
+        <span class="node-id">node ${nodeId}</span>
+      </div>
+      <div class="grid">
+        <div class="card"><div class="label">Presence</div><div class="value" data-el="presence">—</div></div>
+        <div class="card"><div class="label">People</div><div class="value" data-el="persons">—</div></div>
+        <div class="card"><div class="label">Motion</div><div class="value" data-el="motion">—</div></div>
+        <div class="card"><div class="label">Breathing</div><div class="value" data-el="breathing">—<span class="unit">bpm</span></div></div>
+        <div class="card"><div class="label">Heart Rate</div><div class="value" data-el="heart">—<span class="unit">bpm</span></div></div>
+        <div class="card"><div class="label">Confidence</div><div class="value" data-el="confidence">—</div></div>
+      </div>
+      <div class="node-footer" data-el="footer">waiting for data…</div>
+    `;
+    nodesEl.appendChild(card);
+
+    const refs = {
+      root: card,
+      dot: card.querySelector('[data-el="dot"]'),
+      label: card.querySelector('[data-el="label"]'),
+      presence: card.querySelector('[data-el="presence"]'),
+      persons: card.querySelector('[data-el="persons"]'),
+      motion: card.querySelector('[data-el="motion"]'),
+      breathing: card.querySelector('[data-el="breathing"]'),
+      heart: card.querySelector('[data-el="heart"]'),
+      confidence: card.querySelector('[data-el="confidence"]'),
+      footer: card.querySelector('[data-el="footer"]'),
+    };
+    refs.label.addEventListener("change", () => saveLabel(nodeId, refs.label.value.trim() || ("Node " + nodeId)));
+    cardEls.set(nodeId, refs);
+    return refs;
+  }
+
+  function removeStaleCards(currentIds) {
+    for (const [nodeId, refs] of cardEls) {
+      if (!currentIds.has(nodeId)) {
+        refs.root.remove();
+        cardEls.delete(nodeId);
+      }
+    }
+  }
+
+  async function fetchVitals(nodeId) {
+    const res = await fetch(`${API_BASE}/api/v1/vitals/${encodeURIComponent(nodeId)}/latest`, { cache: "no-store" });
+    if (res.status === 503) return null;
+    if (!res.ok) throw new Error(`HTTP ${res.status} for node ${nodeId}`);
+    return res.json();
+  }
+
+  function renderVitals(refs, d) {
+    if (!d) {
+      refs.dot.className = "node-dot dot-stale";
+      refs.footer.textContent = "stale — no recent data";
+      return;
+    }
+    refs.dot.className = "node-dot dot-online";
+    refs.presence.textContent = d.presence ? "YES" : "NO";
+    refs.presence.className = "value " + (d.presence ? "presence-on" : "presence-off");
+    refs.persons.textContent = d.n_persons ?? "—";
+    refs.motion.textContent = (d.motion !== undefined) ? (d.motion >= 0.5 ? "YES" : "no") : "—";
+    refs.breathing.innerHTML = (d.breathing_rate_bpm != null ? d.breathing_rate_bpm.toFixed(1) : "—") + '<span class="unit">bpm</span>';
+    refs.heart.innerHTML = (d.heartrate_bpm != null ? d.heartrate_bpm.toFixed(1) : "—") + '<span class="unit">bpm</span>';
+    refs.confidence.textContent = (d.confidence !== undefined) ? (d.confidence * 100).toFixed(0) + "%" : "—";
+    refs.footer.textContent = "updated " + new Date().toLocaleTimeString();
+  }
+
   async function poll() {
     try {
-      const res = await fetch(API_URL, { cache: "no-store" });
-      if (res.status === 503) {
-        setBadge(false, "stale — no recent data");
-        clearError();
-        return;
-      }
+      const res = await fetch(`${API_BASE}/api/v1/edge/registry`, { cache: "no-store" });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const d = await res.json();
+      const { nodes } = await res.json();
 
-      document.getElementById("v-presence").textContent = d.presence ? "YES" : "NO";
-      document.getElementById("v-presence").className = "value " + (d.presence ? "presence-on" : "presence-off");
-      document.getElementById("v-persons").textContent = d.n_persons ?? "—";
-      document.getElementById("v-motion").textContent = (d.motion !== undefined) ? (d.motion >= 0.5 ? "YES" : "no") : "—";
-      document.getElementById("v-breathing").innerHTML = (d.breathing_rate_bpm !== undefined ? d.breathing_rate_bpm.toFixed(1) : "—") + '<span class="unit">bpm</span>';
-      document.getElementById("v-heart").innerHTML = (d.heartrate_bpm !== undefined ? d.heartrate_bpm.toFixed(1) : "—") + '<span class="unit">bpm</span>';
-      document.getElementById("v-confidence").textContent = (d.confidence !== undefined) ? (d.confidence * 100).toFixed(0) + "%" : "—";
+      emptyState.style.display = nodes.length === 0 ? "block" : "none";
 
-      setBadge(true, "live");
+      const currentIds = new Set(nodes.map(n => n.node_id));
+      removeStaleCards(currentIds);
+
+      for (const n of nodes) {
+        const refs = cardEls.get(n.node_id) || buildCard(n.node_id);
+        try {
+          const vitals = await fetchVitals(n.node_id);
+          renderVitals(refs, vitals);
+        } catch (e) {
+          refs.dot.className = "node-dot dot-stale";
+          refs.footer.textContent = "error: " + e.message;
+        }
+      }
+
+      setBadge(true, nodes.length + " node" + (nodes.length === 1 ? "" : "s") + " online");
       clearError();
-      lastUpdated.textContent = "last update: " + new Date().toLocaleTimeString();
     } catch (e) {
       setBadge(false, "disconnected");
-      showError("Can't reach sensing server at " + API_URL + " — is ruview-sensing-server.py running? (" + e.message + ")");
+      showError("Can't reach sensing server at " + API_BASE + " — is ruview-sensing-server.py running? (" + e.message + ")");
     }
   }
 

--- a/ui/live-status.html
+++ b/ui/live-status.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>RuView — Live Status</title>
+<style>
+  :root { color-scheme: dark light; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #0f1115;
+    color: #e8eaed;
+    margin: 0;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+  }
+  h1 { margin: 0; font-size: 1.4rem; font-weight: 600; }
+  #status-badge {
+    font-size: 0.85rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-weight: 600;
+  }
+  .badge-ok { background: #103b23; color: #4ade80; }
+  .badge-stale { background: #3b1010; color: #f87171; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    width: 100%;
+    max-width: 900px;
+  }
+  .card {
+    background: #1a1d24;
+    border: 1px solid #2a2e37;
+    border-radius: 12px;
+    padding: 1.25rem;
+    text-align: center;
+  }
+  .card .label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #9aa0aa;
+    margin-bottom: 0.5rem;
+  }
+  .card .value {
+    font-size: 2rem;
+    font-weight: 700;
+  }
+  .card .unit {
+    font-size: 0.9rem;
+    color: #9aa0aa;
+    margin-left: 0.25rem;
+  }
+  .presence-on { color: #4ade80; }
+  .presence-off { color: #6b7280; }
+  #last-updated {
+    font-size: 0.8rem;
+    color: #6b7280;
+  }
+  #error-banner {
+    display: none;
+    background: #3b1010;
+    color: #f87171;
+    padding: 0.75rem 1.25rem;
+    border-radius: 8px;
+    max-width: 900px;
+    width: 100%;
+    box-sizing: border-box;
+    font-size: 0.9rem;
+  }
+</style>
+</head>
+<body>
+  <h1>RuView — Live Sensing Status</h1>
+  <span id="status-badge" class="badge-stale">connecting…</span>
+
+  <div id="error-banner"></div>
+
+  <div class="grid">
+    <div class="card">
+      <div class="label">Presence</div>
+      <div class="value" id="v-presence">—</div>
+    </div>
+    <div class="card">
+      <div class="label">People Detected</div>
+      <div class="value" id="v-persons">—</div>
+    </div>
+    <div class="card">
+      <div class="label">Motion</div>
+      <div class="value" id="v-motion">—</div>
+    </div>
+    <div class="card">
+      <div class="label">Breathing Rate</div>
+      <div class="value" id="v-breathing">—<span class="unit">bpm</span></div>
+    </div>
+    <div class="card">
+      <div class="label">Heart Rate</div>
+      <div class="value" id="v-heart">—<span class="unit">bpm</span></div>
+    </div>
+    <div class="card">
+      <div class="label">Confidence</div>
+      <div class="value" id="v-confidence">—</div>
+    </div>
+  </div>
+
+  <div id="last-updated">waiting for first update…</div>
+
+<script>
+  const API_URL = "http://localhost:3000/api/v1/sensing/latest";
+  const POLL_MS = 1000;
+
+  const badge = document.getElementById("status-badge");
+  const errBanner = document.getElementById("error-banner");
+  const lastUpdated = document.getElementById("last-updated");
+
+  function setBadge(ok, text) {
+    badge.textContent = text;
+    badge.className = ok ? "badge-ok" : "badge-stale";
+  }
+
+  function showError(msg) {
+    errBanner.style.display = "block";
+    errBanner.textContent = msg;
+  }
+  function clearError() {
+    errBanner.style.display = "none";
+  }
+
+  async function poll() {
+    try {
+      const res = await fetch(API_URL, { cache: "no-store" });
+      if (res.status === 503) {
+        setBadge(false, "stale — no recent data");
+        clearError();
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const d = await res.json();
+
+      document.getElementById("v-presence").textContent = d.presence ? "YES" : "NO";
+      document.getElementById("v-presence").className = "value " + (d.presence ? "presence-on" : "presence-off");
+      document.getElementById("v-persons").textContent = d.n_persons ?? "—";
+      document.getElementById("v-motion").textContent = (d.motion !== undefined) ? (d.motion >= 0.5 ? "YES" : "no") : "—";
+      document.getElementById("v-breathing").innerHTML = (d.breathing_rate_bpm !== undefined ? d.breathing_rate_bpm.toFixed(1) : "—") + '<span class="unit">bpm</span>';
+      document.getElementById("v-heart").innerHTML = (d.heartrate_bpm !== undefined ? d.heartrate_bpm.toFixed(1) : "—") + '<span class="unit">bpm</span>';
+      document.getElementById("v-confidence").textContent = (d.confidence !== undefined) ? (d.confidence * 100).toFixed(0) + "%" : "—";
+
+      setBadge(true, "live");
+      clearError();
+      lastUpdated.textContent = "last update: " + new Date().toLocaleTimeString();
+    } catch (e) {
+      setBadge(false, "disconnected");
+      showError("Can't reach sensing server at " + API_URL + " — is ruview-sensing-server.py running? (" + e.message + ")");
+    }
+  }
+
+  poll();
+  setInterval(poll, POLL_MS);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `presence_score` and `motion_score` in `collect_observation()` (`firmware/esp32-csi-node/main/adaptive_controller.c`) are both derived from the same raw, unbounded CSI phase-variance quantity (`edge_processing.c` sets `s_presence_score = s_motion_energy` directly), but were normalized inconsistently: `presence_score` passed through with no clamp at all, while `motion_score` was clamped straight to `[0,1]` without first scaling — since raw values routinely exceed 1.0, this saturated `motion_score` at `1.0` almost unconditionally.
- Net effect: presence/motion read as "detected" essentially regardless of actual occupancy, since downstream thresholds (this file's own `0.5f` quality-valid gate, and consumers like `scripts/c6-presence-watcher.py`'s `0.40/0.20` and `0.30/0.15` hysteresis thresholds) all assume a genuine `0..1` scale.
- The correct normalization already exists elsewhere in the codebase, in `edge_processing.c`'s `send_feature_vector()` (a separate ADR-069 feature-vector wire path): `p > 10.0f ? 1.0f : p / 10.0f`. This PR applies the same scale-then-clamp to both fields in `collect_observation()`.

## Test plan

- [x] Rebuilt firmware for ESP32-C6 (`idf.py build`), no errors.
- [x] Reflashed onto a physical ESP32-C6 CSI node via USB.
- [x] Verified via raw serial log that `motion` and `presence` now report identical, fluctuating values (e.g. `motion=0.18 presence=0.18`, `motion=1.00 presence=1.00`) instead of `motion` being pinned at `1.00`.
- [x] Verified via host-side watcher (`c6-presence-watcher.py`) that `avg_motion`/`avg_presence` now match in every window and vary meaningfully (0.5–1.0 while near the device).
- [x] Verified real empty-room behavior: left the room, `avg_presence` dropped to `0.00` and `motion`/`occupancy` both went to `False`, holding steady for 2.5+ minutes — confirming the original false-positive ("presence detected" in an empty room) is resolved.
- [x] Existing host unit tests (`tests/host/test_adaptive_controller.c`) don't exercise `collect_observation()`'s normalization path directly (they set `presence_score` on the observation struct directly), so this change doesn't touch tested behavior — no regressions expected there, but flagging that this code path had no direct unit coverage before or after this change.