### PR TITLE
docs: fix HF model card download path and publish expected files (#1481)

### DIFF
--- a/docs/huggingface/MODEL_CARD.md
+++ b/docs/huggingface/MODEL_CARD.md
@@ -14,7 +14,7 @@ tags:
   - ruvector
 language:
   - en
-library_name: onnxruntime
+library_name: safetensors
 pipeline_tag: other
 ---
 
@@ -116,12 +116,21 @@ Validated on real hardware (Apple M4 Pro + 2x ESP32-S3):
 
 ## Models in This Repo
 
+Files match what is currently published on
+[`ruvnet/wifi-densepose-pretrained`](https://huggingface.co/ruvnet/wifi-densepose-pretrained)
+(verified against the Hub tree).
+
 | File | Size | Use |
 |------|------|-----|
 | `model.safetensors` | 48 KB | Full contrastive encoder (128-dim embeddings) |
 | `model-q4.bin` | 8 KB | **Recommended** — 4-bit quantized, 8x compression |
 | `model-q2.bin` | 4 KB | Ultra-compact for ESP32 edge inference |
 | `model-q8.bin` | 16 KB | High quality 8-bit |
+| `model.rvf.jsonl` | ~1 KB | RVF JSONL manifest (sensing-server can convert) |
+| `csi-embed-v2.safetensors` | ~40 KB | v2 fp32 encoder (honest re-benchmark) |
+| `csi-embed-v2-int4.bin` | 4.56 KB | v2 4-bit encoder for ESP32 SRAM budget |
+| `csi-embed-v2.py` | <1 KB | `Enc` definition + loader for v2 weights |
+| `csi-embed-v2-metrics.json` | — | v2 metrics + quantization scales |
 | `presence-head.json` | 2.6 KB | Presence detection head (v1 "100%" retracted — single-class; #882) |
 | `node-1.json` | 21 KB | LoRA adapter for room/node 1 |
 | `node-2.json` | 21 KB | LoRA adapter for room/node 2 |
@@ -133,7 +142,7 @@ Validated on real hardware (Apple M4 Pro + 2x ESP32-S3):
 ```bash
 # Download models
 pip install huggingface_hub
-huggingface-cli download ruv/ruview --local-dir models/
+huggingface-cli download ruvnet/wifi-densepose-pretrained --local-dir models/
 
 # Use with RuView sensing pipeline
 git clone https://github.com/ruvnet/RuView.git
@@ -255,12 +264,13 @@ Built on these embeddings ([RuView](https://github.com/ruvnet/RuView)):
   author={rUv},
   year={2026},
   url={https://github.com/ruvnet/RuView},
-  note={Models: https://huggingface.co/ruv/ruview}
+  note={Models: https://huggingface.co/ruvnet/wifi-densepose-pretrained}
 }
 ```
 
 ## Links
 
+- **Models (Hugging Face)**: https://huggingface.co/ruvnet/wifi-densepose-pretrained
 - **GitHub**: https://github.com/ruvnet/RuView
 - **Cognitum Seed**: https://cognitum.one
 - **RuVector**: https://github.com/ruvnet/ruvector

--- a/scripts/publish-huggingface.py
+++ b/scripts/publish-huggingface.py
@@ -25,12 +25,20 @@ import sys
 from pathlib import Path
 
 EXPECTED_FILES = [
-    "pretrained-encoder.onnx",
-    "pretrained-heads.onnx",
-    "pretrained.rvf",
-    "room-profiles.json",
-    "collection-witness.json",
     "config.json",
+    "model.safetensors",
+    "model-q2.bin",
+    "model-q4.bin",
+    "model-q8.bin",
+    "model.rvf.jsonl",
+    "csi-embed-v2.safetensors",
+    "csi-embed-v2-int4.bin",
+    "csi-embed-v2.py",
+    "csi-embed-v2-metrics.json",
+    "presence-head.json",
+    "node-1.json",
+    "node-2.json",
+    "training-metrics.json",
     "README.md",
 ]
 

--- a/scripts/publish-huggingface.sh
+++ b/scripts/publish-huggingface.sh
@@ -58,12 +58,20 @@ fi
 
 # ---------- validate model files ----------
 EXPECTED_FILES=(
-  "pretrained-encoder.onnx"
-  "pretrained-heads.onnx"
-  "pretrained.rvf"
-  "room-profiles.json"
-  "collection-witness.json"
   "config.json"
+  "model.safetensors"
+  "model-q2.bin"
+  "model-q4.bin"
+  "model-q8.bin"
+  "model.rvf.jsonl"
+  "csi-embed-v2.safetensors"
+  "csi-embed-v2-int4.bin"
+  "csi-embed-v2.py"
+  "csi-embed-v2-metrics.json"
+  "presence-head.json"
+  "node-1.json"
+  "node-2.json"
+  "training-metrics.json"
   "README.md"
 )
 


### PR DESCRIPTION
## Summary

Follow-up to **#1481** (`docs/huggingface/MODEL_CARD.md` drifted from the Hub).

Most of the file table was already updated, but a few live hazards remained:

1. **Wrong download command** still used the non-existent Hub id `ruv/ruview`:
   ```bash
   huggingface-cli download ruv/ruview --local-dir models/
   ```
   That command cannot succeed. Updated to `ruvnet/wifi-densepose-pretrained` (matches the README and the live Hub repo).

2. **Citation** still linked `https://huggingface.co/ruv/ruview` → fixed.

3. **Models table** omitted published v2 artifacts (`csi-embed-v2.*`, `model.rvf.jsonl`) that are on the Hub today.

4. **`scripts/publish-huggingface.{sh,py}`** still listed the old never-uploaded names (`pretrained-encoder.onnx`, etc.). A future publish validate step would warn/expect the wrong set; updated `EXPECTED_FILES` to the current Hub tree.

5. Front-matter `library_name: onnxruntime` was misleading (no ONNX files on Hub) → `safetensors`.

## Test plan

- [x] Compared Hub tree via `https://huggingface.co/api/models/ruvnet/wifi-densepose-pretrained/tree/main`
- [x] Grepped changed files for `ruv/ruview` / stale ONNX names
- [ ] Maintainer: confirm publish scripts still dry-run cleanly against a real `dist/models/` layout

Closes #1481 (remaining gaps after the earlier card rewrite).