### PR TITLE
fix: upgrade hono to 4.12.25 (CVE-2026-54290)

### DIFF
--- a/tools/ruview-mcp/package-lock.json
+++ b/tools/ruview-mcp/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "hono": "^4.12.25",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.25.2"
       },
@@ -2410,9 +2411,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/tools/ruview-mcp/package.json
+++ b/tools/ruview-mcp/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "hono": "^4.12.25",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.25.2"
   },


### PR DESCRIPTION
## Summary
Upgrade hono from 4.12.21 to 4.12.25 to fix CVE-2026-54290.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-54290 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-54290` |
| **File** | `tools/ruview-mcp/package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: hono: CORS Middleware reflects any Origin with credentials when `origin` defaults to the wildcard

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-54290` flagged this pattern.

## Threat Model Context

This is embedded firmware - exploitation requires physical access or a compromised network peer on the same bus/LAN segment.

## Changes
- `tools/ruview-mcp/package.json`
- `tools/ruview-mcp/package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
