### PR TITLE
fix(ci): bypass hardened entrypoint for image asset smoke test

### DIFF
--- a/.github/workflows/sensing-server-docker.yml
+++ b/.github/workflows/sensing-server-docker.yml
@@ -124,9 +124,9 @@ jobs:
           set -euo pipefail
           IMAGE="ghcr.io/ruvnet/wifi-densepose:sha-${GITHUB_SHA::7}"
           docker pull "$IMAGE"
-          docker run --rm "$IMAGE" sh -c \
+          docker run --rm --entrypoint sh "$IMAGE" -c \
             'ls /app/ui/observatory.html /app/ui/pose-fusion.html /app/ui/index.html /app/ui/viz.html >/dev/null'
-          docker run --rm "$IMAGE" sh -c 'ls -d /app/ui/observatory /app/ui/pose-fusion >/dev/null'
+          docker run --rm --entrypoint sh "$IMAGE" -c 'ls -d /app/ui/observatory /app/ui/pose-fusion >/dev/null'
 
           docker run -d --name sm -p 3000:3000 \
             -e CSI_SOURCE=simulated \


### PR DESCRIPTION
## Summary
- invoke the published image with an explicit shell entrypoint while inspecting static UI assets
- preserve the hardened production entrypoint for the LAN-mode and bearer-token runtime tests

## Root cause
The post-push asset checks passed sh -c as arguments to the image's hardened entrypoint. Because those inspection containers intentionally have no API token or LAN opt-in, the entrypoint correctly exited 64 before ls ran.

## Validation
- both corrected asset inspection commands pass locally against ghcr.io/ruvnet/wifi-densepose:sha-47dbdb2 (digest sha256:e522b6d9d3d25fd4e6aada3bc367dc74134b71dca14f23000d0045ff21226ef0)
- git diff --check passes

Follow-up to #1362 and failed publication validation run 29674475646.