### PR TITLE
fix(python): authenticate SensingClient WebSocket connections

### DIFF
--- a/python/tests/test_client_ws.py
+++ b/python/tests/test_client_ws.py
@@ -10,7 +10,7 @@ binary, but the wire protocol is the contract under test here.
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 import json
 from typing import Any
 
@@ -76,11 +76,32 @@ async def _handler(websocket: Any) -> None:
     await websocket.send(json.dumps({"type": "edge_vitals", "node_id": "post-bad-frame"}))
 
 
+async def _auth_handler(websocket: Any) -> None:
+    request = getattr(websocket, "request", None)
+    headers = request.headers if request is not None else websocket.request_headers
+    if headers.get("Authorization") != "Bearer test-token":
+        await websocket.close(code=1008, reason="missing or invalid bearer token")
+        return
+    await websocket.send(json.dumps(_FIXTURE_MESSAGES[0]))
+
+
 @pytest.fixture
 async def ws_server() -> Any:
     """Start a websocket server on a random port; yield the bound URL."""
     server = await websockets.serve(_handler, "127.0.0.1", 0)
     # Get the bound port (host="127.0.0.1" returns one socket).
+    port = server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+    try:
+        yield f"ws://127.0.0.1:{port}/ws/sensing"
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.fixture
+async def authenticated_ws_server() -> Any:
+    """Start a WS server that rejects clients without the expected bearer."""
+    server = await websockets.serve(_auth_handler, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
     try:
         yield f"ws://127.0.0.1:{port}/ws/sensing"
@@ -154,6 +175,25 @@ async def test_sensing_client_close_is_idempotent(ws_server: str) -> None:
     await client.close()  # second close is a no-op
 
 
+@pytest.mark.parametrize("explicit_token", [False, True])
+async def test_sensing_client_authenticates_with_bearer_token(
+    authenticated_ws_server: str,
+    monkeypatch: pytest.MonkeyPatch,
+    explicit_token: bool,
+) -> None:
+    if explicit_token:
+        monkeypatch.setenv("RUVIEW_API_TOKEN", "wrong-environment-token")
+        client = SensingClient(authenticated_ws_server, token="test-token")
+    else:
+        monkeypatch.setenv("RUVIEW_API_TOKEN", "test-token")
+        client = SensingClient(authenticated_ws_server)
+
+    async with client:
+        msg = await client.recv_one(timeout=2.0)
+
+    assert isinstance(msg, ConnectionEstablishedMessage)
+
+
 def test_sensing_client_decoder_directly() -> None:
     """The decoder is pure — exercise it without bringing up a WS
     server, so we have a fast unit test for the type mapping."""
@@ -193,3 +233,39 @@ def test_sensing_client_decoder_handles_None_subfields() -> None:
     assert msg.breathing_rate_bpm is None
     assert msg.heartrate_bpm is None
     assert msg.rssi is None
+
+
+@pytest.mark.parametrize("header_parameter", ["extra_headers", "additional_headers"])
+def test_authorization_header_supports_websockets_versions(
+    monkeypatch: pytest.MonkeyPatch, header_parameter: str
+) -> None:
+    """websockets 14 renamed extra_headers to additional_headers."""
+    from wifi_densepose.client import ws as ws_module
+
+    if header_parameter == "additional_headers":
+
+        async def connect_with_additional_headers(
+            *, additional_headers: Any = None
+        ) -> None:
+            pass
+
+        connect = connect_with_additional_headers
+    else:
+
+        async def connect_with_extra_headers(*, extra_headers: Any = None) -> None:
+            pass
+
+        connect = connect_with_extra_headers
+
+    monkeypatch.setattr(ws_module.websockets, "connect", connect)
+    kwargs = ws_module._authorization_header_kwargs("configured-token")
+
+    assert set(inspect.signature(connect).parameters) == {header_parameter}
+    assert kwargs == {header_parameter: {"Authorization": "Bearer configured-token"}}
+
+
+def test_authorization_header_is_omitted_without_token() -> None:
+    from wifi_densepose.client.ws import _authorization_header_kwargs
+
+    assert _authorization_header_kwargs(None) == {}
+    assert _authorization_header_kwargs("") == {}

--- a/python/wifi_densepose/client/ws.py
+++ b/python/wifi_densepose/client/ws.py
@@ -31,8 +31,10 @@ asyncio.run(main())
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Optional
 
@@ -46,6 +48,28 @@ except ImportError:  # pragma: no cover
 
 
 log = logging.getLogger(__name__)
+
+
+def _authorization_header_kwargs(token: str | None) -> dict[str, Any]:
+    """Build version-compatible ``websockets.connect`` header arguments.
+
+    websockets 14 renamed ``extra_headers`` to ``additional_headers``.
+    Inspecting the installed callable keeps the client compatible with the
+    full declared ``websockets>=12`` dependency range without relying on a
+    separately parsed package version.
+    """
+    if not token:
+        return {}
+
+    parameters = inspect.signature(websockets.connect).parameters
+    headers = {"Authorization": f"Bearer {token}"}
+    if "additional_headers" in parameters:
+        return {"additional_headers": headers}
+    if "extra_headers" in parameters:
+        return {"extra_headers": headers}
+    raise RuntimeError(
+        "Unsupported websockets.connect API: expected additional_headers or extra_headers"
+    )
 
 
 # ─── Typed messages ──────────────────────────────────────────────────
@@ -172,12 +196,17 @@ class SensingClient:
     the ``async with`` in your own retry loop. Auto-reconnect logic is
     application-specific (e.g., "retry forever" for a long-running
     automation vs "fail fast" for a CLI tool that should exit).
+
+    When ``token`` is omitted, the client reads ``RUVIEW_API_TOKEN``.
+    Pass a token explicitly to override the environment, or ``token=""``
+    to disable authentication.
     """
 
     def __init__(
         self,
         url: str,
         *,
+        token: str | None = None,
         ping_interval: float = 20.0,
         ping_timeout: float = 20.0,
         max_size: int = 16 * 1024 * 1024,
@@ -191,6 +220,7 @@ class SensingClient:
         self._ping_interval = ping_interval
         self._ping_timeout = ping_timeout
         self._max_size = max_size
+        self._token = token if token is not None else os.environ.get("RUVIEW_API_TOKEN")
         self._ws: Any = None  # websockets.WebSocketClientProtocol — typed Any to avoid import cost
 
     async def __aenter__(self) -> "SensingClient":
@@ -199,6 +229,7 @@ class SensingClient:
             ping_interval=self._ping_interval,
             ping_timeout=self._ping_timeout,
             max_size=self._max_size,
+            **_authorization_header_kwargs(self._token),
         )
         return self
 


### PR DESCRIPTION
## Summary

- Add bearer-token authentication to the Python `SensingClient`.
- Read the token from `RUVIEW_API_TOKEN` by default.
- Allow callers to override the token through the constructor.
- Support both WebSocket header APIs used across the declared `websockets>=12` dependency range.

## Details

`SensingClient` now sends:

```text
Authorization: Bearer <token>
```

during the WebSocket upgrade.

websockets renamed extra_headers to additional_headers in version 14. The client inspects the installed connect() API and deliberately selects the supported argument, preserving compatibility with versions 12, 13, 14, and later.

Passing token="" explicitly disables authentication even when RUVIEW_API_TOKEN is set.


## Validation

Client test suite with websockets==12.0: 11 passed
Client test suite with websockets==15.0.1: 11 passed
Python compile check passed
Targeted Ruff checks passed



Closes #1395