### PR TITLE
fix: crates.io publish-blocking manifest gaps (pointcloud license, nvsim-server version req)

### DIFF
--- a/v2/crates/nvsim-server/Cargo.toml
+++ b/v2/crates/nvsim-server/Cargo.toml
@@ -14,7 +14,7 @@ name = "nvsim-server"
 path = "src/main.rs"
 
 [dependencies]
-nvsim = { path = "../nvsim" }
+nvsim = { path = "../nvsim", version = "0.3.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/v2/crates/wifi-densepose-pointcloud/Cargo.toml
+++ b/v2/crates/wifi-densepose-pointcloud/Cargo.toml
@@ -3,6 +3,9 @@ name = "wifi-densepose-pointcloud"
 version = "0.1.0"
 edition = "2021"
 description = "Real-time dense point cloud from camera depth + WiFi CSI tomography"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "ruview-pointcloud"


### PR DESCRIPTION
## Summary
- `wifi-densepose-pointcloud`'s Cargo.toml had no `license`/`authors`/`repository` at all — crates.io rejects publish with "missing or empty metadata fields: license". Added the standard `.workspace = true` trio every other crate here uses.
- `nvsim-server`'s path dependency on `nvsim` had no version requirement — crates.io rejects "all dependencies must have a version requirement specified when publishing". Pinned to `nvsim = "0.3.1"`.

Found and fixed while publishing both crates to crates.io for the first time (part of a broader "publish outstanding crates" pass). Both now `cargo publish --dry-run` clean; `wifi-densepose-pointcloud v0.1.0` is already live on crates.io with this fix applied.

## Test plan
- [x] `cargo publish -p wifi-densepose-pointcloud --dry-run` — passes (was failing before)
- [x] `cargo publish -p nvsim-server --dry-run` — passes, correctly resolves `nvsim v0.3.1` from crates.io