### PR TITLE
fix(ci): restore workflow and LAN smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,6 @@ jobs:
       # ADR-262 P1: `wifi-densepose-rufield` path-deps the `vendor/rufield`
       # submodule. Without a recursive checkout the workspace build fails to
       # resolve those path deps in CI even though it passes locally.
-      with:
-        submodules: recursive
 
     # `wifi-densepose-desktop` is a Tauri v2 app — `glib-sys`, `gtk-sys`,
     # `webkit2gtk-sys`, etc. need the Linux dev libraries via pkg-config or the
@@ -146,7 +144,10 @@ jobs:
       env:
         CARGO_PROFILE_DEV_DEBUG: "0"
         CARGO_PROFILE_TEST_DEBUG: "0"
-      run: cargo test -p wifi-densepose-worldmodel --no-default-features
+      run: >-
+        cargo test
+        --manifest-path crates/worldgraph/wifi-densepose-worldmodel/Cargo.toml
+        --no-default-features
 
     # ADR-134 CIR tests are behind the `cir` feature so the bench dependency
     # (Criterion) only pulls when actually exercised. Run them as a separate
@@ -249,7 +250,7 @@ jobs:
       continue-on-error: true
       uses: codecov/codecov-action@v6
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
 

--- a/.github/workflows/sensing-server-docker.yml
+++ b/.github/workflows/sensing-server-docker.yml
@@ -115,7 +115,7 @@ jobs:
       #      RUN guard catches missing ones at build time, this re-checks the
       #      pushed artifact post-hoc as belt-and-braces).
       #   2. /health is up.
-      #   3. /api/v1/info returns 200 with no auth (LAN-mode default).
+      #   3. /api/v1/info returns 200 with the explicit trusted-LAN opt-in.
       #   4. With RUVIEW_API_TOKEN set, /api/v1/info returns 401 without a
       #      Bearer header, 200 with the correct one (the #443 auth middleware).
       # ---------------------------------------------------------------------
@@ -128,7 +128,10 @@ jobs:
             'ls /app/ui/observatory.html /app/ui/pose-fusion.html /app/ui/index.html /app/ui/viz.html >/dev/null'
           docker run --rm "$IMAGE" sh -c 'ls -d /app/ui/observatory /app/ui/pose-fusion >/dev/null'
 
-          docker run -d --name sm -p 3000:3000 -e CSI_SOURCE=simulated "$IMAGE"
+          docker run -d --name sm -p 3000:3000 \
+            -e CSI_SOURCE=simulated \
+            -e RUVIEW_ALLOW_UNAUTHENTICATED=1 \
+            "$IMAGE"
           # Wait up to 30 s for /health.
           for _ in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:3000/health >/dev/null 2>&1; then break; fi


### PR DESCRIPTION
## Root cause

Two repository-level CI defects remained after the ADR-270 release:

1. `.github/workflows/ci.yml` was rejected before job creation because the Rust checkout step declared `with:` twice. Its Codecov v6 step also used the obsolete singular `file` input.
2. The sensing-server image built and pushed, but its LAN smoke test launched the hardened entrypoint on `0.0.0.0` without a token or the explicit trusted-LAN opt-in, so it exited 64 before HTTP checks.

These failures predate ADR-270 and reproduce on the prior Qualcomm/MediaTek commits.

## Fix

- Keep one recursive-submodule checkout mapping.
- Use Codecov v6 `files`.
- Set `RUVIEW_ALLOW_UNAUTHENTICATED=1` only in the explicit LAN-mode smoke container. Production defaults remain fail-closed; the bearer-token smoke test remains separate.

## Validation

- `actionlint` passes for both modified workflows (ignoring only unrelated shellcheck style diagnostics).
- Replayed the previously failing published image locally with the exact new LAN environment: `/health` and `/api/v1/info` both returned HTTP 200.
- `git diff --check` passes.