### PR TITLE
feat(sensing): run experimental MM-Fi pose decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,29 @@ huggingface-cli download ruvnet/wifi-densepose-pretrained --local-dir models/wif
 
 **Loader scope:** `--model` now accepts native RVF and auto-converts the published safetensors or JSONL files. The quantized `model-q*.bin` files still need a compatible reader, and loading weights does not supply the matching pose-decoder architecture or establish end-to-end pose accuracy.
 
+### Experimental MM-Fi pose decoder
+
+`--pose-model <path>` loads the published 75k-parameter MM-Fi Micro decoder
+from a non-executable F32 NPZ. Live inference requires exactly three active
+nodes with at least ten CSI frames each. Each node is treated as one MM-Fi
+channel and its current grid is linearly resampled to 114 bins. Outputs are
+labelled `experimental_mmfi`: this adapter is an architecture integration, not
+an accuracy claim for ESP32 hardware or a new room. Validate against reference
+poses in the deployment room before relying on its coordinates.
+The published MM-Fi checkpoint is CC BY-NC 4.0; confirm that license fits the
+deployment before distributing the weights or using them commercially.
+
+The upstream `edge/pose_micro_int4.npz` contains full weights under `f::` in
+FP16. A safe numerical conversion (no PyTorch/pickle loading) is:
+
+```python
+import numpy as np
+z = np.load("pose_micro_int4.npz", allow_pickle=False)
+np.savez("pose_micro_f32.npz", **{
+    k: z[k].astype(np.float32) for k in z.files if k.startswith("f::")
+})
+```
+
 **Quantization choices** (all in the HF repo): `model-q2.bin` (4 KB) · `model-q4.bin` ⭐ recommended (8 KB) · `model-q8.bin` (16 KB) · `model.safetensors` full (48 KB)
 
 The separate **17-keypoint pose-estimation model** is now published at [`ruvnet/wifi-densepose-mmfi-pose`](https://huggingface.co/ruvnet/wifi-densepose-mmfi-pose) — **82.69% torso-PCK@20** on MM-Fi (single model) / **83.59%** (3-model ensemble + TTA), beating the prior published SOTA MultiFormer (72.25%) and CSI2Pose (68.41%) on the matched `random_split` protocol. See **Results & proof** below.

--- a/v2/Cargo.lock
+++ b/v2/Cargo.lock
@@ -11654,6 +11654,8 @@ dependencies = [
  "jsonwebtoken",
  "midstreamer-attractor",
  "midstreamer-temporal-compare",
+ "ndarray 0.17.2",
+ "ndarray-npy",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/v2/crates/wifi-densepose-sensing-server/Cargo.toml
+++ b/v2/crates/wifi-densepose-sensing-server/Cargo.toml
@@ -90,6 +90,8 @@ midstreamer-attractor        = "0.2"   # Lyapunov + regime classification
 ureq      = { version = "2", default-features = false, features = ["tls", "json"] }
 sha2      = "0.10"
 thiserror = "1"
+ndarray = { workspace = true }
+ndarray-npy = { workspace = true }
 
 # ADR-271 — Cognitum OAuth access-token verification. Reuses the `ureq`
 # transport above rather than pulling a second HTTP stack: `ruview-auth`'s

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -16,6 +16,7 @@ mod engine_bridge;
 mod field_bridge;
 mod field_localize;
 mod model_format;
+mod mmfi_pose;
 mod multistatic_bridge;
 mod mediatek_csi;
 mod qualcomm_csi;
@@ -150,6 +151,11 @@ struct Args {
     /// Load a trained .rvf model for inference
     #[arg(long, value_name = "PATH")]
     model: Option<PathBuf>,
+
+    /// Load the published MM-Fi Micro pose checkpoint converted to safe F32 NPZ.
+    /// Output is experimental for live ESP32 input until room validation passes.
+    #[arg(long, value_name = "PATH")]
+    pose_model: Option<PathBuf>,
 
     /// Enable progressive loading (Layer A instant start)
     #[arg(long)]
@@ -1136,6 +1142,8 @@ struct AppStateInner {
     active_sona_profile: Option<String>,
     /// Whether a trained model is loaded.
     model_loaded: bool,
+    /// Native MM-Fi Micro pose decoder (experimental live-domain adapter).
+    pose_model: Option<mmfi_pose::MmfiPoseModel>,
     /// Smoothed person count (EMA) for hysteresis — prevents frame-to-frame jumping.
     smoothed_person_score: f64,
     /// Previous person count for hysteresis (asymmetric up/down thresholds).
@@ -1351,6 +1359,7 @@ impl AppStateInner {
             progressive_loader: None,
             active_sona_profile: None,
             model_loaded: false,
+            pose_model: None,
             smoothed_person_score: 0.0,
             prev_person_count: 0,
             smoothed_motion: 0.0,
@@ -4468,12 +4477,47 @@ fn derive_pose_from_sensing(update: &SensingUpdate) -> Vec<PersonDetection> {
         return vec![];
     }
 
+    // A real decoder result takes precedence over the legacy visualisation skeleton.
+    if let Some(kps) = update.pose_keypoints.as_ref().filter(|v| v.len() == 17) {
+        let names = ["nose", "left_eye", "right_eye", "left_ear", "right_ear",
+            "left_shoulder", "right_shoulder", "left_elbow", "right_elbow",
+            "left_wrist", "right_wrist", "left_hip", "right_hip", "left_knee",
+            "right_knee", "left_ankle", "right_ankle"];
+        let keypoints: Vec<PoseKeypoint> = kps.iter().zip(names).map(|(p, name)| PoseKeypoint {
+            name: name.to_string(), x: p[0] * 640.0, y: p[1] * 480.0,
+            z: p[2], confidence: p[3],
+        }).collect();
+        let min_x = keypoints.iter().map(|p| p.x).fold(f64::INFINITY, f64::min);
+        let max_x = keypoints.iter().map(|p| p.x).fold(f64::NEG_INFINITY, f64::max);
+        let min_y = keypoints.iter().map(|p| p.y).fold(f64::INFINITY, f64::min);
+        let max_y = keypoints.iter().map(|p| p.y).fold(f64::NEG_INFINITY, f64::max);
+        return vec![PersonDetection { id: 1, confidence: cls.confidence, keypoints,
+            bbox: BoundingBox { x: min_x, y: min_y, width: (max_x-min_x).max(1.0),
+                height: (max_y-min_y).max(1.0) }, zone: "experimental_mmfi".into(),
+            position: [0.0; 3], motion_score: 0.0, pose: None }];
+    }
+
     // Use estimated_persons if set by the tick loop; otherwise default to 1.
     let person_count = update.estimated_persons.unwrap_or(1).max(1);
 
     (0..person_count)
         .map(|idx| derive_single_person_pose(update, idx, person_count))
         .collect()
+}
+
+fn infer_mmfi_pose(model: Option<&mmfi_pose::MmfiPoseModel>, nodes: &HashMap<u8, NodeState>,
+    now: std::time::Instant) -> Option<Vec<[f64; 4]>> {
+    let model = model?;
+    let mut active: Vec<_> = nodes.iter().filter(|(_, n)| n.frame_history.len() >= 10
+        && n.last_frame_time.is_some_and(|t| now.duration_since(t).as_secs() < 2)).collect();
+    active.sort_by_key(|(id, _)| **id);
+    if active.len() != 3 { return None; }
+    let input: Vec<Vec<Vec<f64>>> = active.into_iter()
+        .map(|(_, n)| n.frame_history.iter().cloned().collect()).collect();
+    match model.infer(&input) {
+        Ok(kps) => Some(kps.into_iter().map(|p| [p[0] as f64, p[1] as f64, 0.0, 0.5]).collect()),
+        Err(e) => { debug!("MM-Fi pose inference skipped: {e}"); None }
+    }
 }
 
 // ── RuVector Phase 2: Temporal EMA smoothing for keypoints ──────────────────
@@ -6043,6 +6087,7 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         node_features: build_node_features(&s.node_states, now),
                     };
 
+                    update.pose_keypoints = infer_mmfi_pose(s.pose_model.as_ref(), &s.node_states, now);
                     let raw_persons = derive_pose_from_sensing(&update);
                     let mut last_tracker_instant = s.last_tracker_instant.take();
                     let tracked = tracker_bridge::tracker_update(
@@ -6480,6 +6525,7 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         node_features: build_node_features(&s.node_states, now),
                     };
 
+                    update.pose_keypoints = infer_mmfi_pose(s.pose_model.as_ref(), &s.node_states, now);
                     let raw_persons = derive_pose_from_sensing(&update);
                     let mut last_tracker_instant = s.last_tracker_instant.take();
                     let tracked = tracker_bridge::tracker_update(
@@ -7849,6 +7895,16 @@ async fn main() {
         }
     }
 
+    let pose_model = args.pose_model.as_ref().and_then(|path| {
+        match mmfi_pose::MmfiPoseModel::load(path) {
+            Ok(model) => {
+                info!("Loaded experimental MM-Fi Micro pose decoder from {}", path.display());
+                Some(model)
+            }
+            Err(e) => { error!("MM-Fi pose model NOT loaded: {e}"); None }
+        }
+    });
+
     // Ensure data directories exist for models and recordings
     let models_dir = effective_models_dir();
     let _ = std::fs::create_dir_all(&models_dir);
@@ -7994,6 +8050,7 @@ async fn main() {
         progressive_loader,
         active_sona_profile: None,
         model_loaded,
+        pose_model,
         smoothed_person_score: 0.0,
         prev_person_count: 0,
         smoothed_motion: 0.0,

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -4795,9 +4795,8 @@ async fn get_active_model(State(state): State<SharedState>) -> Json<serde_json::
                 .discovered_models
                 .iter()
                 .find(|m| m.get("id").and_then(|v| v.as_str()) == Some(id.as_str()));
-            Json(serde_json::json!({
-                "active": model.cloned().unwrap_or_else(|| serde_json::json!({ "id": id })),
-            }))
+            let model = model.cloned().unwrap_or_else(|| serde_json::json!({ "id": id }));
+            Json(serde_json::json!({ "active": model, "model_id": id }))
         }
         None => Json(serde_json::json!({ "active": serde_json::Value::Null })),
     }
@@ -4817,7 +4816,29 @@ async fn load_model(
     if model_id.is_empty() {
         return Json(serde_json::json!({ "error": "missing 'id' field", "success": false }));
     }
+    let safe_id = std::path::Path::new(&model_id)
+        .file_name().and_then(|v| v.to_str()).filter(|v| *v == model_id).unwrap_or("");
+    if safe_id.is_empty() {
+        return Json(serde_json::json!({ "error": "invalid model id", "success": false }));
+    }
+    let discovered = scan_model_files();
+    let Some(info) = discovered.iter().find(|m| m.get("id").and_then(|v| v.as_str()) == Some(safe_id)) else {
+        return Json(serde_json::json!({ "error": "model not found", "success": false }));
+    };
+    let format = info.get("format").and_then(|v| v.as_str()).unwrap_or("");
+    let loaded_pose = if format == "mmfi_pose_npz" {
+        let path = effective_models_dir().join(format!("{safe_id}.npz"));
+        match mmfi_pose::MmfiPoseModel::load(&path) {
+            Ok(model) => Some(model),
+            Err(e) => {
+                error!("MM-Fi pose model NOT loaded from model manager: {e}");
+                return Json(serde_json::json!({ "error": "model load failed", "success": false }));
+            }
+        }
+    } else { None };
     let mut s = state.write().await;
+    if let Some(model) = loaded_pose { s.pose_model = Some(model); }
+    s.discovered_models = discovered;
     s.active_model_id = Some(model_id.clone());
     s.model_loaded = true;
     if telemetry::curated_events_enabled() {
@@ -4832,6 +4853,7 @@ async fn load_model(
 async fn unload_model(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let mut s = state.write().await;
     let prev = s.active_model_id.take();
+    s.pose_model = None;
     s.model_loaded = false;
     info!("Model unloaded (was: {:?})", prev);
     Json(serde_json::json!({ "success": true, "previous": prev }))
@@ -4850,8 +4872,10 @@ async fn delete_model(
     if safe_id.is_empty() || safe_id != id {
         return Json(serde_json::json!({ "error": "invalid model id", "success": false }));
     }
-    let path = effective_models_dir().join(format!("{}.rvf", safe_id));
-    if path.exists() {
+    let dir = effective_models_dir();
+    let path = [dir.join(format!("{}.rvf", safe_id)), dir.join(format!("{}.npz", safe_id))]
+        .into_iter().find(|p| p.exists());
+    if let Some(path) = path {
         if let Err(e) = std::fs::remove_file(&path) {
             // ADR-080 #2: log the OS error (incl. path) server-side only; the
             // client gets a generic body + correlation id, no leaked path.
@@ -4862,6 +4886,7 @@ async fn delete_model(
         if s.active_model_id.as_deref() == Some(id.as_str()) {
             s.active_model_id = None;
             s.model_loaded = false;
+            s.pose_model = None;
         }
         s.discovered_models
             .retain(|m| m.get("id").and_then(|v| v.as_str()) != Some(id.as_str()));
@@ -4900,7 +4925,7 @@ fn effective_models_dir() -> PathBuf {
     PathBuf::from(std::env::var("MODELS_DIR").unwrap_or_else(|_| "data/models".to_string()))
 }
 
-/// Scan the models directory for `.rvf` files and return metadata.
+/// Scan the models directory for RVF and safe F32 MM-Fi pose NPZ files.
 /// Respects the `MODELS_DIR` environment variable.
 fn scan_model_files() -> Vec<serde_json::Value> {
     let dir = effective_models_dir();
@@ -4908,7 +4933,8 @@ fn scan_model_files() -> Vec<serde_json::Value> {
     if let Ok(entries) = std::fs::read_dir(&dir) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("rvf") {
+            let extension = path.extension().and_then(|e| e.to_str());
+            if matches!(extension, Some("rvf") | Some("npz")) {
                 let name = path
                     .file_stem()
                     .and_then(|s| s.to_str())
@@ -4922,12 +4948,13 @@ fn scan_model_files() -> Vec<serde_json::Value> {
                     .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                     .map(|d| d.as_secs())
                     .unwrap_or(0);
+                let format = if extension == Some("npz") { "mmfi_pose_npz" } else { "rvf" };
                 models.push(serde_json::json!({
                     "id": name,
                     "name": name,
                     "path": path.display().to_string(),
                     "size_bytes": size,
-                    "format": "rvf",
+                    "format": format,
                     "modified_epoch": modified,
                 }));
             }
@@ -7904,6 +7931,9 @@ async fn main() {
             Err(e) => { error!("MM-Fi pose model NOT loaded: {e}"); None }
         }
     });
+    let active_pose_model_id = pose_model.as_ref().and_then(|_| {
+        args.pose_model.as_ref()?.file_stem()?.to_str().map(str::to_string)
+    });
 
     // Ensure data directories exist for models and recordings
     let models_dir = effective_models_dir();
@@ -8069,7 +8099,7 @@ async fn main() {
         latest_wasm_events: None,
         // Model management
         discovered_models: initial_models,
-        active_model_id: None,
+        active_model_id: active_pose_model_id,
         // Recording
         recordings: initial_recordings,
         recording_active: false,

--- a/v2/crates/wifi-densepose-sensing-server/src/mmfi_pose.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/mmfi_pose.rs
@@ -1,0 +1,392 @@
+//! Native inference for the published MM-Fi `Micro` pose checkpoint.
+//!
+//! The checkpoint is loaded from a non-executable NPZ containing F32 tensors.
+//! Live ESP32 input is an explicit domain adapter (3 nodes x 114 bins x 10
+//! frames), so its output must remain labelled experimental until validated in
+//! the deployment room.
+
+use ndarray::ArrayD;
+use ndarray_npy::NpzReader;
+use std::{collections::HashMap, fs::File, path::Path};
+
+const D: usize = 64;
+const T: usize = 10;
+const SC: usize = 114;
+const INPUT: usize = 3 * SC;
+const KP: usize = 17;
+const HEADS: usize = 2;
+const HD: usize = D / HEADS;
+
+#[derive(Debug)]
+pub struct MmfiPoseModel {
+    w: HashMap<String, Vec<f32>>,
+}
+
+impl MmfiPoseModel {
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let file = File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
+        let mut npz = NpzReader::new(file).map_err(|e| format!("NPZ header: {e}"))?;
+        let required = [
+            "pos",
+            "proj.weight",
+            "proj.bias",
+            "tf.layers.0.self_attn.in_proj_weight",
+            "tf.layers.0.self_attn.in_proj_bias",
+            "tf.layers.0.self_attn.out_proj.weight",
+            "tf.layers.0.self_attn.out_proj.bias",
+            "tf.layers.0.linear1.weight",
+            "tf.layers.0.linear1.bias",
+            "tf.layers.0.linear2.weight",
+            "tf.layers.0.linear2.bias",
+            "tf.layers.0.norm1.weight",
+            "tf.layers.0.norm1.bias",
+            "tf.layers.0.norm2.weight",
+            "tf.layers.0.norm2.bias",
+            "att.weight",
+            "att.bias",
+            "head.0.weight",
+            "head.0.bias",
+            "head.3.weight",
+            "head.3.bias",
+            "gr.inp.weight",
+            "gr.inp.bias",
+            "gr.g1.weight",
+            "gr.g1.bias",
+            "gr.g2.weight",
+            "gr.g2.bias",
+            "gr.out.weight",
+            "gr.out.bias",
+        ];
+        let mut w = HashMap::new();
+        for name in required {
+            let key = format!("f::{name}.npy");
+            let a: ArrayD<f32> = npz
+                .by_name(&key)
+                .map_err(|e| format!("missing/invalid {key}: {e}"))?;
+            w.insert(name.to_string(), a.iter().copied().collect());
+        }
+        let model = Self { w };
+        model.validate()?;
+        Ok(model)
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        for (n, len) in [
+            ("pos", T * D),
+            ("proj.weight", D * INPUT),
+            ("proj.bias", D),
+            ("tf.layers.0.self_attn.in_proj_weight", 3 * D * D),
+            ("tf.layers.0.self_attn.in_proj_bias", 3 * D),
+            ("tf.layers.0.self_attn.out_proj.weight", D * D),
+            ("tf.layers.0.self_attn.out_proj.bias", D),
+            ("tf.layers.0.linear1.weight", 2 * D * D),
+            ("tf.layers.0.linear1.bias", 2 * D),
+            ("tf.layers.0.linear2.weight", 2 * D * D),
+            ("tf.layers.0.linear2.bias", D),
+            ("tf.layers.0.norm1.weight", D),
+            ("tf.layers.0.norm1.bias", D),
+            ("tf.layers.0.norm2.weight", D),
+            ("tf.layers.0.norm2.bias", D),
+            ("att.weight", D),
+            ("att.bias", 1),
+            ("head.0.weight", D * D),
+            ("head.0.bias", D),
+            ("head.3.weight", 34 * D),
+            ("head.3.bias", 34),
+            ("gr.inp.weight", D * 66),
+            ("gr.inp.bias", D),
+            ("gr.g1.weight", D * D),
+            ("gr.g1.bias", D),
+            ("gr.g2.weight", D * D),
+            ("gr.g2.bias", D),
+            ("gr.out.weight", 2 * D),
+            ("gr.out.bias", 2),
+        ] {
+            let got = self.w.get(n).map_or(0, Vec::len);
+            if got != len {
+                return Err(format!("tensor {n}: expected {len} values, got {got}"));
+            }
+        }
+        Ok(())
+    }
+
+    fn p(&self, n: &str) -> &[f32] {
+        &self.w[n]
+    }
+
+    /// Infer 17 normalized `(x,y)` keypoints from `[node][time][subcarrier]`.
+    pub fn infer(&self, input: &[Vec<Vec<f64>>]) -> Result<[[f32; 2]; KP], String> {
+        if input.len() != 3 || input.iter().any(|n| n.len() < T) {
+            return Err("need exactly three nodes with ten frames each".into());
+        }
+        let mut x = vec![0.0f32; T * INPUT];
+        for (ni, node) in input.iter().enumerate() {
+            for ti in 0..T {
+                let frame = &node[node.len() - T + ti];
+                if frame.len() < 2 {
+                    return Err("CSI frame has fewer than two bins".into());
+                }
+                for si in 0..SC {
+                    let at = si as f64 * (frame.len() - 1) as f64 / (SC - 1) as f64;
+                    let lo = at.floor() as usize;
+                    let hi = at.ceil() as usize;
+                    let f = (at - lo as f64) as f32;
+                    x[ti * INPUT + ni * SC + si] =
+                        frame[lo] as f32 * (1.0 - f) + frame[hi] as f32 * f;
+                }
+            }
+        }
+        let mean = x.iter().sum::<f32>() / x.len() as f32;
+        let var = x.iter().map(|v| (v - mean) * (v - mean)).sum::<f32>() / x.len() as f32;
+        let sd = var.sqrt().max(1e-6);
+        for v in &mut x {
+            *v = (*v - mean) / sd;
+        }
+
+        let mut h = linear_rows(&x, T, INPUT, self.p("proj.weight"), self.p("proj.bias"), D);
+        for (v, p) in h.iter_mut().zip(self.p("pos")) {
+            *v += p;
+        }
+        let qkv = linear_rows(
+            &h,
+            T,
+            D,
+            self.p("tf.layers.0.self_attn.in_proj_weight"),
+            self.p("tf.layers.0.self_attn.in_proj_bias"),
+            3 * D,
+        );
+        let mut attn = vec![0.0; T * D];
+        for head in 0..HEADS {
+            for qi in 0..T {
+                let mut scores = [0.0f32; T];
+                for ki in 0..T {
+                    let mut s = 0.0;
+                    for j in 0..HD {
+                        s += qkv[qi * 3 * D + head * HD + j] * qkv[ki * 3 * D + D + head * HD + j];
+                    }
+                    scores[ki] = s / (HD as f32).sqrt();
+                }
+                softmax(&mut scores);
+                for j in 0..HD {
+                    for ki in 0..T {
+                        attn[qi * D + head * HD + j] +=
+                            scores[ki] * qkv[ki * 3 * D + 2 * D + head * HD + j];
+                    }
+                }
+            }
+        }
+        let a = linear_rows(
+            &attn,
+            T,
+            D,
+            self.p("tf.layers.0.self_attn.out_proj.weight"),
+            self.p("tf.layers.0.self_attn.out_proj.bias"),
+            D,
+        );
+        for i in 0..h.len() {
+            h[i] += a[i];
+        }
+        layer_norm_rows(
+            &mut h,
+            T,
+            D,
+            self.p("tf.layers.0.norm1.weight"),
+            self.p("tf.layers.0.norm1.bias"),
+        );
+        let mut ff = linear_rows(
+            &h,
+            T,
+            D,
+            self.p("tf.layers.0.linear1.weight"),
+            self.p("tf.layers.0.linear1.bias"),
+            2 * D,
+        );
+        for v in &mut ff {
+            *v = gelu(*v);
+        }
+        let ff = linear_rows(
+            &ff,
+            T,
+            2 * D,
+            self.p("tf.layers.0.linear2.weight"),
+            self.p("tf.layers.0.linear2.bias"),
+            D,
+        );
+        for i in 0..h.len() {
+            h[i] += ff[i];
+        }
+        layer_norm_rows(
+            &mut h,
+            T,
+            D,
+            self.p("tf.layers.0.norm2.weight"),
+            self.p("tf.layers.0.norm2.bias"),
+        );
+
+        let mut aw = [0.0f32; T];
+        for t in 0..T {
+            aw[t] = dot(&h[t * D..(t + 1) * D], self.p("att.weight")) + self.p("att.bias")[0];
+        }
+        softmax(&mut aw);
+        let mut z = [0.0f32; D];
+        for t in 0..T {
+            for j in 0..D {
+                z[j] += aw[t] * h[t * D + j];
+            }
+        }
+        let mut hidden = linear_rows(&z, 1, D, self.p("head.0.weight"), self.p("head.0.bias"), D);
+        for v in &mut hidden {
+            *v = gelu(*v)
+        }
+        let base = linear_rows(
+            &hidden,
+            1,
+            D,
+            self.p("head.3.weight"),
+            self.p("head.3.bias"),
+            34,
+        );
+        let mut kp = [[0.0f32; 2]; KP];
+        for k in 0..KP {
+            for c in 0..2 {
+                kp[k][c] = sigmoid(base[k * 2 + c]);
+            }
+        }
+
+        let mut g0 = vec![0.0f32; KP * D];
+        for k in 0..KP {
+            let mut v = Vec::with_capacity(66);
+            v.extend_from_slice(&z);
+            v.extend_from_slice(&kp[k]);
+            let o = linear_rows(&v, 1, 66, self.p("gr.inp.weight"), self.p("gr.inp.bias"), D);
+            for j in 0..D {
+                g0[k * D + j] = o[j].max(0.0)
+            }
+        }
+        let edges = [
+            (0, 1),
+            (0, 2),
+            (1, 3),
+            (2, 4),
+            (5, 6),
+            (5, 7),
+            (7, 9),
+            (6, 8),
+            (8, 10),
+            (5, 11),
+            (6, 12),
+            (11, 12),
+            (11, 13),
+            (13, 15),
+            (12, 14),
+            (14, 16),
+        ];
+        let aggregate = |src: &[f32]| {
+            let mut out = vec![0.0; KP * D];
+            for k in 0..KP {
+                let mut ns = vec![k];
+                for &(a, b) in &edges {
+                    if a == k {
+                        ns.push(b)
+                    } else if b == k {
+                        ns.push(a)
+                    }
+                }
+                let den = ns.len() as f32;
+                for n in ns {
+                    for j in 0..D {
+                        out[k * D + j] += src[n * D + j] / den
+                    }
+                }
+            }
+            out
+        };
+        let ag = aggregate(&g0);
+        let mut g1 = linear_rows(&ag, KP, D, self.p("gr.g1.weight"), self.p("gr.g1.bias"), D);
+        for v in &mut g1 {
+            *v = v.max(0.0)
+        }
+        let ag = aggregate(&g1);
+        let mut g2 = linear_rows(&ag, KP, D, self.p("gr.g2.weight"), self.p("gr.g2.bias"), D);
+        for v in &mut g2 {
+            *v = v.max(0.0)
+        }
+        let delta = linear_rows(
+            &g2,
+            KP,
+            D,
+            self.p("gr.out.weight"),
+            self.p("gr.out.bias"),
+            2,
+        );
+        for k in 0..KP {
+            for c in 0..2 {
+                kp[k][c] = (kp[k][c] + 0.3 * delta[k * 2 + c].tanh()).clamp(-0.3, 1.3);
+            }
+        }
+        Ok(kp)
+    }
+}
+
+fn dot(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+fn linear_rows(x: &[f32], rows: usize, cols: usize, w: &[f32], b: &[f32], out: usize) -> Vec<f32> {
+    let mut y = vec![0.0; rows * out];
+    for r in 0..rows {
+        for o in 0..out {
+            y[r * out + o] = dot(&x[r * cols..(r + 1) * cols], &w[o * cols..(o + 1) * cols]) + b[o];
+        }
+    }
+    y
+}
+fn softmax(x: &mut [f32]) {
+    let m = x.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut s = 0.0;
+    for v in x.iter_mut() {
+        *v = (*v - m).exp();
+        s += *v
+    }
+    for v in x {
+        *v /= s.max(1e-12)
+    }
+}
+fn layer_norm_rows(x: &mut [f32], rows: usize, cols: usize, w: &[f32], b: &[f32]) {
+    for r in 0..rows {
+        let q = &mut x[r * cols..(r + 1) * cols];
+        let m = q.iter().sum::<f32>() / cols as f32;
+        let v = q.iter().map(|z| (z - m) * (z - m)).sum::<f32>() / cols as f32;
+        let d = (v + 1e-5).sqrt();
+        for j in 0..cols {
+            q[j] = (q[j] - m) / d * w[j] + b[j]
+        }
+    }
+}
+fn gelu(x: f32) -> f32 {
+    0.5 * x * (1.0 + (0.7978845608 * (x + 0.044715 * x * x * x)).tanh())
+}
+fn sigmoid(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn softmax_is_normalized() {
+        let mut x = [1.0, 2.0, 3.0];
+        softmax(&mut x);
+        assert!((x.iter().sum::<f32>() - 1.0).abs() < 1e-6)
+    }
+
+    #[test]
+    fn published_checkpoint_adapter_smoke_when_supplied() {
+        let Ok(path) = std::env::var("RUVIEW_MMFI_TEST_MODEL") else {
+            return;
+        };
+        let model = MmfiPoseModel::load(Path::new(&path)).expect("converted checkpoint loads");
+        let input = vec![vec![vec![1.0; 256]; T]; 3];
+        let pose = model.infer(&input).expect("inference succeeds");
+        assert!(pose.iter().flatten().all(|v| v.is_finite()));
+    }
+}


### PR DESCRIPTION
## What changed

- adds native inference for the published 75k-parameter MM-Fi Micro pose decoder
- adapts three live CSI nodes into the model's `[3, 114, 10]` input tensor
- exposes successful decoder output through `pose_keypoints` and the existing tracker
- adds `--pose-model <F32 NPZ>` and documents safe FP16-to-F32 conversion
- keeps output explicitly labelled `experimental_mmfi` until room-specific validation

## Why

The existing `--model` path loaded weights but did not execute the matching pose decoder in the live ESP32 pipeline. This change supplies the decoder architecture and connects it to real three-node CSI history without introducing Python, PyTorch, or executable pickle artifacts into the runtime.

## Validation

- `cargo check --manifest-path v2/Cargo.toml -p wifi-densepose-sensing-server --features mqtt`
- focused `mmfi_pose` tests, including loading the converted published checkpoint and a full finite-output inference smoke test
- production Linux Docker image built successfully
- deployed test container loaded both the MM-Fi decoder and persisted field calibration successfully

A second check from the isolated PR worktree could not start because vendor submodules are not materialized in that worktree; the full checkout validations above passed.

## Evidence boundary

The published benchmark is MM-Fi in-domain evidence. ESP32-C6 room accuracy remains unmeasured. Live output is therefore experimental and requires exactly three active nodes plus deployment-room reference validation.