### PR TITLE
chore: vendor ruvnet/metaharness as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,7 @@
 	path = v2/crates/worldgraph
 	url = https://github.com/ruvnet/worldgraph.git
 	branch = main
+[submodule "vendor/metaharness"]
+	path = vendor/metaharness
+	url = https://github.com/ruvnet/metaharness
+	branch = main


### PR DESCRIPTION
## Summary
- Adds `vendor/metaharness` (github.com/ruvnet/metaharness, pinned at `87b6c51` on `main`) alongside the repo's other `vendor/*` submodules (rufield, rvcsi, ruvector, sublinear-time-solver, midstream).
- MetaHarness is the real generator behind this repo's `harness/ruview/` (ADR-182) and `harness/homecore/` (ADR-285) — the latter already depends on the real `@metaharness/kernel@0.1.2` npm package. This vendors the source repo itself for local inspection/building of the kernel, `@metaharness/router` (cost-optimal model routing), and `@metaharness/darwin` ("Darwin Mode" self-evolving harness config).
- No wiring into any harness or crate in this PR — just the vendored source, per the explicit ask. Follow-up: minting a `wifi-densepose-sar`-specific harness using this tooling is a separate, larger piece of work.

## Test plan
- [x] `git submodule status vendor/metaharness` — clean, pinned to the fetched commit
- N/A — no code changes, submodule addition only