### PR TITLE
fix(pose): Live-Demo black canvas + ghost skeletons (split from #1381, no depth bundle)

### DIFF
--- a/ui/utils/pose-renderer.js
+++ b/ui/utils/pose-renderer.js
@@ -252,7 +252,7 @@ export class PoseRenderer {
       const hue = (personIdx * 60) % 360; // different hue per person
 
       person.keypoints.forEach((kp) => {
-        if (kp.confidence <= this.config.keypointConfidenceThreshold) return;
+        if (kp.confidence < this.config.keypointConfidenceThreshold) return;
 
         const cx = this.scaleX(kp.x);
         const cy = this.scaleY(kp.y);
@@ -306,7 +306,7 @@ export class PoseRenderer {
       bodyParts.forEach((part) => {
         // Collect valid keypoints for this body part
         const points = part.kps
-          .filter(i => kps[i] && kps[i].confidence > this.config.keypointConfidenceThreshold)
+          .filter(i => kps[i] && kps[i].confidence >= this.config.keypointConfidenceThreshold)
           .map(i => ({ x: this.scaleX(kps[i].x), y: this.scaleY(kps[i].y) }));
 
         if (points.length < 2) return;
@@ -354,8 +354,8 @@ export class PoseRenderer {
       const keypointB = keypoints[pointB];
 
       if (keypointA && keypointB && 
-          keypointA.confidence > this.config.keypointConfidenceThreshold &&
-          keypointB.confidence > this.config.keypointConfidenceThreshold) {
+          keypointA.confidence >= this.config.keypointConfidenceThreshold &&
+          keypointB.confidence >= this.config.keypointConfidenceThreshold) {
         
         const x1 = this.scaleX(keypointA.x);
         const y1 = this.scaleY(keypointA.y);
@@ -401,7 +401,7 @@ export class PoseRenderer {
   // Render keypoints
   renderKeypoints(keypoints, confidence, enhancedMode = false) {
     keypoints.forEach((keypoint, index) => {
-      if (keypoint.confidence > this.config.keypointConfidenceThreshold) {
+      if (keypoint.confidence >= this.config.keypointConfidenceThreshold) {
         const x = this.scaleX(keypoint.x);
         const y = this.scaleY(keypoint.y);
         

--- a/v2/crates/wifi-densepose-sensing-server/src/tracker_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/tracker_bridge.rs
@@ -11,6 +11,24 @@ use wifi_densepose_signal::ruvsense::{TrackId, TrackLifecycleState, NUM_KEYPOINT
 
 use super::{BoundingBox, PersonDetection, PoseKeypoint};
 
+/// Pixels per metre for the pixel-space <-> world-space conversion at the
+/// tracker boundary.
+///
+/// `PersonDetection` keypoints are in image pixels (~0..800), but `PoseTracker`
+/// is tuned for world-space metres: `measurement_noise = 0.08 m`, the
+/// Mahalanobis gate, and the Kalman covariances all assume metre-scale inputs.
+/// Feeding raw pixels made the effective association gate ~1.5 px, so the
+/// natural per-frame jitter of a single person (±20 px) never matched its own
+/// track — every frame spawned a fresh track and the stale ones lingered as
+/// confirmed "ghost" skeletons stacked on top of each other (the reported
+/// "Persons: 4" for one real person, all piled at the centre).
+///
+/// Converting on the way in (px -> m) and back out (m -> px) runs the filter in
+/// the metre space it was designed for: a ±20 px jitter becomes 0.2 m (well
+/// inside the gate) while two genuinely distinct people 180 px apart become
+/// 1.8 m (well outside it). 100 px/m ⇒ an 800 px frame maps to an 8 m room.
+const PIXELS_PER_METER: f32 = 100.0;
+
 /// COCO-17 keypoint names in index order.
 const COCO_NAMES: [&str; 17] = [
     "nose",
@@ -44,23 +62,35 @@ fn keypoint_name_to_coco_index(name: &str) -> Option<usize> {
 /// For each person, maps named keypoints to COCO-17 positions. Unmapped slots are
 /// filled with the centroid of the mapped keypoints so the Kalman filter has a
 /// reasonable initial value rather than zeros.
-fn detections_to_tracker_keypoints(persons: &[PersonDetection]) -> Vec<[[f32; 3]; 17]> {
+///
+/// Returns positions **and** per-keypoint confidences. Unmapped (centroid-filled)
+/// slots get confidence `0.0`, which is what marks them as unobserved for bbox
+/// fitting and for the UI renderer — mapped slots carry the detector's real
+/// confidence so the skeleton survives the round-trip through the tracker.
+type TrackerKeypoints = (Vec<[[f32; 3]; 17]>, Vec<[f32; 17]>);
+
+fn detections_to_tracker_keypoints(persons: &[PersonDetection]) -> TrackerKeypoints {
     persons
         .iter()
         .map(|person| {
             let mut kps = [[0.0_f32; 3]; 17];
+            let mut confs = [0.0_f32; 17];
             let mut mapped_count = 0u32;
             let mut cx = 0.0_f32;
             let mut cy = 0.0_f32;
             let mut cz = 0.0_f32;
 
-            // First pass: place mapped keypoints and accumulate centroid
+            // First pass: place mapped keypoints and accumulate centroid.
+            // Pixels -> metres so the metre-tuned Kalman filter/gate behave.
+            let s = 1.0 / PIXELS_PER_METER;
             for kp in &person.keypoints {
                 if let Some(idx) = keypoint_name_to_coco_index(&kp.name) {
-                    kps[idx] = [kp.x as f32, kp.y as f32, kp.z as f32];
-                    cx += kp.x as f32;
-                    cy += kp.y as f32;
-                    cz += kp.z as f32;
+                    let (x, y, z) = (kp.x as f32 * s, kp.y as f32 * s, kp.z as f32 * s);
+                    kps[idx] = [x, y, z];
+                    confs[idx] = kp.confidence as f32;
+                    cx += x;
+                    cy += y;
+                    cz += z;
                     mapped_count += 1;
                 }
             }
@@ -84,12 +114,14 @@ fn detections_to_tracker_keypoints(persons: &[PersonDetection]) -> Vec<[[f32; 3]
             for i in 0..17 {
                 if !mapped[i] {
                     kps[i] = centroid;
+                    // Centroid-filled slot: never observed, so no confidence.
+                    confs[i] = 0.0;
                 }
             }
 
-            kps
+            (kps, confs)
         })
-        .collect()
+        .unzip()
 }
 
 /// Convert confirmed PoseTracker tracks back into server-side PersonDetection values.
@@ -112,15 +144,17 @@ pub fn tracker_to_person_detections(tracker: &PoseTracker) -> Vec<PersonDetectio
                 TrackLifecycleState::Terminated => 0.0,
             };
 
-            // Build keypoints from Kalman state
+            // Build keypoints from Kalman state. Metres -> pixels to undo the
+            // px->m scaling applied on the way into the tracker.
+            let inv = PIXELS_PER_METER as f64;
             let keypoints: Vec<PoseKeypoint> = (0..NUM_KEYPOINTS)
                 .map(|i| {
                     let pos = track.keypoints[i].position();
                     PoseKeypoint {
                         name: COCO_NAMES[i].to_string(),
-                        x: pos[0] as f64,
-                        y: pos[1] as f64,
-                        z: pos[2] as f64,
+                        x: pos[0] as f64 * inv,
+                        y: pos[1] as f64 * inv,
+                        z: pos[2] as f64 * inv,
                         confidence: track.keypoints[i].confidence as f64,
                     }
                 })
@@ -159,14 +193,16 @@ pub fn tracker_to_person_detections(tracker: &PoseTracker) -> Vec<PersonDetectio
                     height: (max_y - min_y).max(0.01),
                 }
             } else {
-                // No observed keypoints — use a default bbox at centroid
+                // No observed keypoints — use a default bbox at centroid.
+                // Pixel-space, human-sized (~100x200 px), matching the keypoint
+                // coordinate space so a fallback never collapses to a point.
                 let cx = keypoints.iter().map(|k| k.x).sum::<f64>() / keypoints.len() as f64;
                 let cy = keypoints.iter().map(|k| k.y).sum::<f64>() / keypoints.len() as f64;
                 BoundingBox {
-                    x: cx - 0.3,
-                    y: cy - 0.5,
-                    width: 0.6,
-                    height: 1.0,
+                    x: cx - 50.0,
+                    y: cy - 100.0,
+                    width: 100.0,
+                    height: 200.0,
                 }
             };
 
@@ -214,8 +250,8 @@ pub fn tracker_update(
         return tracker_to_person_detections(tracker);
     }
 
-    // Convert detections to f32 keypoint arrays
-    let all_keypoints = detections_to_tracker_keypoints(&persons);
+    // Convert detections to f32 keypoint arrays (positions + per-keypoint confidence)
+    let (all_keypoints, all_confidences) = detections_to_tracker_keypoints(&persons);
 
     // Compute centroids for each detection
     let centroids: Vec<[f32; 3]> = all_keypoints
@@ -294,7 +330,13 @@ pub fn tracker_update(
     for (det_idx, track_id_opt) in matched.iter().enumerate() {
         if let Some(track_id) = track_id_opt {
             if let Some(track) = tracker.find_track_mut(*track_id) {
-                track.update_keypoints(&all_keypoints[det_idx], 0.08, 1.0, timestamp_us);
+                track.update_keypoints(
+                    &all_keypoints[det_idx],
+                    &all_confidences[det_idx],
+                    0.08,
+                    1.0,
+                    timestamp_us,
+                );
             }
         }
     }
@@ -302,7 +344,11 @@ pub fn tracker_update(
     // Create new tracks for unmatched detections
     for (det_idx, track_id_opt) in matched.iter().enumerate() {
         if track_id_opt.is_none() {
-            tracker.create_track(&all_keypoints[det_idx], timestamp_us);
+            tracker.create_track(
+                &all_keypoints[det_idx],
+                &all_confidences[det_idx],
+                timestamp_us,
+            );
         }
     }
 
@@ -378,24 +424,36 @@ mod tests {
             ],
         );
 
-        let result = detections_to_tracker_keypoints(&[person]);
-        assert_eq!(result.len(), 1);
+        let (positions, confidences) = detections_to_tracker_keypoints(&[person]);
+        assert_eq!(positions.len(), 1);
+        assert_eq!(confidences.len(), 1);
 
-        let kps = &result[0];
+        let kps = &positions[0];
+        let confs = &confidences[0];
 
-        // Mapped keypoints should have correct values
-        assert!((kps[0][0] - 1.0).abs() < 1e-5); // nose x
-        assert!((kps[0][1] - 2.0).abs() < 1e-5); // nose y
-        assert!((kps[0][2] - 0.5).abs() < 1e-5); // nose z
+        // Positions are scaled px -> m by 1/PIXELS_PER_METER on the way in.
+        let s = 1.0 / PIXELS_PER_METER;
 
-        assert!((kps[5][0] - 0.8).abs() < 1e-5); // left_shoulder x
-        assert!((kps[6][0] - 1.2).abs() < 1e-5); // right_shoulder x
+        // Mapped keypoints should have correct (scaled) values
+        assert!((kps[0][0] - 1.0 * s).abs() < 1e-6); // nose x
+        assert!((kps[0][1] - 2.0 * s).abs() < 1e-6); // nose y
+        assert!((kps[0][2] - 0.5 * s).abs() < 1e-6); // nose z
 
-        // Unmapped keypoints should be at centroid of mapped keypoints
-        // centroid = ((1.0+0.8+1.2)/3, (2.0+2.5+2.5)/3, (0.5+0.4+0.6)/3)
-        let cx = (1.0 + 0.8 + 1.2) / 3.0;
-        let cy = (2.0 + 2.5 + 2.5) / 3.0;
-        let cz = (0.5 + 0.4 + 0.6) / 3.0;
+        assert!((kps[5][0] - 0.8 * s).abs() < 1e-6); // left_shoulder x
+        assert!((kps[6][0] - 1.2 * s).abs() < 1e-6); // right_shoulder x
+
+        // Mapped keypoints carry the detector's confidence (make_keypoint sets
+        // it to 0.9); unmapped/centroid-filled slots must be exactly 0.0.
+        assert!(confs[0] > 0.0, "mapped nose must be observed");
+        assert!(confs[5] > 0.0, "mapped left_shoulder must be observed");
+        assert!(confs[6] > 0.0, "mapped right_shoulder must be observed");
+        assert_eq!(confs[1], 0.0, "unmapped left_eye must be unobserved");
+
+        // Unmapped keypoints should be at centroid of mapped keypoints (scaled)
+        // centroid = ((1.0+0.8+1.2)/3, (2.0+2.5+2.5)/3, (0.5+0.4+0.6)/3) * s
+        let cx = (1.0 + 0.8 + 1.2) / 3.0 * s;
+        let cy = (2.0 + 2.5 + 2.5) / 3.0 * s;
+        let cz = (0.5 + 0.4 + 0.6) / 3.0 * s;
 
         // left_eye (index 1) should be at centroid
         assert!((kps[1][0] - cx).abs() < 1e-4);
@@ -437,6 +495,116 @@ mod tests {
         // All three updates should return the same track ID
         assert_eq!(id1, id2, "Track ID should be stable across updates");
         assert_eq!(id2, id3, "Track ID should be stable across updates");
+    }
+
+    /// Build a full COCO-17 person centered at pixel `cx`, roughly the shape
+    /// `derive_single_person_pose` emits (torso ~100px wide, ~210px tall).
+    fn make_person_at(id: u32, cx: f64) -> PersonDetection {
+        let offsets: [(f64, f64); 17] = [
+            (0.0, -80.0),
+            (-8.0, -88.0),
+            (8.0, -88.0),
+            (-16.0, -82.0),
+            (16.0, -82.0),
+            (-30.0, -50.0),
+            (30.0, -50.0),
+            (-45.0, -15.0),
+            (45.0, -15.0),
+            (-50.0, 20.0),
+            (50.0, 20.0),
+            (-20.0, 20.0),
+            (20.0, 20.0),
+            (-22.0, 70.0),
+            (22.0, 70.0),
+            (-24.0, 120.0),
+            (24.0, 120.0),
+        ];
+        let kps = COCO_NAMES
+            .iter()
+            .zip(offsets.iter())
+            .map(|(name, (dx, dy))| PoseKeypoint {
+                name: name.to_string(),
+                x: cx + dx,
+                y: 240.0 + dy,
+                z: 0.0,
+                confidence: 0.5,
+            })
+            .collect();
+        make_person(id, kps)
+    }
+
+    /// Regression: three people generated far apart in pixel-space must stay
+    /// spatially separated after passing through the tracker across many
+    /// frames. Before the tracker was fed pixel-space centroids through a
+    /// gate/noise model tuned for metres, tracks churned and collapsed toward
+    /// the centre, so the UI drew several skeletons stacked on top of each
+    /// other. See the "tudo em cima de tudo" report.
+    #[test]
+    fn test_multi_person_stay_separated() {
+        let mut tracker = PoseTracker::new();
+        let mut last_instant: Option<Instant> = None;
+
+        let centers = [140.0_f64, 320.0, 500.0];
+        let mut out = vec![];
+        // Run enough frames for tracks to confirm (Active) and settle.
+        for _ in 0..15 {
+            let persons: Vec<PersonDetection> = centers
+                .iter()
+                .enumerate()
+                .map(|(i, &cx)| make_person_at(i as u32, cx))
+                .collect();
+            out = tracker_update(&mut tracker, &mut last_instant, persons);
+        }
+
+        // Each input person must be represented by a distinct tracked skeleton
+        // near its true centre, not merged into a central blob.
+        let centroid_x = |p: &PersonDetection| -> f64 {
+            p.keypoints.iter().map(|k| k.x).sum::<f64>() / p.keypoints.len() as f64
+        };
+        let mut xs: Vec<f64> = out.iter().map(centroid_x).collect();
+        xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        assert_eq!(
+            out.len(),
+            3,
+            "expected 3 tracked persons, got {} (churn/merge)",
+            out.len()
+        );
+        // Adjacent centroids should stay ~180px apart; allow drift but reject
+        // collapse (they must not all pile within a narrow band).
+        for w in xs.windows(2) {
+            assert!(
+                w[1] - w[0] > 90.0,
+                "tracked persons collapsed together: centroids {xs:?}"
+            );
+        }
+    }
+
+    /// Regression: a single jittering person must stay ONE track, not spawn a
+    /// pile of ghosts. The simulator emits ~1 person whose pixel centroid
+    /// jitters ±20 px frame-to-frame; with the tracker fed raw pixels the
+    /// association gate was ~1.5 px, so every frame minted a fresh track and
+    /// the UI showed "Persons: 4+" all stacked at the centre. Scaling px->m at
+    /// the boundary keeps the jitter (0.2 m) well inside the gate.
+    #[test]
+    fn test_single_jittering_person_stays_one_track() {
+        let mut tracker = PoseTracker::new();
+        let mut last_instant: Option<Instant> = None;
+
+        // Deterministic pseudo-jitter around x = 300 px, amplitude ~±20 px.
+        let mut out = vec![];
+        for f in 0..30 {
+            let jitter = ((f as f64 * 1.9).sin() * 20.0).round();
+            let person = make_person_at(0, 300.0 + jitter);
+            out = tracker_update(&mut tracker, &mut last_instant, vec![person]);
+        }
+
+        assert_eq!(
+            out.len(),
+            1,
+            "one jittering person must yield exactly one tracked skeleton, got {} ghosts",
+            out.len()
+        );
     }
 
     /// Regression test for #420 (ADR-082): tracks that have transitioned to

--- a/v2/crates/wifi-densepose-signal/src/ruvsense/pose_tracker.rs
+++ b/v2/crates/wifi-densepose-signal/src/ruvsense/pose_tracker.rs
@@ -278,15 +278,23 @@ pub struct PoseTrack {
 
 impl PoseTrack {
     /// Create a new tentative track from a detection.
+    ///
+    /// `keypoint_confidences` carries the per-keypoint measurement confidence
+    /// from the detector. Slots the detector did not observe must be passed as
+    /// `0.0` — downstream consumers (bbox fitting, the UI renderer) treat
+    /// confidence `0.0` as "unobserved" and skip those joints.
     pub fn new(
         id: TrackId,
         keypoint_positions: &[[f32; 3]; NUM_KEYPOINTS],
+        keypoint_confidences: &[f32; NUM_KEYPOINTS],
         timestamp_us: u64,
         embedding_dim: usize,
     ) -> Self {
         let keypoints = std::array::from_fn(|i| {
             let [x, y, z] = keypoint_positions[i];
-            KeypointState::new(x, y, z)
+            let mut kp = KeypointState::new(x, y, z);
+            kp.confidence = keypoint_confidences[i];
+            kp
         });
 
         Self {
@@ -343,12 +351,22 @@ impl PoseTrack {
     pub fn update_keypoints(
         &mut self,
         measurements: &[[f32; 3]; NUM_KEYPOINTS],
+        confidences: &[f32; NUM_KEYPOINTS],
         measurement_noise: f32,
         noise_multiplier: f32,
         timestamp_us: u64,
     ) {
-        for (kp, meas) in self.keypoints.iter_mut().zip(measurements.iter()) {
+        for ((kp, meas), conf) in self
+            .keypoints
+            .iter_mut()
+            .zip(measurements.iter())
+            .zip(confidences.iter())
+        {
             kp.update(meas, measurement_noise, noise_multiplier);
+            // Carry the measurement confidence onto the filtered state. Without
+            // this the Kalman state keeps its `0.0` init value forever and every
+            // consumer treats the joint as unobserved.
+            kp.confidence = *conf;
         }
 
         self.time_since_update = 0;
@@ -582,12 +600,19 @@ impl PoseTracker {
     pub fn create_track(
         &mut self,
         keypoints: &[[f32; 3]; NUM_KEYPOINTS],
+        confidences: &[f32; NUM_KEYPOINTS],
         timestamp_us: u64,
     ) -> TrackId {
         let id = TrackId::new(self.next_id);
         self.next_id += 1;
 
-        let track = PoseTrack::new(id, keypoints, timestamp_us, self.config.embedding_dim);
+        let track = PoseTrack::new(
+            id,
+            keypoints,
+            confidences,
+            timestamp_us,
+            self.config.embedding_dim,
+        );
         self.tracks.push(track);
         id
     }
@@ -1069,6 +1094,11 @@ mod tests {
         [[0.0, 0.0, 0.0]; NUM_KEYPOINTS]
     }
 
+    /// All keypoints observed with full confidence.
+    fn full_confidences() -> [f32; NUM_KEYPOINTS] {
+        [1.0; NUM_KEYPOINTS]
+    }
+
     #[allow(dead_code)]
     fn offset_positions(offset: f32) -> [[f32; 3]; NUM_KEYPOINTS] {
         std::array::from_fn(|i| [offset + i as f32 * 0.1, offset, 0.0])
@@ -1144,7 +1174,7 @@ mod tests {
     #[test]
     fn track_creation() {
         let positions = zero_positions();
-        let track = PoseTrack::new(TrackId(0), &positions, 1000, 128);
+        let track = PoseTrack::new(TrackId(0), &positions, &full_confidences(), 1000, 128);
         assert_eq!(track.id, TrackId(0));
         assert_eq!(track.lifecycle, TrackLifecycleState::Tentative);
         assert_eq!(track.embedding.len(), 128);
@@ -1152,21 +1182,52 @@ mod tests {
         assert_eq!(track.consecutive_hits, 1);
     }
 
+    /// Regression: per-keypoint confidence must survive creation and update.
+    ///
+    /// It previously did not — `KeypointState::confidence` kept its `0.0` init
+    /// value forever, so every consumer downstream (bbox fitting, the UI
+    /// renderer) saw all 17 joints as unobserved and drew nothing.
+    #[test]
+    fn track_preserves_keypoint_confidence() {
+        let positions = zero_positions();
+        let mut confidences = [0.0_f32; NUM_KEYPOINTS];
+        // Mixed: some observed, one explicitly unobserved.
+        for (i, c) in confidences.iter_mut().enumerate() {
+            *c = if i == 3 { 0.0 } else { 0.5 + (i as f32) * 0.01 };
+        }
+
+        let mut track = PoseTrack::new(TrackId(0), &positions, &confidences, 0, 128);
+        for (i, kp) in track.keypoints.iter().enumerate() {
+            assert_eq!(kp.confidence, confidences[i], "creation lost kp {i}");
+        }
+        assert!(
+            track.keypoints.iter().any(|k| k.confidence > 0.0),
+            "at least one keypoint must be observed"
+        );
+
+        // A measurement update must refresh confidence, not freeze the initial one.
+        let updated = [0.9_f32; NUM_KEYPOINTS];
+        track.update_keypoints(&positions, &updated, 0.08, 1.0, 100);
+        for (i, kp) in track.keypoints.iter().enumerate() {
+            assert_eq!(kp.confidence, 0.9, "update lost kp {i}");
+        }
+    }
+
     #[test]
     fn track_birth_gate() {
         let positions = zero_positions();
-        let mut track = PoseTrack::new(TrackId(0), &positions, 0, 128);
+        let mut track = PoseTrack::new(TrackId(0), &positions, &full_confidences(), 0, 128);
         assert_eq!(track.lifecycle, TrackLifecycleState::Tentative);
 
         // First update: still tentative (need 2 hits)
-        track.update_keypoints(&positions, 0.08, 1.0, 100);
+        track.update_keypoints(&positions, &full_confidences(), 0.08, 1.0, 100);
         assert_eq!(track.lifecycle, TrackLifecycleState::Active);
     }
 
     #[test]
     fn track_loss_gate() {
         let positions = zero_positions();
-        let mut track = PoseTrack::new(TrackId(0), &positions, 0, 128);
+        let mut track = PoseTrack::new(TrackId(0), &positions, &full_confidences(), 0, 128);
         track.lifecycle = TrackLifecycleState::Active;
 
         // Predict without updates exceeding loss_misses
@@ -1183,7 +1244,7 @@ mod tests {
     #[test]
     fn track_centroid() {
         let positions: [[f32; 3]; NUM_KEYPOINTS] = std::array::from_fn(|_| [1.0, 2.0, 3.0]);
-        let track = PoseTrack::new(TrackId(0), &positions, 0, 128);
+        let track = PoseTrack::new(TrackId(0), &positions, &full_confidences(), 0, 128);
         let c = track.centroid();
         assert!((c[0] - 1.0).abs() < 1e-5);
         assert!((c[1] - 2.0).abs() < 1e-5);
@@ -1193,7 +1254,7 @@ mod tests {
     #[test]
     fn track_embedding_update() {
         let positions = zero_positions();
-        let mut track = PoseTrack::new(TrackId(0), &positions, 0, 4);
+        let mut track = PoseTrack::new(TrackId(0), &positions, &full_confidences(), 0, 4);
         let new_embed = vec![1.0, 2.0, 3.0, 4.0];
         track.update_embedding(&new_embed, 0.5);
         // EMA: 0.5 * 0.0 + 0.5 * new = new / 2
@@ -1206,7 +1267,7 @@ mod tests {
     fn tracker_create_and_find() {
         let mut tracker = PoseTracker::new();
         let positions = zero_positions();
-        let id = tracker.create_track(&positions, 1000);
+        let id = tracker.create_track(&positions, &full_confidences(), 1000);
         assert!(tracker.find_track(id).is_some());
         assert_eq!(tracker.active_count(), 1);
     }
@@ -1219,7 +1280,7 @@ mod tests {
             ..Default::default()
         });
         let positions = zero_positions();
-        let id = tracker.create_track(&positions, 0);
+        let id = tracker.create_track(&positions, &full_confidences(), 0);
 
         // Promote to active
         if let Some(t) = tracker.find_track_mut(id) {
@@ -1239,7 +1300,7 @@ mod tests {
     fn tracker_prune_terminated() {
         let mut tracker = PoseTracker::new();
         let positions = zero_positions();
-        let id = tracker.create_track(&positions, 0);
+        let id = tracker.create_track(&positions, &full_confidences(), 0);
         if let Some(t) = tracker.find_track_mut(id) {
             t.terminate();
         }
@@ -1311,7 +1372,7 @@ mod tests {
     fn assignment_cost_computation() {
         let mut tracker = PoseTracker::new();
         let positions = zero_positions();
-        let id = tracker.create_track(&positions, 0);
+        let id = tracker.create_track(&positions, &full_confidences(), 0);
 
         let track = tracker.find_track(id).unwrap();
         let cost = tracker.assignment_cost(track, &[0.0, 0.0, 0.0], &vec![0.0; 128]);
@@ -1324,7 +1385,7 @@ mod tests {
     #[test]
     fn torso_jitter_rms_stationary() {
         let positions = zero_positions();
-        let track = PoseTrack::new(TrackId(0), &positions, 0, 128);
+        let track = PoseTrack::new(TrackId(0), &positions, &full_confidences(), 0, 128);
         let jitter = track.torso_jitter_rms();
         assert!(
             jitter < 1e-5,
@@ -1350,7 +1411,7 @@ mod tests {
     #[test]
     fn track_terminate_prevents_lost() {
         let positions = zero_positions();
-        let mut track = PoseTrack::new(TrackId(0), &positions, 0, 128);
+        let mut track = PoseTrack::new(TrackId(0), &positions, &full_confidences(), 0, 128);
         track.terminate();
         assert_eq!(track.lifecycle, TrackLifecycleState::Terminated);
         track.mark_lost(); // Should not override Terminated


### PR DESCRIPTION
## Summary

This lands **only the pose-tracking fix** from #1381, split out from the rest of that PR.

#1381's pose fix is correct and well-tested, but it also bundles the entire ADR-271 depth-anything backend (identical to #1375) and an unrelated `vendor/ruvector` submodule bump — so it conflicts with #1375 and mixes an opaque submodule change into a bugfix. This PR carries just the three pose files, none of which are touched by #1375:

- `ui/utils/pose-renderer.js`
- `v2/crates/wifi-densepose-sensing-server/src/tracker_bridge.rs`
- `v2/crates/wifi-densepose-signal/src/ruvsense/pose_tracker.rs`

## The fix (as diagnosed in #1381)

- **Black canvas / skipped joints:** per-keypoint confidence was never set on `KeypointState`, so the tracker's bbox fit — which keeps only `confidence > 0.0` keypoints — collapsed to a degenerate fallback and the renderer skipped every joint. Confidence is now threaded through `PoseTrack` create/update; centroid-filled slots stay `0.0`.
- **Stacked "ghost" skeletons:** tracker input was compared in pixel units against metre-scaled gates; the tracker boundary now converts px↔m.
- **Renderer:** threshold comparisons go from strict (`>` / `<=`) to inclusive (`>=` / `<`) so observed joints at the `0.1` floor render while unobserved `0.0` joints stay hidden.

The confidence-roundtrip / multi-person-separation / single-person-no-churn regression tests #1381 added to these files are included.

## Note

The code and diagnosis are from #1381 — this only isolates them so the pose fix can land independently of the depth backend (#1375) and the submodule bump. Verified the three files carry no coupling to the depth-anything backend or the ruvector bump; CI will confirm the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
