### PR TITLE
fix: restrict WebSocket client-disconnect endpoint to admins (V-003)

### DIFF
--- a/archive/v1/src/api/routers/stream.py
+++ b/archive/v1/src/api/routers/stream.py
@@ -16,7 +16,8 @@ from src.api.dependencies import (
     get_stream_service,
     get_pose_service,
     get_current_user_ws,
-    require_auth
+    require_auth,
+    get_admin_user,
 )
 from src.api.websocket.connection_manager import connection_manager
 from src.services.stream_service import StreamService
@@ -436,11 +437,20 @@ async def get_connected_clients(
 @router.delete("/clients/{client_id}")
 async def disconnect_client(
     client_id: str,
-    current_user: Dict = Depends(require_auth)
+    current_user: Dict = Depends(get_admin_user)
 ):
-    """Disconnect a specific WebSocket client."""
+    """Disconnect a specific WebSocket client.
+
+    Authorization: admin only (V-003). WebSocket connections are anonymous
+    -- no per-connection owner is recorded (see ConnectionManager.connect /
+    WebSocketConnection.get_info), so this destructive operator action is
+    restricted to admins rather than owner-scoped. Previously any
+    authenticated user could disconnect any client by id. If per-user WS
+    authentication is added later (see PRs #1396 / #1400), broaden this to
+    "owner or admin".
+    """
     try:
-        logger.info(f"Disconnecting client {client_id} by user: {current_user['id']}")
+        logger.info(f"Disconnecting client {client_id} by admin: {current_user['id']}")
         
         success = await connection_manager.disconnect(client_id)
         

--- a/archive/v1/tests/integration/test_stream_disconnect_authz.py
+++ b/archive/v1/tests/integration/test_stream_disconnect_authz.py
@@ -1,0 +1,71 @@
+"""
+Regression test for V-003 — DELETE /clients/{client_id} must be admin-only.
+
+Background
+----------
+`archive/v1/src/api/routers/stream.py::disconnect_client` previously depended on
+`require_auth`, so ANY authenticated user could disconnect ANY WebSocket client by
+id — there is no per-connection owner recorded (WS connections are anonymous; see
+`WebSocketConnection.get_info`), so ownership cannot be checked. The fix restricts
+the endpoint to admins by depending on `get_admin_user`.
+
+These tests assert the *authorization* property (admin vs non-admin), which is the
+property V-003 is about — unlike an authentication-only test, which would pass even
+against the broken behaviour.
+
+Injection point: both `require_auth` and `get_admin_user` resolve through
+`get_current_active_user`, so overriding that single dependency injects the desired
+identity without real JWT plumbing.
+
+Note: designed for the v1 test harness (needs fastapi + the `src` package importable).
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.routers.stream import router
+from src.api.dependencies import get_current_active_user
+
+
+ADMIN = {"id": "admin-1", "username": "admin", "is_admin": True, "is_active": True}
+USER = {"id": "user-1", "username": "alice", "is_admin": False, "is_active": True}
+
+
+def _app_as(user):
+    """Build a minimal app exposing the stream router as the given identity."""
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_active_user] = lambda: user
+    return app
+
+
+def test_non_admin_cannot_disconnect_client():
+    """V-003: a non-admin authenticated user is rejected BEFORE any disconnect."""
+    app = _app_as(USER)
+    with patch("src.api.routers.stream.connection_manager") as cm:
+        cm.disconnect = AsyncMock(return_value=True)
+        resp = TestClient(app).delete("/clients/victim-client-id")
+    assert resp.status_code == 403
+    cm.disconnect.assert_not_called()
+
+
+def test_admin_can_disconnect_client():
+    """An admin (operator) can disconnect any client."""
+    app = _app_as(ADMIN)
+    with patch("src.api.routers.stream.connection_manager") as cm:
+        cm.disconnect = AsyncMock(return_value=True)
+        resp = TestClient(app).delete("/clients/some-client-id")
+    assert resp.status_code == 200
+    cm.disconnect.assert_awaited_once_with("some-client-id")
+
+
+def test_admin_disconnect_missing_client_returns_404():
+    """Admin disconnecting an unknown client gets 404 (not 500, not 403)."""
+    app = _app_as(ADMIN)
+    with patch("src.api.routers.stream.connection_manager") as cm:
+        cm.disconnect = AsyncMock(return_value=False)
+        resp = TestClient(app).delete("/clients/ghost")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Alternative fix for **V-003** (`DELETE /clients/{client_id}` authorization) — see the discussion on #1392.

`disconnect_client` in `archive/v1/src/api/routers/stream.py` required authentication but no authorization, so any authenticated user could disconnect **any** WebSocket client by id.

## Why not per-client ownership

#1392 adds an ownership check comparing `client_info["user_id"]` to the caller. But WebSocket connections carry no user identity:

- `ConnectionManager.connect()` records only a random `uuid4` — no user.
- `WebSocketConnection.get_info()` exposes no `user_id`.
- `get_connected_clients()` returns those info dicts.

So `client_info.get("user_id")` is always `None`, and `None != current_user["id"]` is always true — the check returns **403 to everyone** and breaks the endpoint for all callers, admins included. Per-connection ownership isn't possible until WS auth (#1396 / #1400) records a user at connect time.

## This fix

Gate the endpoint on admin using the existing `get_admin_user` dependency (already used across `dependencies.py`). This is a destructive operator action, so admin-only is appropriate; it closes V-003 and keeps the endpoint working for operators.

```diff
-    current_user: Dict = Depends(require_auth)
+    current_user: Dict = Depends(get_admin_user)
```

## Test

Adds `archive/v1/tests/integration/test_stream_disconnect_authz.py`, which asserts the **authorization** property (the actual vulnerability): non-admin → 403 (disconnect never called), admin → 200, admin + unknown client → 404.

## Note

This intentionally narrows the endpoint to admins — ordinary authenticated users can no longer disconnect clients, since connections have no owner to scope against. If per-user WS auth lands (#1396 / #1400), this can broaden to "owner or admin".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
