### PR TITLE
fix: crates.io publish-blocking gaps in homecore-automation, homecore-hap

### DIFF
--- a/v2/crates/homecore-automation/Cargo.toml
+++ b/v2/crates/homecore-automation/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 
 [dependencies]
 # HOMECORE core — state machine, event bus, service registry, entity types
-homecore = { path = "../homecore" }
+homecore = { path = "../homecore", version = "0.1.0-alpha.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }

--- a/v2/crates/homecore-hap/Cargo.toml
+++ b/v2/crates/homecore-hap/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 license = "MIT"
 authors = ["rUv <ruv@ruv.net>", "HOMECORE Contributors"]
 description = "Fail-closed HomeKit Accessory Protocol network foundation for HOMECORE"
-repository = "https://github.com/ruvnet/wifi-densepose"
+repository = "https://github.com/ruvnet/RuView"
 
 [lib]
 name = "homecore_hap"
@@ -23,7 +23,7 @@ default = []
 hap-server = ["dep:httparse", "dep:mdns-sd"]
 
 [dependencies]
-homecore = { path = "../homecore" }
+homecore = { path = "../homecore", version = "0.1.0-alpha.0" }
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary
- `homecore-automation` and `homecore-hap` both path-depend on `homecore` with no version requirement — crates.io rejects "all dependencies must have a version requirement specified when publishing". Pinned both to `homecore = "0.1.0-alpha.0"`.
- `homecore-hap`'s `repository` field pointed at `github.com/ruvnet/wifi-densepose` (404) instead of `github.com/ruvnet/RuView`, inconsistent with every other `homecore-*` crate.

Found while publishing the full `homecore-*` batch to crates.io (all 9: `homecore`, `-api`, `-automation`, `-assist`, `-hap`, `-migrate`, `-plugins`, `-recorder`, `-server`, all `v0.1.0-alpha.0`).

## Test plan
- [x] `cargo publish -p homecore-automation --dry-run` / `cargo publish -p homecore-hap --dry-run` — both pass (were failing before)
- [x] Both crates already live on crates.io with this fix applied