### PR TITLE
test(health): make the event-loop starvation test actually catch the regression

### DIFF
--- a/archive/v1/tests/unit/test_health_concurrency.py
+++ b/archive/v1/tests/unit/test_health_concurrency.py
@@ -28,11 +28,15 @@ async def run_test():
     # Let ticker run for a few ticks
     await asyncio.sleep(0.3)
     
-    print("Calling get_system_metrics offloaded to background thread...")
+    print("Calling get_system_metrics directly on the event loop...")
     start_time = time.time()
-    
-    # Query system metrics using to_thread (simulating FastAPI request)
-    metrics = await asyncio.to_thread(get_system_metrics)
+
+    # Call get_system_metrics() directly on the event loop -- NOT via
+    # asyncio.to_thread. A regressed blocking psutil.cpu_percent(interval=1)
+    # would then freeze the loop (and the ticker) and be caught. The
+    # production endpoints wrap this in to_thread; this unit test targets the
+    # non-blocking property of the function itself.
+    metrics = get_system_metrics()
     
     duration = time.time() - start_time
     print(f"get_system_metrics took: {duration:.4f}s")


### PR DESCRIPTION
## Summary

`archive/v1/tests/unit/test_health_concurrency.py` on `main` is meant to guard against the health/metrics event-loop starvation regression — but as written it can't catch it.

It calls the metric function via `await asyncio.to_thread(get_system_metrics)` (line 35). Because that offloads to a worker thread, a regressed blocking `psutil.cpu_percent(interval=1)` would stall only that thread, not the event loop — the ticker gaps stay ~0.1s and the `max_gap < 0.6` assertion passes even against unfixed code.

## Change

Call `get_system_metrics()` directly on the event loop (no `to_thread`). Now a blocking `interval=1` freezes the concurrent ticker → `max_gap` exceeds ~1s → the assertion fails; the fixed non-blocking `interval=None` keeps gaps small → it passes. The test becomes discriminating.

The production endpoints (`health_check`, `get_health_metrics`) legitimately wrap this call in `asyncio.to_thread` — this unit test targets the non-blocking property of `get_system_metrics` itself.

Context: this is the real remaining issue behind #1337, whose production change and this test file both already landed on `main` (its diff is against a stale merge-base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
