### PR TITLE
fix(firmware): add DEGRADED state recovery path and N16R8 sdkconfig

### DIFF
--- a/firmware/esp32-csi-node/main/Kconfig.projbuild
+++ b/firmware/esp32-csi-node/main/Kconfig.projbuild
@@ -168,6 +168,15 @@ menu "Adaptive Controller (ADR-081)"
             falls back to DEGRADED mode and pins the radio to
             RV_PROFILE_PASSIVE_LOW_RATE. 0 disables the degraded gate.
 
+    config ADAPTIVE_DEGRADED_RECOVERY_TICKS
+        int "Consecutive healthy ticks to exit DEGRADED"
+        default 15
+        range 1 240
+        help
+            Number of consecutive healthy adaptive ticks required before the
+            controller transitions out of DEGRADED back to SENSE_IDLE. Higher
+            values add hysteresis against flapping.
+
 endmenu
 
 menu "AMOLED Display (ADR-045)"

--- a/firmware/esp32-csi-node/main/adaptive_controller.c
+++ b/firmware/esp32-csi-node/main/adaptive_controller.c
@@ -38,6 +38,7 @@ static adapt_state_t       s_state = ADAPT_STATE_BOOT;
 static adapt_observation_t s_last_obs;
 static bool                s_obs_valid = false;
 static portMUX_TYPE        s_obs_lock = portMUX_INITIALIZER_UNLOCKED;
+static uint16_t            s_degraded_recovery_counter = 0;
 
 static TimerHandle_t s_fast_timer   = NULL;
 static TimerHandle_t s_medium_timer = NULL;
@@ -91,6 +92,11 @@ static void apply_defaults(adapt_config_t *cfg)
     cfg->motion_threshold  = (float)CONFIG_ADAPTIVE_MOTION_THRESH_PERMIL  / 1000.0f;
     cfg->anomaly_threshold = (float)CONFIG_ADAPTIVE_ANOMALY_THRESH_PERMIL / 1000.0f;
     cfg->min_pkt_yield     = CONFIG_ADAPTIVE_MIN_PKT_YIELD;
+#ifdef CONFIG_ADAPTIVE_DEGRADED_RECOVERY_TICKS
+    cfg->degraded_recovery_ticks = CONFIG_ADAPTIVE_DEGRADED_RECOVERY_TICKS;
+#else
+    cfg->degraded_recovery_ticks = 15;  /* ~3 s at 200 ms fast loop. */
+#endif
 }
 
 /* Pure decision policy lives in its own file so it can link under
@@ -162,6 +168,15 @@ static void apply_decision(const adapt_decision_t *dec)
                  (unsigned)s_state, (unsigned)dec->new_state);
         s_state = (adapt_state_t)dec->new_state;
 
+        /* RuView#1401: log DEGRADED recovery explicitly so operators can
+         * confirm the recovery path is working. */
+        if (prev == ADAPT_STATE_DEGRADED && s_state != ADAPT_STATE_DEGRADED) {
+            ESP_LOGI(TAG, "DEGRADED recovery complete → state %u "
+                     "(yield recovered above threshold for %u ticks)",
+                     (unsigned)s_state,
+                     (unsigned)s_cfg.degraded_recovery_ticks);
+        }
+
         /* ADR-081 L3: on transition to ALERT, emit ANOMALY_ALERT on the
          * mesh plane. On any role-relevant transition, bump the epoch. */
         if (s_state == ADAPT_STATE_ALERT && prev != ADAPT_STATE_ALERT) {
@@ -217,7 +232,8 @@ static void fast_loop_cb(TimerHandle_t t)
     portEXIT_CRITICAL(&s_obs_lock);
 
     adapt_decision_t dec;
-    adaptive_controller_decide(&s_cfg, s_state, &obs, &dec);
+    adaptive_controller_decide(&s_cfg, s_state, &obs, &dec,
+                               &s_degraded_recovery_counter);
     apply_decision(&dec);
 
     /* ADR-081 Layer 4/5: emit compact feature state at 1 Hz (the spec's

--- a/firmware/esp32-csi-node/main/adaptive_controller.h
+++ b/firmware/esp32-csi-node/main/adaptive_controller.h
@@ -77,6 +77,10 @@ typedef struct {
     float    motion_threshold;    /**< 0..1, enter SENSE_ACTIVE above this. */
     float    anomaly_threshold;   /**< 0..1, enter ALERT above this. */
     uint16_t min_pkt_yield;       /**< pps below this → DEGRADED. */
+    uint16_t degraded_recovery_ticks; /**< Consecutive ticks with yield above
+                                           min_pkt_yield required to exit
+                                           DEGRADED. Default 15 (~3 s at 200 ms
+                                           fast loop). Prevents flapping. */
 } adapt_config_t;
 
 /**
@@ -112,11 +116,21 @@ void adaptive_controller_force_state(adapt_state_t st);
  * Pure-function policy: given an observation + current state + config,
  * compute the decision. Exposed in the header so it can be unit-tested
  * offline (no FreeRTOS / ESP-IDF dependency in the body).
+ *
+ * @param cfg     Controller config.
+ * @param current Current state.
+ * @param obs     Latest observation snapshot.
+ * @param out     Output decision buffer.
+ * @param degraded_recovery_counter  In/out counter tracking consecutive
+ *                healthy ticks while in DEGRADED. Caller initializes to 0
+ *                and preserves across calls. Reset to 0 whenever the board
+ *                re-enters DEGRADED or yield drops below threshold.
  */
 void adaptive_controller_decide(const adapt_config_t *cfg,
                                 adapt_state_t current,
                                 const adapt_observation_t *obs,
-                                adapt_decision_t *out);
+                                adapt_decision_t *out,
+                                uint16_t *degraded_recovery_counter);
 
 #ifdef __cplusplus
 }

--- a/firmware/esp32-csi-node/main/adaptive_controller_decide.c
+++ b/firmware/esp32-csi-node/main/adaptive_controller_decide.c
@@ -14,18 +14,35 @@
 void adaptive_controller_decide(const adapt_config_t *cfg,
                                 adapt_state_t current,
                                 const adapt_observation_t *obs,
-                                adapt_decision_t *out)
+                                adapt_decision_t *out,
+                                uint16_t *degraded_recovery_counter)
 {
-    if (cfg == NULL || obs == NULL || out == NULL) {
+    if (cfg == NULL || obs == NULL || out == NULL || degraded_recovery_counter == NULL) {
         return;
     }
     memset(out, 0, sizeof(*out));
     out->new_state   = (uint8_t)current;
     out->new_profile = RV_PROFILE_PASSIVE_LOW_RATE;
 
-    /* Degraded gate: pkt yield collapse or severe coherence loss → DEGRADED. */
+    /* Recovery threshold: how many consecutive healthy ticks before exiting
+     * DEGRADED. Use config value if set, otherwise default to 15 (~3 s at
+     * the 200 ms fast loop). */
+    uint16_t recovery_threshold = cfg->degraded_recovery_ticks > 0
+                                    ? cfg->degraded_recovery_ticks
+                                    : 15;
+
+    /* Degraded gate: pkt yield collapse or severe coherence loss → DEGRADED.
+     *
+     * RuView#1401 fix: if the board is already in DEGRADED and conditions
+     * have recovered (yield >= threshold AND coherence >= 0.20), increment
+     * the recovery counter. Once the counter reaches recovery_threshold
+     * consecutive healthy ticks, transition back to SENSE_IDLE. This
+     * prevents permanent DEGRADED lock-in while avoiding flapping on
+     * intermittent yield drops. */
     if (obs->pkt_yield_per_sec < cfg->min_pkt_yield ||
         obs->node_coherence    < 0.20f) {
+        /* Conditions are bad — enter or stay in DEGRADED. */
+        *degraded_recovery_counter = 0;  /* Reset recovery progress. */
         if (current != ADAPT_STATE_DEGRADED) {
             out->change_state = true;
             out->new_state    = ADAPT_STATE_DEGRADED;
@@ -35,6 +52,28 @@ void adaptive_controller_decide(const adapt_config_t *cfg,
         out->suggested_vital_interval_ms = 2000;
         return;
     }
+
+    /* Conditions are healthy. If we're in DEGRADED, attempt recovery. */
+    if (current == ADAPT_STATE_DEGRADED) {
+        (*degraded_recovery_counter)++;
+        if (*degraded_recovery_counter < recovery_threshold) {
+            /* Not yet enough consecutive healthy ticks — stay DEGRADED
+             * but use a shorter vital interval to surface progress. */
+            out->suggested_vital_interval_ms = 1000;
+            return;
+        }
+        /* Recovery threshold met — exit DEGRADED → SENSE_IDLE. */
+        *degraded_recovery_counter = 0;
+        out->change_state = true;
+        out->new_state    = ADAPT_STATE_SENSE_IDLE;
+        out->change_profile = true;
+        out->new_profile    = RV_PROFILE_PASSIVE_LOW_RATE;
+        out->suggested_vital_interval_ms = 1000;
+        return;
+    }
+
+    /* Not in DEGRADED and conditions are healthy — reset counter. */
+    *degraded_recovery_counter = 0;
 
     /* Anomaly trumps motion. */
     if (obs->anomaly_score >= cfg->anomaly_threshold) {

--- a/firmware/esp32-csi-node/sdkconfig.defaults.n16r8
+++ b/firmware/esp32-csi-node/sdkconfig.defaults.n16r8
@@ -1,0 +1,71 @@
+# ESP32-S3 N16R8 (WROOM-1, 16MB Flash, 8MB Octal PSRAM) — RuView#1401
+#
+# The pre-built release binaries at release_bins/ were built without PSRAM
+# configuration, causing boards with Octal PSRAM (like the AITRIP ESP32-S3
+# N16R8) to enter DEGRADED state immediately with 0 pps CSI yield.
+#
+# This overlay adds the correct SPIRAM settings for N16R8 modules.
+# These boards have no display (no QSPI contention), so DATA-frame CSI
+# capture is safe and restores full yield.
+#
+# Build:
+#   cp sdkconfig.defaults.n16r8 sdkconfig.defaults
+#   idf.py set-target esp32s3
+#   idf.py build
+#
+# Flash:
+#   idf.py -p /dev/ttyACM0 flash
+#   # or manual:
+#   esptool.py --chip esp32s3 -p /dev/ttyACM0 --flash_mode dio --flash_size 16MB \
+#     write_flash 0x0 build/bootloader/bootloader.bin \
+#     0x8000 build/partition_table/partition-table.bin \
+#     0xd000 build/ota_data_initial.bin \
+#     0x20000 build/esp32-csi-node.bin
+#
+# Restore default overlay:
+#   git checkout sdkconfig.defaults
+
+# ---- Target ----
+CONFIG_IDF_TARGET="esp32s3"
+
+# ---- Flash: 16MB Quad SPI ----
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="16MB"
+CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+
+# ---- PSRAM: 8MB Octal (critical for N16R8 — missing from release_bins) ----
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_OCT=y
+CONFIG_SPIRAM_SPEED_80M=y
+# Place .bss and malloc in PSRAM where possible — frees internal SRAM for
+# WiFi/CSI buffers and FreeRTOS stacks.
+CONFIG_SPIRAM_USE_CAPS_ALLOC=y
+CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=4096
+
+# ---- Partition table: 8MB OTA layout (uses <8MB, compatible with 16MB flash) ----
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_display.csv"
+
+# ---- Compiler ----
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
+
+# ---- WiFi + CSI ----
+CONFIG_ESP_WIFI_CSI_ENABLED=y
+CONFIG_ESP_WIFI_EXTRA_IRAM_OPT=y
+
+# LWIP / WiFi buffer pools (same as base sdkconfig.defaults)
+CONFIG_LWIP_SO_RCVBUF=y
+CONFIG_LWIP_UDP_RECVMBOX_SIZE=32
+CONFIG_LWIP_TCPIP_RECVMBOX_SIZE=64
+CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=64
+
+# ---- FreeRTOS ----
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=8192
+
+# ---- Logging ----
+CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
+CONFIG_LOG_DEFAULT_LEVEL_INFO=y
+
+# ---- Display: disabled (N16R8 modules have no AMOLED panel) ----
+# CONFIG_DISPLAY_ENABLE is not set

--- a/firmware/esp32-csi-node/tests/host/test_adaptive_controller.c
+++ b/firmware/esp32-csi-node/tests/host/test_adaptive_controller.c
@@ -37,6 +37,7 @@ static adapt_config_t default_cfg(void) {
         .motion_threshold = 0.20f,
         .anomaly_threshold = 0.60f,
         .min_pkt_yield = 5,
+        .degraded_recovery_ticks = 15,
     };
     return c;
 }
@@ -60,9 +61,11 @@ static void test_degraded_gate_on_pkt_yield_collapse(void) {
     adapt_config_t cfg = default_cfg();
     adapt_observation_t obs = quiet_obs();
     obs.pkt_yield_per_sec = 2;  /* below min_pkt_yield=5 */
+    uint16_t recovery_counter = 0;
 
     adapt_decision_t dec;
-    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec);
+    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec,
+                               &recovery_counter);
 
     CHECK(dec.change_state, "should change state");
     CHECK(dec.new_state == ADAPT_STATE_DEGRADED, "new state == DEGRADED");
@@ -70,6 +73,7 @@ static void test_degraded_gate_on_pkt_yield_collapse(void) {
           "profile pinned to PASSIVE_LOW_RATE in degraded");
     CHECK(dec.suggested_vital_interval_ms == 2000,
           "cadence relaxed to 2s in degraded");
+    CHECK(recovery_counter == 0, "recovery counter reset on entering DEGRADED");
 }
 
 static void test_degraded_gate_on_coherence_loss(void) {
@@ -77,10 +81,12 @@ static void test_degraded_gate_on_coherence_loss(void) {
     adapt_config_t cfg = default_cfg();
     adapt_observation_t obs = quiet_obs();
     obs.node_coherence = 0.15f;  /* below 0.20 threshold */
+    uint16_t recovery_counter = 0;
 
     adapt_decision_t dec;
-    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec);
-    CHECK(dec.new_state == ADAPT_STATE_DEGRADED, "coherence loss → DEGRADED");
+    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec,
+                               &recovery_counter);
+    CHECK(dec.new_state == ADAPT_STATE_DEGRADED, "coherence loss -> DEGRADED");
 }
 
 static void test_anomaly_trumps_motion(void) {
@@ -89,26 +95,30 @@ static void test_anomaly_trumps_motion(void) {
     adapt_observation_t obs = quiet_obs();
     obs.motion_score = 0.9f;  /* high motion */
     obs.anomaly_score = 0.8f; /* but anomaly is above threshold */
+    uint16_t recovery_counter = 0;
 
     adapt_decision_t dec;
-    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec);
+    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec,
+                               &recovery_counter);
 
-    CHECK(dec.new_state == ADAPT_STATE_ALERT, "anomaly → ALERT");
+    CHECK(dec.new_state == ADAPT_STATE_ALERT, "anomaly -> ALERT");
     CHECK(dec.new_profile == RV_PROFILE_FAST_MOTION,
           "alert uses FAST_MOTION profile");
     CHECK(dec.suggested_vital_interval_ms == 100, "alert cadence 100ms");
 }
 
 static void test_motion_triggers_sense_active(void) {
-    printf("test: motion → SENSE_ACTIVE\n");
+    printf("test: motion -> SENSE_ACTIVE\n");
     adapt_config_t cfg = default_cfg();
     adapt_observation_t obs = quiet_obs();
     obs.motion_score = 0.50f;
+    uint16_t recovery_counter = 0;
 
     adapt_decision_t dec;
-    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec);
+    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec,
+                               &recovery_counter);
 
-    CHECK(dec.new_state == ADAPT_STATE_SENSE_ACTIVE, "motion → SENSE_ACTIVE");
+    CHECK(dec.new_state == ADAPT_STATE_SENSE_ACTIVE, "motion -> SENSE_ACTIVE");
     CHECK(dec.new_profile == RV_PROFILE_FAST_MOTION, "profile FAST_MOTION");
     CHECK(dec.suggested_vital_interval_ms == 200,
           "non-aggressive cadence 200ms");
@@ -120,22 +130,26 @@ static void test_aggressive_cadence(void) {
     cfg.aggressive = true;
     adapt_observation_t obs = quiet_obs();
     obs.motion_score = 0.50f;
+    uint16_t recovery_counter = 0;
 
     adapt_decision_t dec;
-    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec);
+    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec,
+                               &recovery_counter);
     CHECK(dec.suggested_vital_interval_ms == 100,
           "aggressive motion cadence 100ms");
 }
 
 static void test_stable_presence_uses_resp_high_sens(void) {
-    printf("test: stable presence → RESP_HIGH_SENS\n");
+    printf("test: stable presence -> RESP_HIGH_SENS\n");
     adapt_config_t cfg = default_cfg();
     adapt_observation_t obs = quiet_obs();
     obs.presence_score = 0.8f;
     obs.motion_score = 0.01f;
+    uint16_t recovery_counter = 0;
 
     adapt_decision_t dec;
-    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec);
+    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec,
+                               &recovery_counter);
     CHECK(dec.new_profile == RV_PROFILE_RESP_HIGH_SENS,
           "stable presence uses respiration profile");
     CHECK(dec.suggested_vital_interval_ms == 1000,
@@ -143,14 +157,16 @@ static void test_stable_presence_uses_resp_high_sens(void) {
 }
 
 static void test_empty_room_default_is_passive(void) {
-    printf("test: empty room → PASSIVE_LOW_RATE\n");
+    printf("test: empty room -> PASSIVE_LOW_RATE\n");
     adapt_config_t cfg = default_cfg();
     adapt_observation_t obs = quiet_obs();
+    uint16_t recovery_counter = 0;
 
     adapt_decision_t dec;
-    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec);
+    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec,
+                               &recovery_counter);
     CHECK(dec.new_profile == RV_PROFILE_PASSIVE_LOW_RATE,
-          "empty → passive low rate");
+          "empty -> passive low rate");
 }
 
 static void test_hysteresis_no_flap(void) {
@@ -158,27 +174,149 @@ static void test_hysteresis_no_flap(void) {
     adapt_config_t cfg = default_cfg();
     adapt_observation_t obs = quiet_obs();
     obs.motion_score = 0.50f;
+    uint16_t recovery_counter = 0;
 
     adapt_decision_t dec;
-    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_ACTIVE, &obs, &dec);
+    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_ACTIVE, &obs, &dec,
+                               &recovery_counter);
     CHECK(!dec.change_state,
-          "already in SENSE_ACTIVE — no redundant change_state");
+          "already in SENSE_ACTIVE -- no redundant change_state");
 }
 
 static void test_null_safety(void) {
     printf("test: NULL args are no-ops (no crash)\n");
     adapt_decision_t dec = {0};
-    adaptive_controller_decide(NULL, ADAPT_STATE_SENSE_IDLE, NULL, &dec);
-    /* if we got here, no segfault — pass */
+    uint16_t recovery_counter = 0;
+    adaptive_controller_decide(NULL, ADAPT_STATE_SENSE_IDLE, NULL, &dec,
+                               &recovery_counter);
+    /* if we got here, no segfault -- pass */
     g_pass++;
     printf("  OK\n");
 }
+
+/* ---- RuView#1401: DEGRADED recovery tests ---- */
+
+static void test_degraded_recovery_after_sustained_yield(void) {
+    printf("test: DEGRADED exits after sustained healthy yield (#1401)\n");
+    adapt_config_t cfg = default_cfg();
+    cfg.degraded_recovery_ticks = 5;  /* short threshold for test speed */
+    adapt_observation_t obs = quiet_obs();
+    obs.pkt_yield_per_sec = 30;  /* healthy */
+    uint16_t recovery_counter = 0;
+
+    adapt_decision_t dec;
+
+    /* Simulate 4 healthy ticks while in DEGRADED -- should stay DEGRADED. */
+    for (int i = 0; i < 4; i++) {
+        adaptive_controller_decide(&cfg, ADAPT_STATE_DEGRADED, &obs, &dec,
+                                   &recovery_counter);
+        CHECK(!dec.change_state,
+              "should NOT exit DEGRADED before recovery threshold");
+        CHECK(recovery_counter == (uint16_t)(i + 1),
+              "recovery counter increments each healthy tick");
+    }
+
+    /* 5th healthy tick -- should exit DEGRADED. */
+    adaptive_controller_decide(&cfg, ADAPT_STATE_DEGRADED, &obs, &dec,
+                               &recovery_counter);
+    CHECK(dec.change_state, "should exit DEGRADED on 5th healthy tick");
+    CHECK(dec.new_state == ADAPT_STATE_SENSE_IDLE,
+          "recovery target is SENSE_IDLE");
+    CHECK(recovery_counter == 0, "counter resets after successful recovery");
+}
+
+static void test_degraded_recovery_resets_on_yield_drop(void) {
+    printf("test: DEGRADED recovery counter resets if yield drops again\n");
+    adapt_config_t cfg = default_cfg();
+    cfg.degraded_recovery_ticks = 10;
+    uint16_t recovery_counter = 0;
+    adapt_decision_t dec;
+
+    /* 7 healthy ticks -- building toward recovery. */
+    adapt_observation_t obs_healthy = quiet_obs();
+    obs_healthy.pkt_yield_per_sec = 20;
+    for (int i = 0; i < 7; i++) {
+        adaptive_controller_decide(&cfg, ADAPT_STATE_DEGRADED, &obs_healthy,
+                                   &dec, &recovery_counter);
+    }
+    CHECK(recovery_counter == 7, "counter at 7 after 7 healthy ticks");
+
+    /* Yield drops again -- counter must reset. */
+    adapt_observation_t obs_bad = quiet_obs();
+    obs_bad.pkt_yield_per_sec = 2;  /* below min_pkt_yield */
+    adaptive_controller_decide(&cfg, ADAPT_STATE_DEGRADED, &obs_bad, &dec,
+                               &recovery_counter);
+    CHECK(recovery_counter == 0, "counter resets when yield drops in DEGRADED");
+    CHECK(!dec.change_state,
+          "stays in DEGRADED when yield drops (already there)");
+}
+
+static void test_degraded_recovery_coherence_drop_resets(void) {
+    printf("test: DEGRADED recovery resets on coherence loss\n");
+    adapt_config_t cfg = default_cfg();
+    cfg.degraded_recovery_ticks = 5;
+    uint16_t recovery_counter = 0;
+    adapt_decision_t dec;
+
+    /* 3 healthy ticks. */
+    adapt_observation_t obs = quiet_obs();
+    for (int i = 0; i < 3; i++) {
+        adaptive_controller_decide(&cfg, ADAPT_STATE_DEGRADED, &obs, &dec,
+                                   &recovery_counter);
+    }
+    CHECK(recovery_counter == 3, "counter at 3");
+
+    /* Coherence drops -- counter resets. */
+    obs.node_coherence = 0.10f;
+    adaptive_controller_decide(&cfg, ADAPT_STATE_DEGRADED, &obs, &dec,
+                               &recovery_counter);
+    CHECK(recovery_counter == 0, "counter resets on coherence loss");
+}
+
+static void test_degraded_recovery_default_threshold(void) {
+    printf("test: DEGRADED uses default 15 ticks when config is 0\n");
+    adapt_config_t cfg = default_cfg();
+    cfg.degraded_recovery_ticks = 0;  /* should fall back to default 15 */
+    adapt_observation_t obs = quiet_obs();
+    uint16_t recovery_counter = 0;
+    adapt_decision_t dec;
+
+    /* 14 ticks -- should not exit. */
+    for (int i = 0; i < 14; i++) {
+        adaptive_controller_decide(&cfg, ADAPT_STATE_DEGRADED, &obs, &dec,
+                                   &recovery_counter);
+    }
+    CHECK(!dec.change_state, "14 ticks < default 15 -- stays DEGRADED");
+    CHECK(recovery_counter == 14, "counter at 14");
+
+    /* 15th tick -- should exit. */
+    adaptive_controller_decide(&cfg, ADAPT_STATE_DEGRADED, &obs, &dec,
+                               &recovery_counter);
+    CHECK(dec.change_state, "15th tick exits DEGRADED (default threshold)");
+    CHECK(dec.new_state == ADAPT_STATE_SENSE_IDLE, "exits to SENSE_IDLE");
+}
+
+static void test_degraded_no_false_recovery_on_normal_states(void) {
+    printf("test: recovery counter stays 0 when not in DEGRADED\n");
+    adapt_config_t cfg = default_cfg();
+    adapt_observation_t obs = quiet_obs();
+    uint16_t recovery_counter = 5;  /* leftover from previous DEGRADED */
+    adapt_decision_t dec;
+
+    /* Normal operation in SENSE_IDLE -- counter should be cleared. */
+    adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec,
+                               &recovery_counter);
+    CHECK(recovery_counter == 0, "counter zeroed when not in DEGRADED");
+}
+
+/* ---- Benchmark ---- */
 
 static void benchmark_decide(void) {
     printf("bench: adaptive_controller_decide() throughput\n");
     adapt_config_t cfg = default_cfg();
     adapt_observation_t obs = quiet_obs();
     adapt_decision_t dec;
+    uint16_t recovery_counter = 0;
 
     const int N = 10000000;
     struct timespec a, b;
@@ -186,13 +324,14 @@ static void benchmark_decide(void) {
     for (int i = 0; i < N; i++) {
         /* Vary input slightly so the compiler can't fold the call. */
         obs.motion_score = (i & 0xff) / 255.0f;
-        adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec);
+        adaptive_controller_decide(&cfg, ADAPT_STATE_SENSE_IDLE, &obs, &dec,
+                                   &recovery_counter);
     }
     clock_gettime(CLOCK_MONOTONIC, &b);
     double ns_per_call = ((b.tv_sec - a.tv_sec) * 1e9 +
                           (b.tv_nsec - a.tv_nsec)) / (double)N;
     printf("  %d calls, %.1f ns/call\n", N, ns_per_call);
-    /* Sanity: decide() is O(constant) — must be under 10us even on a
+    /* Sanity: decide() is O(constant) -- must be under 10us even on a
      * slow emulator. Real ESP32 will be ~100-300ns. */
     CHECK(ns_per_call < 10000.0, "decide() must be under 10us/call");
 }
@@ -209,6 +348,14 @@ int main(void) {
     test_empty_room_default_is_passive();
     test_hysteresis_no_flap();
     test_null_safety();
+
+    /* RuView#1401: DEGRADED recovery tests. */
+    test_degraded_recovery_after_sustained_yield();
+    test_degraded_recovery_resets_on_yield_drop();
+    test_degraded_recovery_coherence_drop_resets();
+    test_degraded_recovery_default_threshold();
+    test_degraded_no_false_recovery_on_normal_states();
+
     benchmark_decide();
 
     printf("\n=== result: %d pass, %d fail ===\n", g_pass, g_fail);


### PR DESCRIPTION
## Summary

Fixes #1401 — ESP32-S3 N16R8 boards entering DEGRADED state permanently with no recovery path.

## Problem

The adaptive controller DEGRADED state (state 8) had no exit mechanism. Once `pkt_yield_per_sec` dropped below `min_pkt_yield`, the board stayed in DEGRADED permanently — even if yield later recovered.

On N16R8 boards the pre-built binaries lacked PSRAM config, so CSI callbacks never fired, yield stayed at 0, and DEGRADED was immediate and permanent.

## Changes

### DEGRADED recovery with hysteresis (`adaptive_controller_decide.c`)

- If a board is in DEGRADED and yield recovers above `min_pkt_yield` for `degraded_recovery_ticks` consecutive fast-loop ticks (default 15 = ~3s at 200ms), it transitions back to `SENSE_IDLE`
- Counter resets on any yield drop mid-recovery, preventing flapping
- New config field `degraded_recovery_ticks` (Kconfig: `CONFIG_ADAPTIVE_DEGRADED_RECOVERY_TICKS`)

### N16R8 sdkconfig overlay (`sdkconfig.defaults.n16r8`)

- New overlay for ESP32-S3 WROOM-1 N16R8 modules (16MB flash, 8MB Octal PSRAM)
- Adds `CONFIG_SPIRAM=y`, `CONFIG_SPIRAM_MODE_OCT=y`, `CONFIG_SPIRAM_SPEED_80M=y`
- Disables display (no QSPI contention on these boards)

### Unit tests (`tests/host/test_adaptive_controller.c`)

- 5 new test cases covering recovery scenarios
- Updated existing tests for new function signature
- All 82 host assertions pass, 0 failures

## Testing

- **Host tests:** `make check` in `tests/host/` — 82 pass, 0 fail
- **Docker build:** `espressif/idf:v5.4` builds successfully with N16R8 overlay (binary: 920KB, 56% partition free)
- **Hardware:** Not tested on N16R8 boards — requesting reporter validation

## Files Changed

| File | Change |
|------|--------|
| `main/adaptive_controller.h` | Added `degraded_recovery_ticks` config field, updated `decide()` signature |
| `main/adaptive_controller_decide.c` | Recovery logic with hysteresis counter |
| `main/adaptive_controller.c` | Wired counter as module state, added recovery log |
| `sdkconfig.defaults.n16r8` | New overlay for N16R8 boards |
| `tests/host/test_adaptive_controller.c` | 5 new recovery tests, updated existing calls |
