### PR TITLE
fix(sensing-server): derive classification presence from motion_level so a moving person is not reported as an empty room

### DIFF
--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -5899,9 +5899,22 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     // Cross-node fusion: combine features from all active nodes.
                     let fused_features = fuse_multi_node_features(&features, &s.node_states);
 
+                    // Derive `presence` from the label rather than reading
+                    // `vitals.presence` directly, so the three classification
+                    // fields cannot contradict each other. `motion_level` above
+                    // reports "present_moving" whenever `vitals.motion` is set,
+                    // without consulting `vitals.presence` — a frame carrying
+                    // motion=1/presence=0 previously emitted
+                    // `{presence: false, motion_level: "present_moving"}`, and
+                    // every UI gates visibility on the boolean, so a moving
+                    // person rendered as an empty room. Motion implies presence.
+                    //
+                    // This matches the convention already used elsewhere:
+                    // `smooth_and_classify_node` (main.rs) and `csi.rs` both
+                    // derive presence as `label != "absent"`.
                     let mut classification = ClassificationInfo {
                         motion_level: motion_level.to_string(),
-                        presence: vitals.presence,
+                        presence: motion_level != "absent",
                         confidence: vitals.presence_score as f64,
                     };
 


### PR DESCRIPTION
Fixes the contradictory `classification` payload reported in #1442.

## Problem

On the multi-node ESP32 vitals path, the three `classification` fields are built from independent sources, so they can disagree:

```json
{"presence": false, "motion_level": "present_moving", "confidence": 1.0}
```

`motion_level` (`main.rs:5789`) reports `"present_moving"` whenever `vitals.motion` is set and never consults `vitals.presence`, while `presence` was read directly from `vitals.presence`. A frame carrying `motion=1, presence=0` therefore announced a moving person and an empty room in the same object.

Every UI gates visibility on the boolean — `ui/observatory/js/main.js:560` fades the whole scene when `!isPresent` — so an occupied room renders as empty while `motion_level` says someone is moving.

## Fix

Derive `presence` from the label so motion implies presence:

```rust
presence: motion_level != "absent",
```

This is the convention the codebase already uses everywhere else:

- `main.rs:923` — `presence: !matches!(ns.current_motion_level.as_str(), "absent")`
- `csi.rs:605` — `classification.presence = label != "absent"`

The vitals path was the outlier.

## Scope — what this does *not* do

Deliberately narrow. It makes the emitted payload self-consistent so UIs stop blanking on moving occupants. It does **not**:

- Change the multi-node confidence boost (`main.rs:5908`). Whether `confidence: 1.0` should be reachable while `presence` is false is a semantics call for maintainers — raised as a question in #1442, not answered here.
- Address the apparent anti-correlation between `vitals.presence` and `vitals.presence_score` noted in #1442 (confidence ≈ 0.48 when presence is true, 1.0 when false, suggesting a possible field-offset issue in the vitals decoder à la #1348). That needs someone with knowledge of the packet layout.
- Improve presence *accuracy*. #1440's controlled reproduction (AUC ≈ 0.58) is a separate, deeper problem.

## Verification

- `cargo check -p wifi-densepose-sensing-server --no-default-features` — passes, no new warnings.
- Behaviour observed on a live 4-node rig (2× ESP32-S3 + 2× ESP32-C6, firmware built from source at `main`, `ruvnet/wifi-densepose:latest`, all nodes 30–41 fps, `is_valid: true`). The contradictory frames in #1442 were captured from this setup.

I have **not** yet re-run the rig against a rebuilt server image to confirm the UI stops blanking — the change is a one-line consequence of the label, but I'd rather state that than imply an end-to-end verification I didn't perform. Happy to build and confirm if useful.

## Note on repository setup

`cargo check` fails from a fresh clone until `git submodule update --init` is run — five workspace members and vendored crates are submodules, and the failure surfaces as `failed to load manifest for dependency ...` rather than anything mentioning submodules. Possibly worth a line in the contributing docs; not addressed here.
