### PR TITLE
Add remote-sleep endpoint (POST /system/sleep) + provision.py --ota-psk support

### DIFF
--- a/firmware/esp32-csi-node/main/ota_update.c
+++ b/firmware/esp32-csi-node/main/ota_update.c
@@ -6,6 +6,16 @@
  * The HTTP server runs on port 8032 and accepts:
  *   POST /ota — firmware binary payload (application/octet-stream)
  *   GET /ota/status — current firmware version and partition info
+ *   POST /system/sleep — enter indefinite deep sleep (remote "off")
+ *
+ * /system/sleep shares the OTA endpoint's PSK auth (fail-closed the same
+ * way): unprovisioned nodes reject it, same as /ota. There is deliberately
+ * no wake-on-network path here -- deep sleep powers down the WiFi radio, so
+ * nothing can reach the node again over the air. Waking it back up needs a
+ * physical power-cycle (or, on hardware with the wake GPIO wired up, an
+ * external trigger). This is a real, unavoidable limitation of WiFi-based
+ * remote control, not an oversight -- document it for callers rather than
+ * pretend a remote wake exists.
  */
 
 #include "ota_update.h"
@@ -15,6 +25,7 @@
 #include "esp_ota_ops.h"
 #include "esp_http_server.h"
 #include "esp_app_desc.h"
+#include "esp_sleep.h"
 #include "nvs_flash.h"
 #include "nvs.h"
 
@@ -209,6 +220,44 @@ static esp_err_t ota_upload_handler(httpd_req_t *req)
     return ESP_OK;  /* Never reached. */
 }
 
+/**
+ * POST /system/sleep — enter indefinite deep sleep (remote "off").
+ *
+ * Reuses the OTA PSK auth: an unprovisioned node (no PSK in NVS) rejects
+ * this the same way it rejects OTA uploads. This is deliberately a
+ * heavier-weight check than a simple on/off toggle deserves in isolation,
+ * but it means there's exactly one auth mechanism to reason about and
+ * provision for this whole server, not two.
+ *
+ * No wake timer, no wake-on-network -- see the file header comment. The
+ * caller is expected to already know they'll need physical access (or a
+ * smart-plug power cycle) to bring the node back.
+ */
+static esp_err_t system_sleep_handler(httpd_req_t *req)
+{
+    if (!ota_check_auth(req)) {
+        ESP_LOGW(TAG, "sleep request rejected: authentication failed");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN,
+                            "Authentication required. Use: Authorization: Bearer <psk>");
+        return ESP_FAIL;
+    }
+
+    ESP_LOGW(TAG, "Remote sleep requested over HTTP -- entering deep sleep. "
+                  "Physical power-cycle required to wake.");
+
+    const char *resp = "{\"status\":\"ok\",\"message\":\"Entering deep sleep. "
+                        "Physical power-cycle required to wake.\"}";
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, resp, strlen(resp));
+
+    /* Let the response flush before the radio (and everything else) goes
+     * down -- same pattern as the OTA reboot below. */
+    vTaskDelay(pdMS_TO_TICKS(500));
+    esp_deep_sleep_start();
+
+    return ESP_OK;  /* Never reached. */
+}
+
 /** Internal: start the HTTP server and register OTA endpoints. */
 static esp_err_t ota_start_server(httpd_handle_t *out_handle)
 {
@@ -243,9 +292,18 @@ static esp_err_t ota_start_server(httpd_handle_t *out_handle)
     };
     httpd_register_uri_handler(server, &upload_uri);
 
+    httpd_uri_t sleep_uri = {
+        .uri      = "/system/sleep",
+        .method   = HTTP_POST,
+        .handler  = system_sleep_handler,
+        .user_ctx = NULL,
+    };
+    httpd_register_uri_handler(server, &sleep_uri);
+
     ESP_LOGI(TAG, "OTA HTTP server started on port %d", OTA_PORT);
-    ESP_LOGI(TAG, "  GET  /ota/status — firmware version info");
-    ESP_LOGI(TAG, "  POST /ota        — upload new firmware binary");
+    ESP_LOGI(TAG, "  GET  /ota/status     — firmware version info");
+    ESP_LOGI(TAG, "  POST /ota            — upload new firmware binary");
+    ESP_LOGI(TAG, "  POST /system/sleep   — enter deep sleep (physical power-cycle to wake)");
 
     if (out_handle) *out_handle = server;
     return ESP_OK;

--- a/firmware/esp32-csi-node/provision.py
+++ b/firmware/esp32-csi-node/provision.py
@@ -79,6 +79,7 @@ CONFIG_VALUE_CHECKS = [
     ("zone", lambda value: value is not None),
     ("swarm_hb", lambda value: value is not None),
     ("swarm_ingest", lambda value: value is not None),
+    ("ota_psk", lambda value: value is not None),
 ]
 
 
@@ -108,6 +109,7 @@ MERGEABLE_ATTRS = [
     "channel", "filter_mac",
     "hop_channels", "hop_dwell",
     "seed_url", "seed_token", "zone", "swarm_hb", "swarm_ingest",
+    "ota_psk",
 ]
 
 
@@ -234,6 +236,13 @@ def build_nvs_csv(args):
         writer.writerow(["swarm_hb", "data", "u16", str(args.swarm_hb)])
     if args.swarm_ingest is not None:
         writer.writerow(["swarm_ingest", "data", "u16", str(args.swarm_ingest)])
+    # ADR-050: OTA pre-shared key + remote-sleep auth. Separate namespace from
+    # csi_cfg (ota_update.c reads NVS_NAMESPACE "security", key "ota_psk") --
+    # an NVS CSV can define multiple namespaces in one file, each starting
+    # with its own "namespace" row.
+    if args.ota_psk is not None:
+        writer.writerow(["security", "namespace", "", ""])
+        writer.writerow(["ota_psk", "data", "string", args.ota_psk])
     return buf.getvalue()
 
 
@@ -352,6 +361,12 @@ def main():
     parser.add_argument("--zone", type=str, help="Zone name for this node (e.g. lobby, hallway)")
     parser.add_argument("--swarm-hb", type=int, help="Swarm heartbeat interval in seconds (default 30)")
     parser.add_argument("--swarm-ingest", type=int, help="Swarm vector ingest interval in seconds (default 5)")
+    # ADR-050: OTA / remote-sleep pre-shared key
+    parser.add_argument("--ota-psk", type=str, help="Pre-shared key (hex string) authenticating the "
+                        "OTA upload endpoint (POST /ota) and the remote-sleep endpoint "
+                        "(POST /system/sleep) on port 8032. Both are fail-closed until this is "
+                        "set -- generate one yourself, e.g.: "
+                        "python -c \"import secrets; print(secrets.token_hex(32))\"")
     parser.add_argument("--dry-run", action="store_true", help="Generate NVS binary but don't flash")
     parser.add_argument("--force-partial", action="store_true",
                         help="[deprecated since #391/#574] Suppress the missing-WiFi-trio "
@@ -476,6 +491,8 @@ def main():
         print(f"  Swarm HB:      {args.swarm_hb}s")
     if args.swarm_ingest is not None:
         print(f"  Swarm Ingest:  {args.swarm_ingest}s")
+    if args.ota_psk is not None:
+        print(f"  OTA/Sleep PSK: (set, {len(args.ota_psk)} chars)")
 
     csv_content = build_nvs_csv(args)
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -462,6 +462,11 @@ struct NodeState {
     vital_detector: VitalSignDetector,
     latest_vitals: VitalSigns,
     pub(crate) last_frame_time: Option<std::time::Instant>,
+    /// Source IP of this node's most recent UDP packet. Lets a caller find
+    /// a node on the LAN (e.g. to hit its `/system/sleep` endpoint) without
+    /// a separate discovery mechanism -- the sensing server already knows
+    /// this from every packet it receives.
+    pub(crate) last_ip: Option<std::net::IpAddr>,
     edge_vitals: Option<Esp32VitalsPacket>,
     /// ADR-110 §A0.12: Latest sync packet received from this node. When a
     /// CSI frame arrives with byte 19 bit 4 set (`adr018_flags.ieee802154_sync_valid`),
@@ -738,6 +743,7 @@ impl NodeState {
             vital_detector: VitalSignDetector::new(10.0),
             latest_vitals: VitalSigns::default(),
             last_frame_time: None,
+            last_ip: None,
             edge_vitals: None,
             latest_sync: None,
             latest_sync_at: None,
@@ -5559,6 +5565,7 @@ async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Va
                 "rssi_dbm": rssi,
                 "motion_level": &ns.current_motion_level,
                 "person_count": ns.prev_person_count,
+                "ip_address": ns.last_ip.map(|ip| ip.to_string()),
             })
         })
         .collect();
@@ -6124,6 +6131,7 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     // CSI arrivals. The helper sets `last_frame_time` as a
                     // side effect, so the previous bare assignment is gone.
                     ns.observe_csi_frame_arrival(std::time::Instant::now());
+                    ns.last_ip = Some(src.ip());
 
                     // ADR-084 Pass 3: cluster-Pi novelty sensor.
                     // Score this frame's feature vector against the per-node


### PR DESCRIPTION
## Summary

Adds an optional remote-shutdown capability for ESP32 CSI nodes — useful for anyone running a multi-node mesh who wants to power nodes down from a companion server/script without walking to each physical board. Built and tested this against my own 3-node deployment; opening it in case it's useful upstream, not because anything's broken — happy to adjust scope/approach if you'd rather do this differently.

## What's added

1. **`POST /system/sleep`** on the existing OTA HTTP server (port 8032) — calls `esp_deep_sleep_start()`. Reuses the OTA endpoint's existing PSK auth (`ota_check_auth`) rather than introducing a second auth mechanism, so it's fail-closed the same way `/ota` already is until a PSK is provisioned.

2. **`provision.py --ota-psk <hex>`** — this flag didn't actually exist despite the firmware's own log message telling operators to run it (`"No OTA PSK in NVS — ... (provision.py --ota-psk <hex>)"`). Writes to the `security` NVS namespace `ota_update.c` already reads. Benefits from the existing additive-by-default state merging (#391/#574) — provisioning just the PSK on an already-configured node doesn't require re-passing WiFi credentials.

3. **`GET /api/v1/nodes` gains `ip_address`** per node (sensing-server side) — the source IP of that node's most recent UDP packet. This is what makes the sleep endpoint actually usable from a script: something wanting to sleep every currently-active node needs to know where they are, and the sensing server already has that from every packet it receives; no separate discovery mechanism needed.

## Deliberately NOT included: remote wake

`/system/sleep` has no wake timer and there's no wake-on-network path. Deep sleep turns off the WiFi radio, so nothing can reach the node again over the air — waking it back up needs a physical power-cycle (or, on hardware with a wake GPIO wired up, an external trigger, which this PR doesn't add). This is a real limitation of WiFi-based remote control, not an oversight, and the response message/docs say so rather than implying a remote wake exists. Happy to add a timed-wake option (`esp_sleep_enable_timer_wakeup`) as a follow-up if there's interest — kept this PR to just the "off" half since that's what I actually needed and tested.

## Testing

- `cargo test -p wifi-densepose-sensing-server`: 484 passed, 0 failed.
- Live on 3× ESP32-S3 (devkitc-overlay firmware, real WiFi CSI): flashed and provisioned all 3 with a real PSK via the new `--ota-psk` flag, then individually confirmed each:
  - Accepts `POST /system/sleep` with the correct bearer token → `200 {"status":"ok",...}`, board goes offline (confirmed via the sensing server's `/api/v1/nodes` — `status` flips to `stale` within ~10-15s).
  - The `ip_address` field in `/api/v1/nodes` correctly tracks each node's actual current IP, including across a DHCP reassignment after reflash.

## Files changed

- `firmware/esp32-csi-node/main/ota_update.c`
- `firmware/esp32-csi-node/provision.py`
- `v2/crates/wifi-densepose-sensing-server/src/main.rs`
