### PR TITLE
fix: HeartRateExtractor.extract() PyO3 binding misnames Rust phases param as weights

### DIFF
--- a/python/bench/test_bench_vitals.py
+++ b/python/bench/test_bench_vitals.py
@@ -57,12 +57,12 @@ def test_heart_rate_extract_per_frame_cost(benchmark) -> None:
     hr = HeartRateExtractor.esp32_default()
     rng = Random(43)
     for i in range(1500):
-        residuals, weights = _synth_frame(56, 100.0, i / 100.0, 1.2, rng)
-        hr.extract(residuals=residuals, weights=weights)
+        residuals, phases = _synth_frame(56, 100.0, i / 100.0, 1.2, rng)
+        hr.extract(residuals=residuals, phases=phases)
 
     def _one_frame():
-        residuals, weights = _synth_frame(56, 100.0, 16.0, 1.2, rng)
-        return hr.extract(residuals=residuals, weights=weights)
+        residuals, phases = _synth_frame(56, 100.0, 16.0, 1.2, rng)
+        return hr.extract(residuals=residuals, phases=phases)
 
     benchmark(_one_frame)
 

--- a/python/src/bindings/vitals.rs
+++ b/python/src/bindings/vitals.rs
@@ -242,7 +242,22 @@ impl PyBreathingExtractor {
 // ─── HeartRateExtractor ──────────────────────────────────────────────
 
 /// Extracts heart rate (40–120 BPM) from per-subcarrier amplitude
-/// residuals via 0.8–2.0 Hz bandpass + autocorrelation peak detection.
+/// residuals and per-subcarrier unwrapped phases (radians) via
+/// 0.8–2.0 Hz bandpass + autocorrelation peak detection.
+///
+/// Python:
+/// ```python
+/// from wifi_densepose import HeartRateExtractor
+///
+/// hr = HeartRateExtractor.esp32_default()  # 56 subcarriers, 100 Hz, 15s window
+///
+/// # Feed residuals and matching unwrapped phases from your preprocessor.
+/// # Unlike BreathingExtractor weights, phases=[] is invalid for heart-rate
+/// # extraction because the Rust core requires phase data for each subcarrier.
+/// est = hr.extract(residuals=[0.01, -0.02, …], phases=[0.0, 0.01, …])
+/// if est is not None:
+///     print(est.value_bpm, est.confidence)
+/// ```
 #[pyclass(name = "HeartRateExtractor")]
 pub struct PyHeartRateExtractor {
     inner: HeartRateExtractor,
@@ -265,10 +280,17 @@ impl PyHeartRateExtractor {
         Self { inner: HeartRateExtractor::esp32_default() }
     }
 
-    /// Extract heart rate from per-subcarrier residuals. GIL released
-    /// during DSP.
-    fn extract(&mut self, py: Python<'_>, residuals: Vec<f64>, weights: Vec<f64>) -> Option<PyVitalEstimate> {
-        let est = py.allow_threads(|| self.inner.extract(&residuals, &weights));
+    /// Extract heart rate from per-subcarrier residuals and matching
+    /// per-subcarrier unwrapped phases (radians). Empty phases are invalid
+    /// and return `None` because the Rust extractor requires phase data.
+    /// GIL released during DSP.
+    fn extract(
+        &mut self,
+        py: Python<'_>,
+        residuals: Vec<f64>,
+        phases: Vec<f64>,
+    ) -> Option<PyVitalEstimate> {
+        let est = py.allow_threads(|| self.inner.extract(&residuals, &phases));
         est.map(PyVitalEstimate::from_rust)
     }
 

--- a/python/tests/test_vitals.py
+++ b/python/tests/test_vitals.py
@@ -185,8 +185,42 @@ def test_heart_rate_explicit_ctor() -> None:
 
 def test_heart_rate_extract_returns_none_with_too_few_samples() -> None:
     hr = HeartRateExtractor.esp32_default()
-    out = hr.extract(residuals=[0.0] * 56, weights=[])
+    out = hr.extract(residuals=[0.0] * 56, phases=[0.0] * 56)
     assert out is None
+
+
+def test_heart_rate_extract_rejects_old_weights_keyword() -> None:
+    hr = HeartRateExtractor.esp32_default()
+    with pytest.raises(TypeError):
+        hr.extract(residuals=[0.0] * 56, weights=[0.0] * 56)
+
+
+def test_heart_rate_extract_with_synthetic_signal_and_phases() -> None:
+    """Drive the extractor with a synthetic 1.2 Hz sine (72 BPM) plus
+    same-length phase data. This proves the binding feeds Rust's required
+    `phases` slice instead of an empty vector that would keep returning None."""
+    hr = HeartRateExtractor.esp32_default()
+    sample_rate = 100.0
+    target_freq = 1.2  # 72 BPM
+    n_samples = int(60 * sample_rate)
+    phases = [i * 0.01 for i in range(56)]
+
+    produced_estimate = False
+    rng = Random(43)
+    for i in range(n_samples):
+        t = i / sample_rate
+        base = math.sin(2.0 * math.pi * target_freq * t)
+        residuals = [base + rng.gauss(0.0, 0.01) for _ in range(56)]
+        est = hr.extract(residuals=residuals, phases=phases)
+        if est is not None:
+            produced_estimate = True
+            assert math.isfinite(est.value_bpm)
+            assert 0.0 <= est.confidence <= 1.0
+            break
+
+    assert produced_estimate, (
+        "HeartRateExtractor never produced an estimate after 60s of synthetic data"
+    )
 
 
 # ─── Build feature flag ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`HeartRateExtractor.extract()` now takes a `phases` argument that matches the Rust core, so the documented call path returns real estimates instead of always returning `None`.

## Why this matters

Issue #1225 reports that `hr.extract(residuals=..., weights=[])` always returns `None`. The PyO3 binding named the second parameter `weights`, but the Rust core requires per-subcarrier unwrapped phases:

```rust
// v2/crates/wifi-densepose-vitals/src/heartrate.rs:100
pub fn extract(&mut self, residuals: &[f64], phases: &[f64]) -> Option<VitalEstimate> {
    let n = residuals.len().min(self.n_subcarriers).min(phases.len());
```

Because the sample count is clamped by `phases.len()`, passing the documented `weights=[]` sets `n = 0` and the extractor returns `None` for every frame. `HeartRateExtractor` is not `BreathingExtractor`: it needs phase data, so an empty second argument is never valid.

## Changes

- Rename the binding parameter `weights` -> `phases` and pass it straight through to the core, so the Python API name reflects what the DSP actually consumes.
- Update the docstring with a runnable example and a note that `phases=[]` is invalid for heart-rate extraction.
- Update the two keyword call sites in the test and benchmark suites.

## Testing

Added `test_heart_rate_extract_with_synthetic_signal_and_phases` (drives a synthetic 1.2 Hz / 72 BPM signal with matching phase data and asserts a finite BPM and a confidence in `[0, 1]`) and `test_heart_rate_extract_rejects_old_weights_keyword` (asserts the removed `weights=` keyword now raises `TypeError`). The parameter rename matches the core signature at `heartrate.rs:100`.

Fixes #1225
