### PR TITLE
chore: republish wifi-densepose-vitals 0.3.3 to crates.io

### DIFF
--- a/v2/Cargo.lock
+++ b/v2/Cargo.lock
@@ -11572,7 +11572,7 @@ dependencies = [
 
 [[package]]
 name = "wifi-densepose-vitals"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "serde",

--- a/v2/crates/wifi-densepose-vitals/Cargo.toml
+++ b/v2/crates/wifi-densepose-vitals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wifi-densepose-vitals"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 description = "ESP32 CSI-grade vital sign extraction (ADR-021): heart rate and respiratory rate from WiFi Channel State Information"
 license.workspace = true


### PR DESCRIPTION
Published `wifi-densepose-vitals` 0.3.3 to crates.io — the previously-published 0.3.2 predated the #1449 HeartRateExtractor/BreathingExtractor fixes. This PR is the version-bump paper trail.

No other documented publish-order crate has unpublished changes right now: `wifi-densepose-sensing-server`/`-cli` remain blocked on the `ruview-auth` `publish = false` decision (#1439); `wifi-densepose-calibration` (the #1440 fix) was never part of the crates.io publish list.

64 tests passing, 0 failed.

Co-Authored-By: claude-flow <ruv@ruv.net>