### PR TITLE
Wire ADR-110 mesh-aligned timestamps into the fusion path (+ fix a sequence-delta sign bug it exposed)

### DIFF
--- a/v2/crates/wifi-densepose-hardware/src/sync_packet.rs
+++ b/v2/crates/wifi-densepose-hardware/src/sync_packet.rs
@@ -176,7 +176,23 @@ impl SyncPacket {
     /// |error| < 1/fps_hz ≈ 50 ms × the per-frame jitter ratio).
     pub fn mesh_aligned_us_for_sequence(&self, frame_seq: u32, fps_hz: f64) -> u64 {
         debug_assert!(fps_hz > 0.0, "fps_hz must be positive");
-        let dframes = (frame_seq.wrapping_sub(self.sequence)) as i64;
+        // RFC 1982 serial-number-arithmetic style delta: `wrapping_sub` keeps
+        // true u32 wraparound working (sequence near u32::MAX rolling over to
+        // a small frame_seq must read as a small *forward* delta — see
+        // `mesh_aligned_for_sequence_handles_seq_wraparound`), but the u32
+        // result must be reinterpreted as `i32` (sign-extend), not widened
+        // straight to `i64` (zero-extend). A plain `as i64` treats a
+        // `frame_seq` that is merely a few hundred *behind* `self.sequence`
+        // (the common case when the paired CSI frame lags the latest sync
+        // packet — sync packets go out on a priority send path, ordinary CSI
+        // frames don't and can be delayed/dropped under load) as a ~4.29
+        // billion-frame forward jump instead of a small negative one, which
+        // blew the estimated timestamp out by trillions of microseconds
+        // (observed live: `Timestamp spread 9_xxx_xxx_xxx_xxx us`, i.e.
+        // years). Going through `i32` gives the correct small-magnitude
+        // delta in both directions; only sequence deltas near ±2^31 frames
+        // (unreachable in practice) are ambiguous between the two readings.
+        let dframes = (frame_seq.wrapping_sub(self.sequence)) as i32 as i64;
         let dus = (dframes as f64 * 1_000_000.0 / fps_hz) as i64;
         let local_at = (self.local_us as i64).wrapping_add(dus) as u64;
         self.apply_to_local(local_at)
@@ -381,6 +397,28 @@ mod tests {
         // Next sequence after u32::MAX is 0 (wrap). Δframes = 1, not -2^32.
         let mesh = pkt.mesh_aligned_us_for_sequence(0, 20.0);
         assert_eq!(mesh, pkt.epoch_us + 50_000);  // 1 frame at 20 fps = 50 ms
+    }
+
+    /// Regression for a live bug: a `frame_seq` a small amount *behind*
+    /// `self.sequence` (sync packets are sent on a priority path and can
+    /// race ahead of the ordinary CSI frame the caller is pairing against)
+    /// must extrapolate a small step *backward* in time, not wrap around to
+    /// ~4.29 billion frames forward (~years of µs). Before the `as i32`
+    /// sign-extension fix, this produced `Timestamp spread` values in the
+    /// tens of trillions of µs in the live fusion pipeline.
+    #[test]
+    fn mesh_aligned_for_sequence_handles_small_backward_drift() {
+        let pkt = SyncPacket {
+            node_id: 9, proto_ver: 1,
+            flags: SyncPacketFlags { is_leader: false, is_valid: true, smoothed_used: true },
+            local_us: 28_798_450, epoch_us: 27_634_885, sequence: 68_400,
+        };
+        // The paired CSI frame's sequence is 400 behind the sync packet's
+        // (e.g. the sync packet raced ahead on the priority send path).
+        let mesh = pkt.mesh_aligned_us_for_sequence(68_000, 20.0);
+        // 400 frames behind at 20 fps = 20 s earlier — a plausible, bounded
+        // value, not a multi-year swing.
+        assert_eq!(mesh, pkt.epoch_us - 20_000_000);
     }
 
     /// End-to-end ADR-110 pipeline sanity:

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -462,6 +462,11 @@ struct NodeState {
     vital_detector: VitalSignDetector,
     latest_vitals: VitalSigns,
     pub(crate) last_frame_time: Option<std::time::Instant>,
+    /// ADR-110 §A0.12: sequence number of the most recently accepted CSI
+    /// frame, paired against `latest_sync.sequence` by
+    /// `mesh_aligned_us_for_csi_frame` to recover a mesh-aligned timestamp
+    /// for this frame instead of the server's own arrival time.
+    pub(crate) last_frame_sequence: Option<u32>,
     edge_vitals: Option<Esp32VitalsPacket>,
     /// ADR-110 §A0.12: Latest sync packet received from this node. When a
     /// CSI frame arrives with byte 19 bit 4 set (`adr018_flags.ieee802154_sync_valid`),
@@ -698,6 +703,21 @@ impl NodeState {
     }
 
     pub(crate) fn observe_csi_frame_arrival(&mut self, now: std::time::Instant) {
+        self.observe_csi_frame_arrival_seq(now, None);
+    }
+
+    /// Same as [`Self::observe_csi_frame_arrival`], but also records the
+    /// frame's ADR-018 sequence number (when known) so
+    /// `mesh_aligned_us_for_csi_frame` can pair it against the latest
+    /// `SyncPacket` later. `sequence = None` preserves the old behavior for
+    /// callers that don't have a parsed frame (grid-rejected arrivals still
+    /// count for fps/liveness, but a frame that isn't going to fusion is not
+    /// worth mesh-aligning).
+    pub(crate) fn observe_csi_frame_arrival_seq(
+        &mut self,
+        now: std::time::Instant,
+        sequence: Option<u32>,
+    ) {
         if let Some(prev) = self.last_frame_time {
             let dt = now.duration_since(prev).as_secs_f64();
             // Burst arrivals (sub-floor dt, issue #1180): do NOT re-anchor on
@@ -715,6 +735,9 @@ impl NodeState {
             }
         }
         self.last_frame_time = Some(now);
+        if sequence.is_some() {
+            self.last_frame_sequence = sequence;
+        }
     }
 
     pub(crate) fn new() -> Self {
@@ -738,6 +761,7 @@ impl NodeState {
             vital_detector: VitalSignDetector::new(10.0),
             latest_vitals: VitalSigns::default(),
             last_frame_time: None,
+            last_frame_sequence: None,
             edge_vitals: None,
             latest_sync: None,
             latest_sync_at: None,
@@ -6123,7 +6147,10 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     // ADR-110 iter 19 — feed the per-node fps EMA from real
                     // CSI arrivals. The helper sets `last_frame_time` as a
                     // side effect, so the previous bare assignment is gone.
-                    ns.observe_csi_frame_arrival(std::time::Instant::now());
+                    // Also records `frame.sequence` so `node_frame_from_state`
+                    // can recover a mesh-aligned timestamp via the latest
+                    // `SyncPacket` instead of falling back to arrival time.
+                    ns.observe_csi_frame_arrival_seq(std::time::Instant::now(), Some(frame.sequence));
 
                     // ADR-084 Pass 3: cluster-Pi novelty sensor.
                     // Score this frame's feature vector against the per-node

--- a/v2/crates/wifi-densepose-sensing-server/src/multistatic_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/multistatic_bridge.rs
@@ -36,7 +36,17 @@ static NORMALIZER: LazyLock<HardwareNormalizer> = LazyLock::new(HardwareNormaliz
 ///
 /// Returns `None` when the node has no frame history or no recorded
 /// `last_frame_time`.
-pub fn node_frame_from_state(node_id: u8, ns: &NodeState) -> Option<MultiBandCsiFrame> {
+///
+/// `use_mesh_aligned` must be decided once for the whole batch (see
+/// [`node_frames_from_states`]) — mixing a mesh-aligned timestamp for one
+/// node with the server-arrival-time fallback for another would compare two
+/// unrelated numeric references and make `guard_interval_us` spurious rather
+/// than meaningful.
+pub fn node_frame_from_state(
+    node_id: u8,
+    ns: &NodeState,
+    use_mesh_aligned: bool,
+) -> Option<MultiBandCsiFrame> {
     let last_time = ns.last_frame_time.as_ref()?;
     let latest = ns.frame_history.back()?;
     if latest.is_empty() {
@@ -54,10 +64,19 @@ pub fn node_frame_from_state(node_id: u8, ns: &NodeState) -> Option<MultiBandCsi
     let n_sub = amplitude.len();
     let phase = vec![0.0_f32; n_sub];
 
-    // Monotonic timestamp: microseconds since a shared process-local epoch.
-    // All nodes use the same reference so the fuser's guard_interval_us check
-    // compares apples to apples. No wall-clock mixing (immune to NTP jumps).
-    let timestamp_us = last_time.duration_since(*EPOCH).as_micros() as u64;
+    // Prefer the ADR-110 mesh-aligned timestamp (recovered from this node's
+    // latest SyncPacket, paired against the frame's own sequence number) so
+    // the fuser's guard_interval_us check is actually comparing device-clock
+    // alignment across nodes, per the mesh-sync design. Only used when the
+    // whole batch agreed to it (see `use_mesh_aligned` doc); otherwise falls
+    // back to the server's own arrival-time reference — microseconds since a
+    // shared process-local epoch, immune to NTP jumps.
+    let mesh_aligned = use_mesh_aligned
+        .then(|| ns.last_frame_sequence)
+        .flatten()
+        .and_then(|seq| ns.mesh_aligned_us_for_csi_frame(seq));
+    let timestamp_us =
+        mesh_aligned.unwrap_or_else(|| last_time.duration_since(*EPOCH).as_micros() as u64);
 
     let canonical = CanonicalCsiFrame {
         amplitude,
@@ -80,24 +99,34 @@ pub fn node_frame_from_state(node_id: u8, ns: &NodeState) -> Option<MultiBandCsi
 /// [`STALE_THRESHOLD`] of `now`.
 pub fn node_frames_from_states(node_states: &HashMap<u8, NodeState>) -> Vec<MultiBandCsiFrame> {
     let now = Instant::now();
-    let mut frames = Vec::with_capacity(node_states.len());
 
-    for (&node_id, ns) in node_states {
-        // Skip stale nodes
-        if let Some(ref t) = ns.last_frame_time {
-            if now.duration_since(*t) > STALE_THRESHOLD {
-                continue;
-            }
-        } else {
-            continue;
-        }
+    let active: Vec<(u8, &NodeState)> = node_states
+        .iter()
+        .filter(|(_, ns)| {
+            ns.last_frame_time
+                .is_some_and(|t| now.duration_since(t) <= STALE_THRESHOLD)
+        })
+        .map(|(&node_id, ns)| (node_id, ns))
+        .collect();
 
-        if let Some(frame) = node_frame_from_state(node_id, ns) {
-            frames.push(frame);
-        }
-    }
+    // Mesh-aligned timestamps are only trustworthy for this cycle if EVERY
+    // active node has fresh ADR-110 sync right now — a single node falling
+    // back to server-arrival-time while its peers use mesh-aligned epochs
+    // would compare two unrelated numeric references and spuriously trip
+    // (or spuriously pass) `guard_interval_us`. Below the full-coverage bar,
+    // all nodes use the server-arrival-time reference together, same as
+    // before this change.
+    let use_mesh_aligned = !active.is_empty()
+        && active.iter().all(|(_, ns)| {
+            ns.last_frame_sequence
+                .and_then(|seq| ns.mesh_aligned_us_for_csi_frame(seq))
+                .is_some()
+        });
 
-    frames
+    active
+        .into_iter()
+        .filter_map(|(node_id, ns)| node_frame_from_state(node_id, ns, use_mesh_aligned))
+        .collect()
 }
 
 /// Attempt multistatic fusion; fall back to max per-node person count on failure.
@@ -191,7 +220,7 @@ mod tests {
     #[test]
     fn test_node_frame_from_empty_state() {
         let ns = make_node_state(VecDeque::new(), Some(Instant::now()), 0);
-        assert!(node_frame_from_state(1, &ns).is_none());
+        assert!(node_frame_from_state(1, &ns, false).is_none());
     }
 
     #[test]
@@ -199,7 +228,7 @@ mod tests {
         let mut history = VecDeque::new();
         history.push_back(vec![1.0, 2.0, 3.0]);
         let ns = make_node_state(history, None, 0);
-        assert!(node_frame_from_state(1, &ns).is_none());
+        assert!(node_frame_from_state(1, &ns, false).is_none());
     }
 
     #[test]
@@ -208,7 +237,7 @@ mod tests {
         history.push_back(vec![10.0, 20.0, 30.5]);
         let ns = make_node_state(history, Some(Instant::now()), 0);
 
-        let frame = node_frame_from_state(42, &ns).expect("should produce a frame");
+        let frame = node_frame_from_state(42, &ns, false).expect("should produce a frame");
         assert_eq!(frame.node_id, 42);
         assert_eq!(frame.channel_frames.len(), 1);
 


### PR DESCRIPTION
# Wire ADR-110 mesh-aligned timestamps into the fusion path (+ fix a sequence-delta sign bug it exposed)

## Summary

While bringing up 3× ESP32-S3 (devkitc-overlay, display-less) nodes end-to-end against `wifi-densepose-sensing-server`, found and fixed two related issues:

1. **`node_frame_from_state` never actually used the ADR-110 mesh-aligned timestamp.** `NodeState::mesh_aligned_us_for_csi_frame` (recovers a cross-node-aligned epoch from the `SyncPacket` stream) is implemented and unit-tested, but its only callers were its own tests — the live fusion path built `MultiBandCsiFrame.timestamp_us` from the server's own packet-arrival time instead. So `MultistaticFuser::fuse()`'s `guard_interval_us` check was really measuring inter-node *arrival jitter at the server*, not device clock alignment, regardless of whether the nodes' clocks were actually synced.
2. **Fixing that exposed a real sign bug**: `SyncPacket::mesh_aligned_us_for_sequence` computed the frame/sync sequence delta as `frame_seq.wrapping_sub(self.sequence) as i64` — a `u32` wrapping subtraction zero-extended to `i64`. That's correct for true sequence wraparound (`frame_seq` just past `u32::MAX`), but wrong for the far more common case of `frame_seq` merely a little *behind* `self.sequence` (sync packets go out on a priority send path; ordinary CSI frames don't, and can lag), which produced ~4.29-billion-frame swings instead of small negative ones. Live effect: `Timestamp spread` errors in the **tens of trillions of microseconds** once the mesh-aligned path was wired in.

Also confirms, as a side effect of testing this live: ADR-110's ESP-NOW cross-node sync (`c6_sync_espnow.c`) does work correctly — `docs/WITNESS-LOG-110.md` §D-workaround flagged the multi-board RX measurement as never actually collected (previous session's other boards dropped off USB mid-experiment). See "Bonus finding" below for real numbers and a caveat on effective range.

## Changes

- `crates/wifi-densepose-hardware/src/sync_packet.rs`: `mesh_aligned_us_for_sequence` now reinterprets the `wrapping_sub` result as `i32` (sign-extend) before widening to `i64`, instead of zero-extending directly. This is the standard RFC 1982 serial-number-arithmetic pattern — it keeps the existing wraparound behavior correct (`mesh_aligned_for_sequence_handles_seq_wraparound` still passes unmodified) while also correctly handling small backward deltas. Added `mesh_aligned_for_sequence_handles_small_backward_drift` as a regression test.
- `crates/wifi-densepose-sensing-server/src/main.rs`: `NodeState` gains `last_frame_sequence: Option<u32>`, recorded via a new `observe_csi_frame_arrival_seq` (old `observe_csi_frame_arrival` now delegates to it with `None`, so no existing call sites break).
- `crates/wifi-densepose-sensing-server/src/multistatic_bridge.rs`: `node_frame_from_state` takes a new `use_mesh_aligned: bool` and prefers `ns.mesh_aligned_us_for_csi_frame(seq)` when true, falling back to the original arrival-time reference otherwise. `node_frames_from_states` decides `use_mesh_aligned` **once per batch**, and only sets it `true` when *every* currently-active node has a fresh mesh-aligned timestamp available — mixing a mesh-aligned epoch for one node with the arrival-time epoch for another would compare two unrelated numeric references and make the guard check meaningless (worse than either pure mode). Below full coverage, all nodes fall back together, matching pre-existing behavior exactly.

## Testing

- `cargo test -p wifi-densepose-hardware -p wifi-densepose-sensing-server`: 484 + 193 + others, all passing, 0 failures (full output available on request).
- Live 3-node hardware run (3× ESP32-S3 DevKitC-1, WiFi CSI, real sensing-server):
  - Before this fix: `Timestamp spread 60000-90000us` continuously, `trust.demoted: true`, `raw_outputs_suppressed: true`, `engine_error_count` climbing indefinitely (>1000 in ~25 min) even after all 3 nodes had individually-healthy CSI streams.
  - With only the sequence-delta bug still present (mesh-aligned path wired in, sign bug not yet fixed): `Timestamp spread` blew out to 88,000,000,000-95,000,000,000 us (confirms the bug was real and would have shipped a much worse regression than the dead code it replaced).
  - With both fixes: spreads back to 60,000-145,000us range (bounded, plausible), `trust.demoted` self-clears to `false` once nodes stabilize, `engine_error_count` stops climbing.

## Bonus finding: ESP-NOW mesh sync range (informational, no code change)

Confirmed live: `c6_sync_espnow.c` cross-node sync (the ESP-NOW workaround for the documented-broken 802.15.4 path, D1 in `WITNESS-LOG-110.md`) works correctly, but its effective range is well under normal AP-relative deployment spacing:

- 3 nodes at normal room spacing (each with good AP RSSI, -30 to -50 dBm): sustained `rx#0 (match=0)` on all boards for 10+ minutes, 100% TX success the whole time.
- Two of the three nodes moved to ~arm's length apart (still same AP): sync started working immediately, 100% delivery:
  ```
  [node2] tx#1201 (fail=0) rx#2399 (match=2399) leader=0 offset_us=1411799105 smoothed=1411799032
  [node3] tx#16251 (fail=0) rx#28358 (match=28358) leader=0 offset_us=-93697073 smoothed=-93697626
  ```
  Both showed `leader=0` (neither elected leader), consistent with both hearing a third, lower-MAC leader (node 1, still powered on elsewhere) — so real range may be somewhat better than "arm's length," but clearly short of what AP RSSI alone would suggest is safe for a multi-room deployment.

Not fixed here since it's a hardware/RF-range characteristic rather than a code bug, but worth documenting as a real deployment constraint, and/or worth investigating `esp_now` TX power tuning specifically for the sync beacons. Happy to open a separate issue if useful.

## Repro environment

- 3× ESP32-S3 DevKitC-1 (display-less), 8MB flash
- Firmware: `sdkconfig.defaults` + `sdkconfig.defaults.devkitc` overlay, built via `docker run espressif/idf:v5.4`
- `wifi-densepose-sensing-server` built from current `v2/` workspace
- Windows 11, boards on the same 2.4GHz AP
