### PR TITLE
feat(python-client): send bearer token on WS upgrade

### DIFF
--- a/python/tests/test_client_ws.py
+++ b/python/tests/test_client_ws.py
@@ -65,6 +65,15 @@ _FIXTURE_MESSAGES = [
 ]
 
 
+def _request_headers(websocket: Any) -> Any:
+    """Return the upgrade-request headers regardless of websockets version:
+    the legacy server protocol (<14, still reachable via >=12.0's floor)
+    exposes `request_headers`; the newer asyncio-based server exposes
+    `request.headers` instead."""
+    legacy = getattr(websocket, "request_headers", None)
+    return legacy if legacy is not None else websocket.request.headers
+
+
 async def _handler(websocket: Any) -> None:
     for msg in _FIXTURE_MESSAGES:
         await websocket.send(json.dumps(msg))
@@ -172,6 +181,77 @@ def test_sensing_client_decoder_directly() -> None:
     assert msg.breathing_rate_bpm is None  # not present → None, not 0.0
     assert msg.heartrate_bpm is None
     assert msg.rssi is None
+
+
+async def test_sensing_client_sends_bearer_token_on_upgrade() -> None:
+    """#1395: a token passed to the constructor must reach the server as
+    an `Authorization: Bearer <token>` header on the WS upgrade request."""
+    captured_auth: dict[str, Any] = {}
+
+    async def handler(websocket: Any) -> None:
+        captured_auth["value"] = _request_headers(websocket).get("Authorization")
+        await websocket.send(json.dumps({"type": "connection_established", "node_id": "auth-test"}))
+        await websocket.wait_closed()
+
+    server = await websockets.serve(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+    try:
+        async with SensingClient(f"ws://127.0.0.1:{port}/ws/sensing", token="s3cr3t") as client:
+            await client.recv_one(timeout=2.0)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert captured_auth["value"] == "Bearer s3cr3t"
+
+
+async def test_sensing_client_omits_auth_header_when_no_token(monkeypatch: Any) -> None:
+    """No token passed and RUVIEW_API_TOKEN unset: no Authorization header
+    at all, not an empty one — matches the HTTP client's no-op behaviour."""
+    monkeypatch.delenv("RUVIEW_API_TOKEN", raising=False)
+    captured_auth: dict[str, Any] = {}
+
+    async def handler(websocket: Any) -> None:
+        captured_auth["present"] = "Authorization" in _request_headers(websocket)
+        await websocket.send(
+            json.dumps({"type": "connection_established", "node_id": "no-auth-test"})
+        )
+        await websocket.wait_closed()
+
+    server = await websockets.serve(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+    try:
+        async with SensingClient(f"ws://127.0.0.1:{port}/ws/sensing") as client:
+            await client.recv_one(timeout=2.0)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert captured_auth["present"] is False
+
+
+async def test_sensing_client_reads_token_from_env(monkeypatch: Any) -> None:
+    """Constructor token defaults to RUVIEW_API_TOKEN when not passed explicitly."""
+    monkeypatch.setenv("RUVIEW_API_TOKEN", "from-env-token")
+    captured_auth: dict[str, Any] = {}
+
+    async def handler(websocket: Any) -> None:
+        captured_auth["value"] = _request_headers(websocket).get("Authorization")
+        await websocket.send(
+            json.dumps({"type": "connection_established", "node_id": "env-token-test"})
+        )
+        await websocket.wait_closed()
+
+    server = await websockets.serve(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+    try:
+        async with SensingClient(f"ws://127.0.0.1:{port}/ws/sensing") as client:
+            await client.recv_one(timeout=2.0)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert captured_auth["value"] == "Bearer from-env-token"
 
 
 def test_sensing_client_decoder_handles_None_subfields() -> None:

--- a/python/wifi_densepose/client/ws.py
+++ b/python/wifi_densepose/client/ws.py
@@ -31,8 +31,10 @@ asyncio.run(main())
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Optional
 
@@ -41,6 +43,16 @@ try:
     import websockets  # type: ignore[import-not-found]
     from websockets.exceptions import ConnectionClosed  # type: ignore[import-not-found]
     _WEBSOCKETS_AVAILABLE = True
+    # The `websockets.connect` keyword for custom headers was renamed within
+    # the >=12.0 range this package pins: `extra_headers` (<14) became
+    # `additional_headers` (>=14). Detect via signature introspection rather
+    # than parsing __version__, so this doesn't silently drift if the cutover
+    # version turns out to be off by a patch release.
+    _CONNECT_HEADERS_KWARG = (
+        "additional_headers"
+        if "additional_headers" in inspect.signature(websockets.connect).parameters
+        else "extra_headers"
+    )
 except ImportError:  # pragma: no cover
     _WEBSOCKETS_AVAILABLE = False
 
@@ -178,6 +190,7 @@ class SensingClient:
         self,
         url: str,
         *,
+        token: Optional[str] = None,
         ping_interval: float = 20.0,
         ping_timeout: float = 20.0,
         max_size: int = 16 * 1024 * 1024,
@@ -188,18 +201,24 @@ class SensingClient:
                 "`pip install \"wifi-densepose[client]\"` to enable the client extras."
             )
         self.url = url
+        # Bearer token for RUVIEW_API_TOKEN-protected servers. Python isn't
+        # browser-constrained (unlike the web UI), so the header can go
+        # straight on the WS upgrade — no ticket/round-trip indirection.
+        self._token = token if token is not None else os.environ.get("RUVIEW_API_TOKEN")
         self._ping_interval = ping_interval
         self._ping_timeout = ping_timeout
         self._max_size = max_size
         self._ws: Any = None  # websockets.WebSocketClientProtocol — typed Any to avoid import cost
 
     async def __aenter__(self) -> "SensingClient":
-        self._ws = await websockets.connect(
-            self.url,
-            ping_interval=self._ping_interval,
-            ping_timeout=self._ping_timeout,
-            max_size=self._max_size,
-        )
+        connect_kwargs: dict[str, Any] = {
+            "ping_interval": self._ping_interval,
+            "ping_timeout": self._ping_timeout,
+            "max_size": self._max_size,
+        }
+        if self._token:
+            connect_kwargs[_CONNECT_HEADERS_KWARG] = {"Authorization": f"Bearer {self._token}"}
+        self._ws = await websockets.connect(self.url, **connect_kwargs)
         return self
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:


### PR DESCRIPTION
Fixes #1395.

## Problem

`SensingClient` (`python/wifi_densepose/client/ws.py`) had no credential path at all — `git grep -n "Authorization\|RUVIEW_API_TOKEN" python/` returned nothing. Against a sensing-server with `RUVIEW_API_TOKEN` set, the Python client simply cannot connect. The TS MCP client (`tools/ruview-mcp/src/http.ts`) has honoured this token for a while, so this was a gap between the two clients rather than a missing feature overall.

## Fix

- `SensingClient.__init__` accepts a `token` keyword, defaulting to `RUVIEW_API_TOKEN` when not passed explicitly.
- When a token is present, `__aenter__` sends `Authorization: Bearer <token>` on the WS upgrade. Python isn't browser-constrained the way the web UI is, so this goes straight on the upgrade request — no ticket/round-trip indirection, per the issue's explicit guidance.
- Handled the `websockets>=12.0` keyword rename **deliberately**, per the issue's callout: the header kwarg to `websockets.connect()` is `extra_headers` below version 14 and `additional_headers` from 14 onward. Detected via `inspect.signature(websockets.connect).parameters` at import time, not by parsing `__version__` — so it can't be thrown off by a version-string format change on either side of the cutover.

## Testing

I didn't just trust the issue's description of the version split — I installed `websockets` 12.0, 13.1, and 16.1.1 in three isolated venvs and inspected the actual `connect()` signature in each to confirm exactly where `extra_headers` becomes `additional_headers` before writing the branch logic.

Added three tests to `test_client_ws.py` using the same in-process `websockets.serve()` pattern the file already uses:
- token passed to the constructor arrives as the correct `Authorization: Bearer <token>` header
- no token passed and `RUVIEW_API_TOKEN` unset → no `Authorization` header sent at all (not an empty one)
- `RUVIEW_API_TOKEN` env var is honoured when no token is passed explicitly

Ran the full `test_client_ws.py` suite (9 tests, including the 3 new ones) against both `websockets` 13.1 and 16.1.1 in separate venvs — all pass on both sides of the keyword rename. Also confirmed the change doesn't newly break `ruff check` beyond one pre-existing style debt already present in this file (`Optional[X]` vs `X | None`) that I matched rather than mixed styles.