### PR TITLE
fix(firmware): accept WPA/WPA2-mixed routers; warn about compact-board thermal risk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,8 @@ All 5 ruvector crates integrated in workspace:
 
 **Not supported:** ESP32 (original), ESP32-C3 — single-core, can't run CSI DSP pipeline.
 
+**⚠️ Compact boards (SuperMini, ESP32-S3-Zero, other coin-sized clones) run hot:** the firmware keeps the WiFi radio on continuously (`WIFI_PS_NONE`) and runs a full DSP pipeline (`edge_tier=2`), which is sustained high current draw. Full-size dev boards handle this fine; coin-sized clones with minimal PCB copper and budget regulators can run uncomfortably hot and, per at least one field report, have failed to power on again after a hot session. Give them airflow and check by touch during the first few minutes. See `firmware/esp32-csi-node/README.md` for details.
+
 ### Build & Test Commands (this repo)
 ```bash
 # Rust — full workspace tests (1,031+ tests, ~2 min)

--- a/firmware/esp32-csi-node/README.md
+++ b/firmware/esp32-csi-node/README.md
@@ -105,6 +105,8 @@ curl http://<ESP32_IP>:8032/wasm/list
 
 > **Tip:** A single node provides presence and vital signs along its line of sight. Multiple nodes (3-6) create a multistatic mesh that resolves 3D pose with <30 mm jitter and zero identity swaps.
 
+> **⚠️ Thermal warning — compact boards (ESP32-S3-Zero, SuperMini, other coin-sized clones):** This firmware runs the WiFi radio with modem sleep disabled (`WIFI_PS_NONE`, required for continuous CSI capture) plus a full edge-processing DSP pipeline on Core 1 (`edge_tier=2`) plus, on ADR-183 builds, a continuous 40 Hz onboard LED driver. That's sustained high current draw with no duty-cycling. Full-size dev boards (DevKitC-1, XIAO) have more copper pour and thermal mass around the regulator and tolerate this fine. Coin-sized clones with minimal PCB area and budget regulators may run hot to the touch during normal operation, and in at least one field report, boards that ran hot during a session failed to power on afterward (regulator damage suspected — see issue tracker). Give these boards airflow, don't stack or enclose them, and check them by touch during the first several minutes of a new deployment. If a board is uncomfortably hot (not just warm), power it down and let it cool before continuing.
+
 ---
 
 ## Firmware Architecture

--- a/firmware/esp32-csi-node/main/main.c
+++ b/firmware/esp32-csi-node/main/main.c
@@ -67,6 +67,8 @@ static void event_handler(void *arg, esp_event_base_t event_base,
     if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
         esp_wifi_connect();
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        wifi_event_sta_disconnected_t *disc = (wifi_event_sta_disconnected_t *)event_data;
+        ESP_LOGW(TAG, "WiFi disconnected, reason=%d rssi=%d", disc->reason, disc->rssi);
         if (s_retry_num < MAX_RETRY) {
             esp_wifi_connect();
             s_retry_num++;
@@ -102,7 +104,10 @@ static void wifi_init_sta(void)
 
     wifi_config_t wifi_config = {
         .sta = {
-            .threshold.authmode = WIFI_AUTH_WPA2_PSK,
+            /* WPA_PSK (not WPA2_PSK) so routers running WPA/WPA2-mixed
+             * compatibility mode aren't rejected with
+             * WIFI_REASON_NO_AP_FOUND_IN_AUTHMODE_THRESHOLD (#1050). */
+            .threshold.authmode = WIFI_AUTH_WPA_PSK,
         },
     };
 

--- a/plugins/ruview/skills/ruview-hardware-setup/SKILL.md
+++ b/plugins/ruview/skills/ruview-hardware-setup/SKILL.md
@@ -18,6 +18,8 @@ Bring a RuView sensing node online: build firmware → flash → provision WiFi 
 
 **Not supported:** original ESP32, ESP32-C3 (single-core).
 
+**⚠️ Ask about board form factor before flashing.** If the user's board is a coin-sized clone (ESP32-S3-Zero, SuperMini, or similar — not a full DevKitC/XIAO-style board with a real USB connector and visible regulator), warn them before they walk away from it: this firmware runs the WiFi radio continuously (`WIFI_PS_NONE`) plus a full DSP pipeline (`edge_tier=2`), which is sustained high current draw that full-size dev boards handle fine but tiny clones with minimal copper/budget regulators may not. At least one field report: boards ran hot during a normal session and failed to power on again afterward (regulator damage suspected). Tell them to give the board airflow (don't stack/enclose it) and check it by touch during the first several minutes of any new deployment.
+
 ## 1. Build firmware (Windows — Python subprocess, NOT bash directly)
 
 ESP-IDF v5.4 does not support MSYS2/Git Bash. Use the Espressif Python venv as a subprocess with `MSYSTEM*` env vars stripped. The proven command lives in `CLAUDE.local.md` — reproduce it:


### PR DESCRIPTION
## Summary

- Lower the ESP32 STA auth threshold from `WIFI_AUTH_WPA2_PSK` to `WIFI_AUTH_WPA_PSK` so routers running WPA/WPA2-mixed compatibility mode (common default on many consumer routers) aren't rejected with `WIFI_REASON_NO_AP_FOUND_IN_AUTHMODE_THRESHOLD` (reason=211). Also log the disconnect reason + RSSI instead of retrying blind, so this is diagnosable from serial output next time.
- Add a thermal-risk warning for compact/coin-sized ESP32-S3 clones (ESP32-S3-Zero, SuperMini) to `firmware/esp32-csi-node/README.md`, the repo's `CLAUDE.md` hardware table, and the `ruview-hardware-setup` skill (so an AI agent flashing on someone's behalf asks about board form factor and warns proactively).

## Why

Hit both issues live while onboarding a fresh 3-node deployment:

1. WiFi wouldn't connect at all — serial log showed silent retries with no reason code. Added the reason/rssi log, found `reason=211`, traced it to the router's WPA/WPA2-mixed mode being rejected by the strict `WPA2_PSK` threshold.
2. After a normal ~20-30 min CSI session, three ESP32-S3-Zero (compact/coin-sized clone) boards ran warm to the touch throughout (not flagged as unusual at the time), and failed to power on again afterward — heating up immediately even from a known-good USB power source on the next attempt, consistent with permanent regulator damage rather than a transient fault. This firmware runs the WiFi radio with modem sleep disabled (`WIFI_PS_NONE`) plus a full edge DSP pipeline (`edge_tier=2`) continuously, with no duty-cycling. Full-size dev boards (DevKitC-1, XIAO) have the copper pour/thermal mass to handle that; coin-sized clones with minimal PCB copper and budget regulators may not. Nothing in the docs warned about this before someone (or their AI agent) walks away from a board assuming any ESP32-S3 handles sustained full-load operation.

Full incident writeup + follow-up ideas (duty-cycled mode for compact boards, runtime thermal check) in #1289.

## Test plan

- [x] Rebuilt firmware (4MB variant) with the WPA_PSK threshold change via `espressif/idf:v5.4` Docker build
- [x] Reflashed an ESP32-S3-Zero, confirmed it connects to a WPA/WPA2-mixed-mode router and streams CSI to a `wifi-densepose-sensing-server` over UDP
- [x] Confirmed the disconnect-reason log correctly surfaced `reason=211` before the fix, and connects cleanly after
- [ ] Maintainers: re-run `cargo test --workspace --no-default-features` / firmware CI as this only touches `main.c` + docs

Docs portion addresses #1289 — thermal follow-up items in that issue remain open.

Co-Authored-By: claude-flow <ruv@ruv.net>