### PR TITLE
fix(deps): complete the fastapi/python-multipart CVE floor bump (pyproject.toml + setup.py)

### DIFF
--- a/archive/v1/setup.py
+++ b/archive/v1/setup.py
@@ -44,7 +44,7 @@ def get_requirements():
     
     # Default requirements (should match pyproject.toml)
     return [
-        "fastapi>=0.104.0",
+        "fastapi>=0.115.0",
         "uvicorn[standard]>=0.24.0",
         "pydantic>=2.5.0",
         "pydantic-settings>=2.1.0",
@@ -69,7 +69,7 @@ def get_requirements():
         "click>=8.1.0",
         "rich>=13.6.0",
         "typer>=0.9.0",
-        "python-multipart>=0.0.6",
+        "python-multipart>=0.0.20",
         "python-jose[cryptography]>=3.3.0",
         "passlib[bcrypt]>=1.7.4",
         "python-dotenv>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     # Core framework
-    "fastapi>=0.104.0",
+    "fastapi>=0.115.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
@@ -80,7 +80,7 @@ dependencies = [
     "click>=8.1.0",
     "rich>=13.6.0",
     "typer>=0.9.0",
-    "python-multipart>=0.0.6",
+    "python-multipart>=0.0.20",
     "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",
     "python-dotenv>=1.0.0",


### PR DESCRIPTION
## Summary

Completes the CVE floor bump started in #1409.

#1409 raised `fastapi>=0.115.0` and `python-multipart>=0.0.20` in `requirements.txt` to close 7 HIGH CVEs (Starlette CORS/routing + `python-multipart` ReDoS). But the same two dependencies were left at the vulnerable floors in the other two manifests, so a wheel build / `pip install .` can still resolve vulnerable versions:

- `pyproject.toml` — `fastapi>=0.104.0` (line 46), `python-multipart>=0.0.6` (line 83)
- `archive/v1/setup.py` — `fastapi>=0.104.0` (line 47), `python-multipart>=0.0.6` (line 72)

## Change

Bumps those four floors to match #1409:

- `fastapi>=0.104.0` → `>=0.115.0`
- `python-multipart>=0.0.6` → `>=0.0.20`

No upper caps exist anywhere, so nothing conflicts, and both are compatible with the pinned pydantic-v2 stack. Complementary to #1409 (which covers `requirements.txt`) — merging both fully closes the CVEs across every install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
