### PR TITLE
Fix: short pytest param ids to avoid Windows env-length error

### DIFF
--- a/tests/test_invariant_Cargo.py
+++ b/tests/test_invariant_Cargo.py
@@ -93,7 +93,7 @@ def simulate_version_comparison(version_str: str) -> bool:
         return False
 
 
-@pytest.mark.parametrize("payload", ADVERSARIAL_PAYLOADS)
+@pytest.mark.parametrize("payload", ADVERSARIAL_PAYLOADS, ids=[f"p{i}" for i in range(len(ADVERSARIAL_PAYLOADS))])
 def test_openssl_version_handling_security_invariant(payload):
     """Invariant: Adversarial inputs must not cause unsafe behavior when processed
     as version strings or package metadata. Version parsing must remain safe and


### PR DESCRIPTION
Pytest parametrized tests generated extremely long node ids on Windows which triggered a ValueError due to environment variable length during test teardown. This change adds short explicit ids for ADVERSARIAL_PAYLOADS in tests/test_invariant_Cargo.py to avoid massive node ids while preserving all payloads. Verified: full test suite passes (34 passed, 1 warning) on Windows.\n\nNo functional change to test logic; only test metadata (ids).