### PR TITLE
feat: improve topology-aware adaptive presence sensing

### DIFF
--- a/v2/.gitignore
+++ b/v2/.gitignore
@@ -1,1 +1,4 @@
 baselines/
+
+# Generated browser-session signing material must remain machine-local.
+data/session-secret

--- a/v2/Cargo.lock
+++ b/v2/Cargo.lock
@@ -179,7 +179,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -190,7 +190,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1325,36 +1325,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd990d8a6304475bbad64534a0d418f5572f44d5f011437e6b9f1ee7d5c2570"
+checksum = "5f8e1303ae2128891cb59691a74de4547dd208bc8511a2f287cca2b93bb3c728"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccabe4636007296721080e02d7dab46d4319638ec4e3f6f7402fcb46dc5122c6"
+checksum = "58b2740a5936332028d9a1e8f29a199de2fd386e426d44da5fea70cf8e3f8e75"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7ed173c870c0aea202a9830880156905a028a88df076e35ce383a8acbf90a7"
+checksum = "37fd128d3629fb105e433bda09744c5a2959cd1da04617a455c4cc17dff1ebef"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800cc586df98b12c502e76707c96565e40629a5322eaa15aaa34ba05f5721e31"
+checksum = "24a88f6d5a6cf6fcbc6386415d48948094721dfa4585d6615938b11ca938f20a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae93f863f9094ae34d2567f9edb0ae2c41d35228b286598354dd78b198868ebd"
+checksum = "daa4a357d030bdd586d8fe3da56b394f7f6b6ded506e59f945e7b32b1e126b71"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c505162bcf77dcb859905b3eac56a1917fc3cf326424fb06e7732031e3a8ae"
+checksum = "4121e36a8757dea6fb237435ee5095eba25bc13ecc2eaee57eb9bffd4b27784f"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1402,24 +1402,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b786958bcb79bdb5fbae095af58f0c2da7d7895c475c991f6a6bb5a9c7e6d9"
+checksum = "5173265fc30b9e42205cf06dfca9a272ee949667ce4115d975ed2c08d466e2f8"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faf9a5009bce7f725ce2af7a08c4883ebac6af933e7e0aa7d84f976f4e6deb5"
+checksum = "9b6ca8a393e66dc13f915c6f456bdcf496d78fac4995792f7022b7806352d7a4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017271194ba5e101d626560d0d6767efd341468d1ba0f4d015f19fe64020b65b"
+checksum = "e609d9ba416bc26d774f343295a1d411515248a6a6d83d5f7492a0dd919569fa"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1428,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f80847f0929967f0cec82f9e0543b3901e0f0063690405891f22107b5a130fd8"
+checksum = "90a3a277b1a0aff1123f6bae61c080a4bcb6df964829ed427f98e18dff14257f"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1440,15 +1440,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75904abbc0e7b46d20f7a49c8042c8a4481c0db4253b99889c723c566295d506"
+checksum = "be53dd9b3a4cbeb9ced45c4a543ea8417ccfb334c3ba1cbb2233f4b25fb2531f"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0135923540574362e16f01bf40000664263840991039ff3041ba717de6cf3a"
+checksum = "ca62ab1d9f48cad97da5843b913ccf96c3dfde935af5d750cb5a6d367ccfb262"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fb12f76c482e034f6ebefa843c914e74112f088215d8d36d33a649f9fab99b"
+checksum = "a13b72860f54a2a19d3756bd47575fd8bddeafd6e5bbbf16372cdfebc482628a"
 
 [[package]]
 name = "crc"
@@ -1945,7 +1945,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2256,7 +2256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3490,6 +3490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4294,7 +4300,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5331,7 +5337,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5878,7 +5884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6599,7 +6605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6636,9 +6642,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558181096e0df4984f45cfc3a7087052df4a61c36089b135a08ceca9cbd352fb"
+checksum = "2662666315cb90dfb4d99a652ee053d4d8598f71c474209e84da031ca56ae5a4"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -6648,9 +6654,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d52e2f14e168d75cdabe9bd5fb1ff18a1b119dc6699684aee895dbc3524da9"
+checksum = "bb9a7d9ed2618f94b6d054aba3eb2768c9b489fe16b4ef8847fbc6ed41b707bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6797,7 +6803,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7329,13 +7335,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "munge",
  "ptr_meta",
@@ -7348,9 +7354,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7553,7 +7559,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7668,7 +7674,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9562,7 +9568,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10899,9 +10905,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4442dc12aa2473def8334f0e0f2b489be52c52507c938bbdc8be69ded4ded6"
+checksum = "93d881c5dcff5f230368d84fcf110ca25fe47badc694e7d559c3891492159916"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -10954,9 +10960,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d881c3d6205898a226cc487b117f23b9ed1c7da39952d65bd5eeb6745b3789c"
+checksum = "a4b25534a3ff9dd844701c2bc997f76cb1f97bf2af0546a7066ae96f49c2e068"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -10981,18 +10987,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab1876bcfa51d6a05dea1c13933f53cbc1e316c783fddebc859f56a736eae07"
+checksum = "1d02832d760351fb3a1aa99eb8f7b95596c0f4e4e52df1547fcdb295ea5c780c"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2195a1521a5214a71b67ca2ba2d9317ae15917288ea9d8e5836142b921c9d155"
+checksum = "651f8a16b51cde3ee8bd5b775bcedc24b66040d7dca1f13ad855b10c660e1d01"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11010,9 +11016,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae1407944a0b13a8a77930b5b951aa7134beccecad7efac1ef9f03adb7d1a0f"
+checksum = "ba2ed6dbe24607573f7bcc59222f3bc2e7f7d31609466055c67b9484045a374a"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -11025,15 +11031,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646a53678ce6aaf6f097e18ca51f650f2841aea6d2bcd7b61931397b8b8f30db"
+checksum = "e21aadbf677ee3503ef2580ce3c6955508e90a2810e961739b30f79585af254c"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3495aa8300e4ca6b53f81a53ce5eff6621fd5ff8378ef9ae552d1479d57371"
+checksum = "65821bab751956cddfc6ee957beb13a0e2a6cf682050d75dfb7a0228db2ed499"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -11058,9 +11064,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5e4023a6b167da157338f5f0f505945eb45e78f1cac2d4dcce0922457d7d4"
+checksum = "18cf73e5e8d28a2b30d86454430c7dea3b593598dcbbc0ebb927ca2716222d41"
 dependencies = [
  "anyhow",
  "cc",
@@ -11074,9 +11080,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da71e2d573e3cc6f753a3b7bff98f425ca060c0e8071cc55c3d867a9edf3ecc"
+checksum = "4279dc3147ddaa21e5b3d2c0eaff117881c4f937747bdd2379eb361665843bd3"
 dependencies = [
  "cc",
  "object",
@@ -11086,9 +11092,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627d8f57909a4f9bb1dbe57a96229a54b89d5995353d0b321f3cb9a1a118977a"
+checksum = "a8eb677944201839c0be19b39b0f19dcd663efbcbc05a09c73f26fec7bdf0331"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -11098,24 +11104,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b99315585a8a27125dd9b0150edb115d6f6ff0baae453c21d30822aab77f00"
+checksum = "db9a153e184878df396a11f8912444531c2e4d0c7a1d9e9a52b30d9853d89cb9"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaee97281dd3fe47ec3d46c16fb9fe2dd32f37d0523c2d5c484f11b348734e4"
+checksum = "b771494bead25e1f0c4c89a9476dd0b65eacca314ed82125f1e197fbc3f0396b"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c005f82c48492b6b44fa19ee5205bd933c4f8baca41e314eca8331dd3c4fd9"
+checksum = "90199caed6925420434a923861d8ad813689ca8533d2c679f805d12e35b40a4b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -11126,9 +11132,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b73639a9c0c0e33a2ef942ca99b6772b48393be92bebbd0767c607e5b0a68e0"
+checksum = "ae71687aa834f9cc9eb5b0f97c85184d7dc70b84d32fd8927af0887998a1ba35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11137,9 +11143,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392ca021d084c7426616ef77e1284315555f11bcbb34f416d74b0732db622811"
+checksum = "5d0ba45c0d766dd56257d97702d3284b6f69efdd4c53ca981a0754cc0a139df0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -11154,9 +11160,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd4703351476262d715b72431e80d10289908e3494050071d6521267f522d97"
+checksum = "41a64d5112c06f9d54b41e61f0b757d3a5a52361bf359f01131cc7cb8551ac73"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -11826,7 +11832,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11837,9 +11843,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ec880b20caaa72245944b54cfb22aca111f8c805e12a7542b40d66921e5323"
+checksum = "82ea9625459ce35d6a4188cf0f07c9095cbb0e5afd86f711d63955bfc4216e64"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -421,9 +421,17 @@ impl AdaptiveModel {
 // ── Training ─────────────────────────────────────────────────────────────────
 
 /// A labeled training sample.
+#[derive(Clone)]
 struct Sample {
     features: [f64; N_FEATURES],
     class_idx: usize,
+}
+
+/// Frames captured during one continuous physical session.
+struct Recording {
+    name: String,
+    class_idx: usize,
+    samples: Vec<Sample>,
 }
 
 /// Load JSONL recording frames and assign a class label based on filename.
@@ -496,9 +504,6 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
         .flatten()
         .collect();
 
-    let mut class_map: HashMap<String, usize> = HashMap::new();
-    let mut class_names: Vec<String> = Vec::new();
-
     // Collect (entry, class_name) pairs for files that match.
     let mut file_classes: Vec<(PathBuf, String, String)> = Vec::new(); // (path, fname, class_name)
     for entry in &entries {
@@ -507,115 +512,214 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
             continue;
         }
         if let Some(class_name) = classify_recording_name(&fname) {
-            if !class_map.contains_key(&class_name) {
-                let idx = class_names.len();
-                class_map.insert(class_name.clone(), idx);
-                class_names.push(class_name.clone());
-            }
             file_classes.push((entry.path(), fname, class_name));
         }
     }
 
-    let n_classes = class_names.len();
-    if n_classes == 0 {
+    if file_classes.is_empty() {
         return Err("No training samples found. Record data with train_* prefix.".into());
     }
 
-    // Stable ordering makes both the held-out choice and model fitting
-    // reproducible across filesystems whose read_dir order differs.
+    // Stable ordering makes class indices, folds, and fitting reproducible
+    // across filesystems whose read_dir order differs.
     file_classes.sort_by(|a, b| a.1.cmp(&b.1));
+    let mut class_names: Vec<String> = file_classes
+        .iter()
+        .map(|(_, _, class_name)| class_name.clone())
+        .collect();
+    class_names.sort();
+    class_names.dedup();
+    let class_map: HashMap<String, usize> = class_names
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(index, name)| (name, index))
+        .collect();
+    let n_classes = class_names.len();
 
-    // Hold out one whole recording per class. Adjacent CSI frames are highly
-    // autocorrelated, so a random frame split leaks a session's room/channel
-    // fingerprint into validation and overstates deployment accuracy.
+    let mut recordings = Vec::with_capacity(file_classes.len());
     let mut recordings_per_class: HashMap<String, usize> = HashMap::new();
-    for (_, _, class_name) in &file_classes {
+    for (path, fname, class_name) in file_classes {
+        let class_idx = class_map[&class_name];
+        let samples = load_recording(&path, class_idx);
+        if samples.is_empty() {
+            return Err(format!(
+                "Training recording '{fname}' contains no valid frames"
+            ));
+        }
+        eprintln!(
+            "  Loaded {}: {} frames → class '{}'",
+            fname,
+            samples.len(),
+            class_name
+        );
         *recordings_per_class.entry(class_name.clone()).or_default() += 1;
+        recordings.push(Recording {
+            name: fname,
+            class_idx,
+            samples,
+        });
     }
+
+    // Adjacent CSI frames are highly autocorrelated. Leave-one-session-out
+    // (LOSO) ensures every reported prediction comes from a model that never
+    // saw that physical session, instead of validating on a favorable tail.
     let can_validate_sessions = class_names
         .iter()
         .all(|name| recordings_per_class.get(name).copied().unwrap_or(0) >= 2);
-    let mut held_out_path_by_class: HashMap<String, PathBuf> = HashMap::new();
-    if can_validate_sessions {
-        for (path, _, class_name) in &file_classes {
-            // Sorted iteration intentionally leaves the last session per class.
-            held_out_path_by_class.insert(class_name.clone(), path.clone());
-        }
-    }
 
-    // Second pass: load fitting and held-out sessions separately.
-    let mut samples: Vec<Sample> = Vec::new();
-    let mut validation_samples: Vec<Sample> = Vec::new();
-    for (path, fname, class_name) in &file_classes {
-        let class_idx = class_map[class_name];
-        let loaded = load_recording(path, class_idx);
-        let is_held_out = held_out_path_by_class.get(class_name) == Some(path);
+    let validation = if can_validate_sessions {
+        let mut class_correct = vec![0usize; n_classes];
+        let mut class_total = vec![0usize; n_classes];
+        for held_out_index in 0..recordings.len() {
+            let training_recordings: Vec<&Recording> = recordings
+                .iter()
+                .enumerate()
+                .filter_map(|(index, recording)| (index != held_out_index).then_some(recording))
+                .collect();
+            let fold_model = fit_model(&training_recordings, &class_names, false)?;
+            let held_out = &recordings[held_out_index];
+            eprintln!("  LOSO held out '{}'", held_out.name);
+            for sample in &held_out.samples {
+                class_total[sample.class_idx] += 1;
+                let (predicted, _) = fold_model.classify(&sample.features);
+                if predicted == class_names[sample.class_idx] {
+                    class_correct[sample.class_idx] += 1;
+                }
+            }
+        }
+
+        let per_class_recall: HashMap<String, f64> = class_names
+            .iter()
+            .enumerate()
+            .map(|(class_idx, class_name)| {
+                let recall = class_correct[class_idx] as f64 / class_total[class_idx] as f64;
+                (class_name.clone(), recall)
+            })
+            .collect();
+        let balanced_accuracy = per_class_recall.values().sum::<f64>() / n_classes as f64;
+        let held_out_frames = class_total.iter().sum();
         eprintln!(
-            "  Loaded {}: {} frames → class '{}'{}",
-            fname,
-            loaded.len(),
-            class_name,
-            if is_held_out { " [held out]" } else { "" }
+            "LOSO balanced accuracy: {:.1}% across {} recording(s) / {} frames",
+            balanced_accuracy * 100.0,
+            recordings.len(),
+            held_out_frames
         );
-        if is_held_out {
-            validation_samples.extend(loaded);
-        } else {
-            samples.extend(loaded);
-        }
-    }
+        Some(ValidationMetrics {
+            held_out_recordings: recordings.len(),
+            held_out_frames,
+            balanced_accuracy,
+            per_class_recall,
+        })
+    } else {
+        eprintln!(
+            "Session-held-out validation unavailable: record at least two independent sessions per class"
+        );
+        None
+    };
 
-    if samples.is_empty() {
+    // Validation models are disposable. The deployed model is refit on every
+    // accepted session so scarce local calibration data is not wasted.
+    let all_recordings: Vec<&Recording> = recordings.iter().collect();
+    let mut model = fit_model(&all_recordings, &class_names, true)?;
+    model.validation = validation;
+    Ok(model)
+}
+
+/// Fit one room-specific classifier from complete recording sessions.
+fn fit_model(
+    recordings: &[&Recording],
+    class_names: &[String],
+    print_progress: bool,
+) -> Result<AdaptiveModel, String> {
+    let n_classes = class_names.len();
+    let n: usize = recordings
+        .iter()
+        .map(|recording| recording.samples.len())
+        .sum();
+    if n == 0 {
         return Err("No training samples found. Record data with train_* prefix.".into());
     }
 
-    let n = samples.len();
-    eprintln!(
-        "Total training samples: {n} across {n_classes} classes: {:?}",
-        class_names
-    );
+    let mut sessions_per_class = vec![0usize; n_classes];
+    for recording in recordings {
+        sessions_per_class[recording.class_idx] += 1;
+    }
+    if let Some(class_idx) = sessions_per_class.iter().position(|count| *count == 0) {
+        return Err(format!(
+            "Training fold contains no '{}' session",
+            class_names[class_idx]
+        ));
+    }
+
+    // Give each class equal total mass and each session within that class equal
+    // mass. Otherwise a ten-minute empty capture can dominate a short activity
+    // capture even though its adjacent frames add little independent evidence.
+    let weighted_samples: Vec<(&Sample, f64)> = recordings
+        .iter()
+        .flat_map(|recording| {
+            let session_weight = 1.0
+                / (sessions_per_class[recording.class_idx] as f64 * recording.samples.len() as f64);
+            recording
+                .samples
+                .iter()
+                .map(move |sample| (sample, session_weight))
+        })
+        .collect();
+    let total_weight: f64 = weighted_samples.iter().map(|(_, weight)| weight).sum();
+    if print_progress {
+        eprintln!(
+            "Total training samples: {n} across {n_classes} classes: {:?}",
+            class_names
+        );
+    }
 
     // ── Compute global normalisation stats ──
     let mut global_mean = [0.0f64; N_FEATURES];
     let mut global_var = [0.0f64; N_FEATURES];
-    for s in &samples {
-        for (m, &f) in global_mean.iter_mut().zip(s.features.iter()) {
-            *m += f;
+    for (sample, weight) in &weighted_samples {
+        for (mean, feature) in global_mean.iter_mut().zip(sample.features.iter()) {
+            *mean += feature * weight;
         }
     }
-    for m in global_mean.iter_mut() {
-        *m /= n as f64;
+    for mean in &mut global_mean {
+        *mean /= total_weight;
     }
-    for s in &samples {
+    for (sample, weight) in &weighted_samples {
         for i in 0..N_FEATURES {
-            global_var[i] += (s.features[i] - global_mean[i]).powi(2);
+            global_var[i] += weight * (sample.features[i] - global_mean[i]).powi(2);
         }
     }
     let mut global_std = [0.0f64; N_FEATURES];
     for i in 0..N_FEATURES {
-        global_std[i] = (global_var[i] / n as f64).sqrt().max(1e-9);
+        global_std[i] = (global_var[i] / total_weight).sqrt().max(1e-9);
     }
 
     // ── Compute per-class statistics ──
     let mut class_sums = vec![[0.0f64; N_FEATURES]; n_classes];
     let mut class_sq = vec![[0.0f64; N_FEATURES]; n_classes];
     let mut class_counts = vec![0usize; n_classes];
-    for s in &samples {
-        let c = s.class_idx;
+    let mut class_weight = vec![0.0f64; n_classes];
+    for (sample, weight) in &weighted_samples {
+        let c = sample.class_idx;
         class_counts[c] += 1;
+        class_weight[c] += weight;
         for i in 0..N_FEATURES {
-            class_sums[c][i] += s.features[i];
-            class_sq[c][i] += s.features[i] * s.features[i];
+            class_sums[c][i] += weight * sample.features[i];
+            class_sq[c][i] += weight * sample.features[i] * sample.features[i];
         }
     }
 
     let mut class_stats = Vec::new();
     for c in 0..n_classes {
-        let cnt = class_counts[c].max(1) as f64;
+        let weight = class_weight[c];
         let mut mean = [0.0; N_FEATURES];
         let mut stddev = [0.0; N_FEATURES];
         for i in 0..N_FEATURES {
-            mean[i] = class_sums[c][i] / cnt;
-            stddev[i] = ((class_sq[c][i] / cnt) - mean[i] * mean[i]).max(0.0).sqrt();
+            mean[i] = class_sums[c][i] / weight;
+            stddev[i] = ((class_sq[c][i] / weight) - mean[i] * mean[i])
+                .max(0.0)
+                .sqrt();
         }
         class_stats.push(ClassStats {
             label: class_names[c].clone(),
@@ -626,14 +730,14 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
     }
 
     // ── Normalise all samples ──
-    let mut norm_samples: Vec<([f64; N_FEATURES], usize)> = samples
+    let mut norm_samples: Vec<([f64; N_FEATURES], usize, f64)> = weighted_samples
         .iter()
-        .map(|s| {
+        .map(|(sample, weight)| {
             let mut x = [0.0; N_FEATURES];
             for i in 0..N_FEATURES {
-                x[i] = (s.features[i] - global_mean[i]) / (global_std[i] + 1e-9);
+                x[i] = (sample.features[i] - global_mean[i]) / (global_std[i] + 1e-9);
             }
-            (x, s.class_idx)
+            (x, sample.class_idx, *weight)
         })
         .collect();
 
@@ -668,7 +772,8 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
             // Accumulate gradients.
             let mut grad: Vec<Vec<f64>> = vec![vec![0.0f64; N_FEATURES + 1]; n_classes];
 
-            for (x, target) in batch {
+            let batch_weight: f64 = batch.iter().map(|(_, _, weight)| weight).sum();
+            for (x, target, sample_weight) in batch {
                 // Forward: softmax.
                 let mut logits: Vec<f64> = vec![0.0; n_classes];
                 for (c, logit) in logits.iter_mut().enumerate() {
@@ -687,11 +792,11 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
                 }
 
                 // Cross-entropy loss.
-                epoch_loss += -(probs[*target].max(1e-15)).ln();
+                epoch_loss += sample_weight * -(probs[*target].max(1e-15)).ln();
 
                 // Gradient: prob - one_hot(target).
                 for c in 0..n_classes {
-                    let delta = probs[c] - if c == *target { 1.0 } else { 0.0 };
+                    let delta = sample_weight * (probs[c] - if c == *target { 1.0 } else { 0.0 });
                     for (g, &xi) in grad[c][..N_FEATURES].iter_mut().zip(x.iter()) {
                         *g += delta * xi;
                     }
@@ -700,17 +805,16 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
             }
 
             // Update weights.
-            let bs = batch.len() as f64;
             let current_lr = lr * (1.0 - epoch as f64 / epochs as f64); // linear decay
             for c in 0..n_classes {
                 for i in 0..=N_FEATURES {
-                    weights[c][i] -= current_lr * grad[c][i] / bs;
+                    weights[c][i] -= current_lr * grad[c][i] / batch_weight;
                 }
             }
         }
 
-        if epoch % 50 == 0 || epoch == epochs - 1 {
-            let avg_loss = epoch_loss / n as f64;
+        if print_progress && (epoch % 50 == 0 || epoch == epochs - 1) {
+            let avg_loss = epoch_loss / total_weight;
             eprintln!("  Epoch {epoch:3}: loss = {avg_loss:.4}");
         }
     }
@@ -729,7 +833,7 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
             .collect()
     };
     let mut correct = 0;
-    for (x, target) in &norm_samples {
+    for (x, target, _) in &norm_samples {
         let logits = compute_logits(x);
         let pred = logits
             .iter()
@@ -742,15 +846,17 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
         }
     }
     let accuracy = correct as f64 / n as f64;
-    eprintln!(
-        "Training accuracy: {correct}/{n} = {:.1}%",
-        accuracy * 100.0
-    );
+    if print_progress {
+        eprintln!(
+            "Training accuracy: {correct}/{n} = {:.1}%",
+            accuracy * 100.0
+        );
+    }
 
     // ── Per-class accuracy ──
     let mut class_correct = vec![0usize; n_classes];
     let mut class_total = vec![0usize; n_classes];
-    for (x, target) in &norm_samples {
+    for (x, target, _) in &norm_samples {
         class_total[*target] += 1;
         let logits = compute_logits(x);
         let pred = logits
@@ -763,18 +869,20 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
             class_correct[*target] += 1;
         }
     }
-    for c in 0..n_classes {
-        let tot = class_total[c].max(1);
-        eprintln!(
-            "  {}: {}/{} ({:.0}%)",
-            class_names[c],
-            class_correct[c],
-            tot,
-            class_correct[c] as f64 / tot as f64 * 100.0
-        );
+    if print_progress {
+        for c in 0..n_classes {
+            let tot = class_total[c].max(1);
+            eprintln!(
+                "  {}: {}/{} ({:.0}%)",
+                class_names[c],
+                class_correct[c],
+                tot,
+                class_correct[c] as f64 / tot as f64 * 100.0
+            );
+        }
     }
 
-    let mut model = AdaptiveModel {
+    Ok(AdaptiveModel {
         class_stats,
         weights,
         global_mean,
@@ -782,67 +890,9 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
         trained_frames: n,
         training_accuracy: accuracy,
         version: 2,
-        class_names,
+        class_names: class_names.to_vec(),
         validation: None,
-    };
-    if can_validate_sessions {
-        model.validation = Some(evaluate_held_out(
-            &model,
-            &validation_samples,
-            held_out_path_by_class.len(),
-        ));
-    } else {
-        eprintln!(
-            "Session-held-out validation unavailable: record at least two independent sessions per class"
-        );
-    }
-    Ok(model)
-}
-
-/// Evaluate the fitted model only on sessions excluded from fitting.
-fn evaluate_held_out(
-    model: &AdaptiveModel,
-    samples: &[Sample],
-    held_out_recordings: usize,
-) -> ValidationMetrics {
-    let n_classes = model.class_names.len();
-    let mut class_correct = vec![0usize; n_classes];
-    let mut class_total = vec![0usize; n_classes];
-    for sample in samples {
-        class_total[sample.class_idx] += 1;
-        let (predicted, _) = model.classify(&sample.features);
-        if predicted == model.class_names[sample.class_idx] {
-            class_correct[sample.class_idx] += 1;
-        }
-    }
-
-    let mut per_class_recall = HashMap::new();
-    for class_idx in 0..n_classes {
-        let recall = if class_total[class_idx] == 0 {
-            0.0
-        } else {
-            class_correct[class_idx] as f64 / class_total[class_idx] as f64
-        };
-        per_class_recall.insert(model.class_names[class_idx].clone(), recall);
-    }
-    let balanced_accuracy = if n_classes == 0 {
-        0.0
-    } else {
-        per_class_recall.values().sum::<f64>() / n_classes as f64
-    };
-    eprintln!(
-        "Held-out balanced accuracy: {:.1}% across {} recording(s) / {} frames",
-        balanced_accuracy * 100.0,
-        held_out_recordings,
-        samples.len()
-    );
-
-    ValidationMetrics {
-        held_out_recordings,
-        held_out_frames: samples.len(),
-        balanced_accuracy,
-        per_class_recall,
-    }
+    })
 }
 
 /// Default path for the saved adaptive model.
@@ -987,7 +1037,7 @@ mod tests {
     }
 
     #[test]
-    fn validation_uses_whole_recording_sessions_not_training_frames() {
+    fn validation_covers_every_recording_and_final_fit_uses_all_frames() {
         let dir = tempfile::tempdir().unwrap();
         for session in 1..=2 {
             write_recording(
@@ -1007,8 +1057,9 @@ mod tests {
         let model = train_from_recordings(dir.path()).unwrap();
         let validation = model.validation.as_ref().expect("held-out metrics");
 
-        assert_eq!(validation.held_out_recordings, 2);
-        assert_eq!(validation.held_out_frames, 80);
+        assert_eq!(validation.held_out_recordings, 4);
+        assert_eq!(validation.held_out_frames, 160);
+        assert_eq!(model.trained_frames, 160);
         assert!(validation.balanced_accuracy > 0.95);
         assert!(model.runtime_eligibility().is_ok());
     }

--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -215,6 +215,23 @@ pub struct AdaptiveModel {
     /// Dynamically discovered class names (in index order).
     #[serde(default = "default_class_names")]
     pub class_names: Vec<String>,
+    /// Session-held-out evaluation. Models saved before schema v2 do not have
+    /// this field and are deliberately ineligible for automatic activation.
+    #[serde(default)]
+    pub validation: Option<ValidationMetrics>,
+}
+
+/// Leakage-resistant evaluation metadata for the runtime activation gate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationMetrics {
+    /// Recording sessions excluded from fitting and used only for evaluation.
+    pub held_out_recordings: usize,
+    /// Frames contained in the held-out sessions.
+    pub held_out_frames: usize,
+    /// Macro-average recall, so a dominant class cannot hide a failed class.
+    pub balanced_accuracy: f64,
+    /// Recall for each class name.
+    pub per_class_recall: HashMap<String, f64>,
 }
 
 /// Backward-compatible fallback for models saved without class_names.
@@ -234,11 +251,78 @@ impl Default for AdaptiveModel {
             training_accuracy: 0.0,
             version: 1,
             class_names: default_class_names(),
+            validation: None,
         }
     }
 }
 
 impl AdaptiveModel {
+    /// Whether this model has enough independent evidence to override the
+    /// conservative threshold classifier in production.
+    pub fn runtime_eligibility(&self) -> Result<(), String> {
+        let metrics = self.validation.as_ref().ok_or_else(|| {
+            "model has no session-held-out validation; automatic activation is unsafe".to_string()
+        })?;
+        let n_classes = self.class_names.len();
+        if n_classes < 2 {
+            return Err("model needs at least two classes".into());
+        }
+        if self.trained_frames == 0 {
+            return Err("model contains no fitted frames".into());
+        }
+        if self.weights.len() != n_classes
+            || self
+                .weights
+                .iter()
+                .any(|row| row.len() != N_FEATURES + 1 || row.iter().any(|v| !v.is_finite()))
+        {
+            return Err("model weight shape or values do not match its classes".into());
+        }
+        if self.class_stats.len() != n_classes
+            || self.global_mean.iter().any(|v| !v.is_finite())
+            || self.global_std.iter().any(|v| !v.is_finite() || *v <= 0.0)
+        {
+            return Err("model normalization or class statistics are invalid".into());
+        }
+        if metrics.held_out_recordings < n_classes {
+            return Err(format!(
+                "held-out validation needs at least one independent recording per class (have {}, need {n_classes})",
+                metrics.held_out_recordings
+            ));
+        }
+        if metrics.held_out_frames == 0 {
+            return Err("held-out validation contains no frames".into());
+        }
+
+        // Binary classifiers must clear a higher bar than four-way models
+        // because 50% is already random chance. The fixed 0.60 floor prevents
+        // a many-class model from activating on a superficially small margin.
+        let chance = 1.0 / n_classes as f64;
+        let required_balanced_accuracy = 0.60_f64.max(chance + 0.20);
+        if !metrics.balanced_accuracy.is_finite()
+            || metrics.balanced_accuracy < required_balanced_accuracy
+        {
+            return Err(format!(
+                "held-out balanced accuracy {:.3} is below activation floor {:.3}",
+                metrics.balanced_accuracy, required_balanced_accuracy
+            ));
+        }
+
+        for class_name in &self.class_names {
+            let recall = metrics
+                .per_class_recall
+                .get(class_name)
+                .copied()
+                .ok_or_else(|| format!("held-out recall missing for class '{class_name}'"))?;
+            if !recall.is_finite() || recall < 0.50 {
+                return Err(format!(
+                    "held-out recall for class '{class_name}' is {recall:.3}, below 0.500"
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Classify a raw feature vector.  Returns (class_label, confidence).
     pub fn classify(&self, raw_features: &[f64; N_FEATURES]) -> (String, f64) {
         let n_classes = self.weights.len();
@@ -299,6 +383,14 @@ impl AdaptiveModel {
     pub fn load(path: &Path) -> std::io::Result<Self> {
         let json = std::fs::read_to_string(path)?;
         serde_json::from_str(&json).map_err(std::io::Error::other)
+    }
+
+    /// Load a persisted model only when its independent-session evidence is
+    /// strong enough for automatic runtime activation.
+    pub fn load_runtime(path: &Path) -> Result<Self, String> {
+        let model = Self::load(path).map_err(|error| error.to_string())?;
+        model.runtime_eligibility()?;
+        Ok(model)
     }
 }
 
@@ -405,18 +497,47 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
         return Err("No training samples found. Record data with train_* prefix.".into());
     }
 
-    // Second pass: load recordings with the discovered class indices.
+    // Stable ordering makes both the held-out choice and model fitting
+    // reproducible across filesystems whose read_dir order differs.
+    file_classes.sort_by(|a, b| a.1.cmp(&b.1));
+
+    // Hold out one whole recording per class. Adjacent CSI frames are highly
+    // autocorrelated, so a random frame split leaks a session's room/channel
+    // fingerprint into validation and overstates deployment accuracy.
+    let mut recordings_per_class: HashMap<String, usize> = HashMap::new();
+    for (_, _, class_name) in &file_classes {
+        *recordings_per_class.entry(class_name.clone()).or_default() += 1;
+    }
+    let can_validate_sessions = class_names
+        .iter()
+        .all(|name| recordings_per_class.get(name).copied().unwrap_or(0) >= 2);
+    let mut held_out_path_by_class: HashMap<String, PathBuf> = HashMap::new();
+    if can_validate_sessions {
+        for (path, _, class_name) in &file_classes {
+            // Sorted iteration intentionally leaves the last session per class.
+            held_out_path_by_class.insert(class_name.clone(), path.clone());
+        }
+    }
+
+    // Second pass: load fitting and held-out sessions separately.
     let mut samples: Vec<Sample> = Vec::new();
+    let mut validation_samples: Vec<Sample> = Vec::new();
     for (path, fname, class_name) in &file_classes {
         let class_idx = class_map[class_name];
         let loaded = load_recording(path, class_idx);
+        let is_held_out = held_out_path_by_class.get(class_name) == Some(path);
         eprintln!(
-            "  Loaded {}: {} frames → class '{}'",
+            "  Loaded {}: {} frames → class '{}'{}",
             fname,
             loaded.len(),
-            class_name
+            class_name,
+            if is_held_out { " [held out]" } else { "" }
         );
-        samples.extend(loaded);
+        if is_held_out {
+            validation_samples.extend(loaded);
+        } else {
+            samples.extend(loaded);
+        }
     }
 
     if samples.is_empty() {
@@ -597,7 +718,10 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
         }
     }
     let accuracy = correct as f64 / n as f64;
-    eprintln!("Training accuracy: {correct}/{n} = {accuracy:.1}%");
+    eprintln!(
+        "Training accuracy: {correct}/{n} = {:.1}%",
+        accuracy * 100.0
+    );
 
     // ── Per-class accuracy ──
     let mut class_correct = vec![0usize; n_classes];
@@ -626,19 +750,242 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
         );
     }
 
-    Ok(AdaptiveModel {
+    let mut model = AdaptiveModel {
         class_stats,
         weights,
         global_mean,
         global_std,
         trained_frames: n,
         training_accuracy: accuracy,
-        version: 1,
+        version: 2,
         class_names,
-    })
+        validation: None,
+    };
+    if can_validate_sessions {
+        model.validation = Some(evaluate_held_out(
+            &model,
+            &validation_samples,
+            held_out_path_by_class.len(),
+        ));
+    } else {
+        eprintln!(
+            "Session-held-out validation unavailable: record at least two independent sessions per class"
+        );
+    }
+    Ok(model)
+}
+
+/// Evaluate the fitted model only on sessions excluded from fitting.
+fn evaluate_held_out(
+    model: &AdaptiveModel,
+    samples: &[Sample],
+    held_out_recordings: usize,
+) -> ValidationMetrics {
+    let n_classes = model.class_names.len();
+    let mut class_correct = vec![0usize; n_classes];
+    let mut class_total = vec![0usize; n_classes];
+    for sample in samples {
+        class_total[sample.class_idx] += 1;
+        let (predicted, _) = model.classify(&sample.features);
+        if predicted == model.class_names[sample.class_idx] {
+            class_correct[sample.class_idx] += 1;
+        }
+    }
+
+    let mut per_class_recall = HashMap::new();
+    for class_idx in 0..n_classes {
+        let recall = if class_total[class_idx] == 0 {
+            0.0
+        } else {
+            class_correct[class_idx] as f64 / class_total[class_idx] as f64
+        };
+        per_class_recall.insert(model.class_names[class_idx].clone(), recall);
+    }
+    let balanced_accuracy = if n_classes == 0 {
+        0.0
+    } else {
+        per_class_recall.values().sum::<f64>() / n_classes as f64
+    };
+    eprintln!(
+        "Held-out balanced accuracy: {:.1}% across {} recording(s) / {} frames",
+        balanced_accuracy * 100.0,
+        held_out_recordings,
+        samples.len()
+    );
+
+    ValidationMetrics {
+        held_out_recordings,
+        held_out_frames: samples.len(),
+        balanced_accuracy,
+        per_class_recall,
+    }
 }
 
 /// Default path for the saved adaptive model.
 pub fn model_path() -> PathBuf {
     PathBuf::from("data/adaptive_model.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn model_with_validation(balanced_accuracy: f64, recalls: &[(&str, f64)]) -> AdaptiveModel {
+        let mut model = AdaptiveModel::default();
+        model.version = 2;
+        model.class_names = recalls
+            .iter()
+            .map(|(name, _)| (*name).to_string())
+            .collect();
+        model.trained_frames = 800;
+        model.weights = vec![vec![0.0; N_FEATURES + 1]; recalls.len()];
+        model.class_stats = recalls
+            .iter()
+            .map(|(name, _)| ClassStats {
+                label: (*name).to_string(),
+                count: 400,
+                mean: [0.0; N_FEATURES],
+                stddev: [1.0; N_FEATURES],
+            })
+            .collect();
+        model.validation = Some(ValidationMetrics {
+            held_out_recordings: recalls.len(),
+            held_out_frames: 400,
+            balanced_accuracy,
+            per_class_recall: recalls
+                .iter()
+                .map(|(name, recall)| ((*name).to_string(), *recall))
+                .collect(),
+        });
+        model
+    }
+
+    #[test]
+    fn legacy_model_without_session_validation_is_not_runtime_eligible() {
+        let mut model = AdaptiveModel::default();
+        model.training_accuracy = 1.0;
+
+        let error = model.runtime_eligibility().unwrap_err();
+
+        assert!(error.contains("held-out"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn model_must_beat_dynamic_chance_margin_and_each_class_floor() {
+        let weak_binary = model_with_validation(0.69, &[("absent", 0.70), ("present_still", 0.68)]);
+        assert!(weak_binary.runtime_eligibility().is_err());
+
+        let collapsed_class =
+            model_with_validation(0.75, &[("absent", 0.98), ("present_still", 0.49)]);
+        assert!(collapsed_class.runtime_eligibility().is_err());
+
+        let eligible = model_with_validation(0.80, &[("absent", 0.82), ("present_still", 0.78)]);
+        assert!(eligible.runtime_eligibility().is_ok());
+    }
+
+    #[test]
+    fn every_class_needs_an_independent_held_out_recording() {
+        let mut model = model_with_validation(0.80, &[("absent", 0.82), ("present_still", 0.78)]);
+        model.validation.as_mut().unwrap().held_out_recordings = 1;
+
+        assert!(model.runtime_eligibility().is_err());
+    }
+
+    #[test]
+    fn malformed_or_non_finite_model_artifacts_are_never_activated() {
+        let mut wrong_shape =
+            model_with_validation(0.80, &[("absent", 0.82), ("present_still", 0.78)]);
+        wrong_shape.weights[0].pop();
+        assert!(wrong_shape.runtime_eligibility().is_err());
+
+        let mut non_finite =
+            model_with_validation(0.80, &[("absent", 0.82), ("present_still", 0.78)]);
+        non_finite.global_std[3] = f64::NAN;
+        assert!(non_finite.runtime_eligibility().is_err());
+    }
+
+    #[test]
+    fn runtime_loader_rejects_legacy_model_even_when_training_accuracy_is_high() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("model.json");
+        let mut model = AdaptiveModel::default();
+        model.training_accuracy = 1.0;
+        model.save(&path).unwrap();
+
+        assert!(AdaptiveModel::load_runtime(&path).is_err());
+    }
+
+    #[test]
+    fn runtime_loader_accepts_session_validated_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("model.json");
+        let model = model_with_validation(0.80, &[("absent", 0.82), ("present_still", 0.78)]);
+        model.save(&path).unwrap();
+
+        assert!(AdaptiveModel::load_runtime(&path).is_ok());
+    }
+
+    fn write_recording(dir: &Path, name: &str, variance: f64, amp: f64) {
+        let mut file = std::fs::File::create(dir.join(name)).unwrap();
+        for i in 0..40 {
+            let frame = serde_json::json!({
+                "features": {
+                    "variance": variance + (i % 3) as f64 * 0.01,
+                    "motion_band_power": variance,
+                    "breathing_band_power": variance * 0.5,
+                    "spectral_power": variance + 1.0,
+                    "dominant_freq_hz": variance * 0.01,
+                    "change_points": if variance > 10.0 { 8 } else { 0 },
+                    "mean_rssi": if variance > 10.0 { -45.0 } else { -60.0 }
+                },
+                "nodes": [{ "amplitude": [amp, amp + 0.1, amp + 0.2, amp + 0.3] }]
+            });
+            writeln!(file, "{frame}").unwrap();
+        }
+    }
+
+    #[test]
+    fn one_recording_per_class_cannot_claim_generalization() {
+        let dir = tempfile::tempdir().unwrap();
+        write_recording(dir.path(), "train_absent_session1.jsonl", 1.0, 1.0);
+        write_recording(
+            dir.path(),
+            "train_present_still_session1.jsonl",
+            100.0,
+            20.0,
+        );
+
+        let model = train_from_recordings(dir.path()).unwrap();
+
+        assert!(model.validation.is_none());
+        assert!(model.runtime_eligibility().is_err());
+    }
+
+    #[test]
+    fn validation_uses_whole_recording_sessions_not_training_frames() {
+        let dir = tempfile::tempdir().unwrap();
+        for session in 1..=2 {
+            write_recording(
+                dir.path(),
+                &format!("train_absent_session{session}.jsonl"),
+                1.0,
+                1.0,
+            );
+            write_recording(
+                dir.path(),
+                &format!("train_present_still_session{session}.jsonl"),
+                100.0,
+                20.0,
+            );
+        }
+
+        let model = train_from_recordings(dir.path()).unwrap();
+        let validation = model.validation.as_ref().expect("held-out metrics");
+
+        assert_eq!(validation.held_out_recordings, 2);
+        assert_eq!(validation.held_out_frames, 80);
+        assert!(validation.balanced_accuracy > 0.95);
+        assert!(model.runtime_eligibility().is_ok());
+    }
 }

--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -288,6 +288,48 @@ pub fn reconcile_presence_prediction(
     }
 }
 
+/// Debounces learned presence probabilities before they can change room state.
+#[derive(Debug, Default)]
+pub struct AdaptivePresenceSmoother {
+    present_score: Option<f64>,
+    present: Option<bool>,
+}
+
+impl AdaptivePresenceSmoother {
+    pub fn update(&mut self, learned_label: &str, confidence: f64) -> bool {
+        let confidence = if confidence.is_finite() {
+            confidence.clamp(0.0, 1.0)
+        } else {
+            0.5
+        };
+        let observation = if learned_label == "absent" {
+            1.0 - confidence
+        } else {
+            confidence
+        };
+        let score = self
+            .present_score
+            .map(|previous| previous * 0.9 + observation * 0.1)
+            .unwrap_or(observation);
+        self.present_score = Some(score);
+        let present = match self.present {
+            Some(true) => score >= 0.35,
+            Some(false) => score > 0.65,
+            None => score >= 0.5,
+        };
+        self.present = Some(present);
+        present
+    }
+
+    pub fn is_present(&self) -> Option<bool> {
+        self.present
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
 /// Compute statistical features from raw subcarrier amplitudes.
 fn subcarrier_stats(amps: &[f64]) -> (f64, f64, f64, f64, f64, f64, f64, f64) {
     // HashMap-backed node serialization has no stable order. Sorting makes all
@@ -1094,9 +1136,16 @@ fn fit_model(
     })
 }
 
-/// Default path for the saved adaptive model.
+fn model_path_from(configured: Option<std::ffi::OsString>) -> PathBuf {
+    configured
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("data/adaptive_model.json"))
+}
+
+/// Default path for the saved adaptive model, overridable for private products.
 pub fn model_path() -> PathBuf {
-    PathBuf::from("data/adaptive_model.json")
+    model_path_from(std::env::var_os("RUVIEW_ADAPTIVE_MODEL_PATH"))
 }
 
 #[cfg(test)]
@@ -1293,6 +1342,33 @@ mod tests {
         assert_eq!(
             ("absent".to_string(), false),
             reconcile_presence_prediction("absent", "active")
+        );
+    }
+
+    #[test]
+    fn presence_smoother_rejects_a_single_contrary_prediction() {
+        let mut smoother = AdaptivePresenceSmoother::default();
+        assert!(smoother.update("present", 0.9));
+
+        assert!(
+            smoother.update("absent", 0.9),
+            "one noisy frame must not clear an occupied room"
+        );
+        for _ in 0..20 {
+            smoother.update("absent", 0.9);
+        }
+        assert!(!smoother.is_present().unwrap());
+    }
+
+    #[test]
+    fn private_model_path_does_not_change_the_default() {
+        assert_eq!(
+            PathBuf::from("/private/model.json"),
+            model_path_from(Some("/private/model.json".into()))
+        );
+        assert_eq!(
+            PathBuf::from("data/adaptive_model.json"),
+            model_path_from(None)
         );
     }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -16,19 +16,29 @@
 //! with the appropriate filename convention.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 // ── Feature vector ───────────────────────────────────────────────────────────
 
-/// Extended feature vector: 7 server features + 8 subcarrier-derived features = 15.
-const N_FEATURES: usize = 15;
+/// Instantaneous feature vector: 7 server features + 8 subcarrier statistics.
+const N_BASE_FEATURES: usize = 15;
+/// The most dynamic server/subcarrier channels used by the temporal patch.
+const TEMPORAL_FEATURE_INDICES: [usize; 8] = [0, 1, 2, 3, 4, 5, 7, 8];
+const N_TEMPORAL_FEATURES: usize = TEMPORAL_FEATURE_INDICES.len();
+/// Five-second patch: current features + selected velocity + selected stddev.
+/// Kept at 31 so the persisted fixed-size arrays remain natively serde-compatible.
+const N_FEATURES: usize = N_BASE_FEATURES + N_TEMPORAL_FEATURES * 2;
+const TEMPORAL_BUCKET_SECONDS: f64 = 1.0;
+const TEMPORAL_WINDOW_BUCKETS: i64 = 5;
+const TEMPORAL_MIN_CONTEXT_BUCKETS: usize = 3;
 
 /// Default class names for backward compatibility with old saved models.
-const DEFAULT_CLASSES: &[&str] = &["absent", "present_still", "present_moving", "active"];
+const DEFAULT_CLASSES: &[&str] = &["absent", "present"];
 
 /// Extract extended feature vector from a JSONL frame (features + raw amplitudes).
-pub fn features_from_frame(frame: &serde_json::Value) -> [f64; N_FEATURES] {
+pub fn features_from_frame(frame: &serde_json::Value) -> [f64; N_BASE_FEATURES] {
     // spatial-intelligence stores the original RuView envelope under
     // `payload`; RuView's own recorder writes the envelope at the root. Keep
     // one feature contract so offline evaluation cannot silently turn every
@@ -103,7 +113,7 @@ pub fn features_from_frame(frame: &serde_json::Value) -> [f64; N_FEATURES] {
 }
 
 /// Also keep a simpler version for runtime (no JSONL, just FeatureInfo + amps).
-pub fn features_from_runtime(feat: &serde_json::Value, amps: &[f64]) -> [f64; N_FEATURES] {
+pub fn features_from_runtime(feat: &serde_json::Value, amps: &[f64]) -> [f64; N_BASE_FEATURES] {
     let variance = feat.get("variance").and_then(|v| v.as_f64()).unwrap_or(0.0);
     let mbp = feat
         .get("motion_band_power")
@@ -148,6 +158,134 @@ pub fn features_from_runtime(feat: &serde_json::Value, amps: &[f64]) -> [f64; N_
         amp_max,
         amp_range,
     ]
+}
+
+/// Rate-invariant short temporal patch shared by offline fitting and runtime.
+///
+/// RuView can process ESP32 frames around 30 Hz while the product recorder
+/// polls `/latest` at 1 Hz. Keeping one latest observation per wall-clock
+/// second prevents sample rate from becoming an accidental class label.
+#[derive(Debug, Default)]
+pub struct AdaptiveFeatureExtractor {
+    history: VecDeque<(i64, [f64; N_BASE_FEATURES])>,
+    runtime_origin: Option<Instant>,
+}
+
+impl AdaptiveFeatureExtractor {
+    /// Add one observation at a monotonic/epoch timestamp in seconds.
+    pub fn observe_at(
+        &mut self,
+        base: [f64; N_BASE_FEATURES],
+        timestamp_seconds: f64,
+    ) -> Option<[f64; N_FEATURES]> {
+        if !timestamp_seconds.is_finite() || base.iter().any(|value| !value.is_finite()) {
+            return None;
+        }
+        let bucket = (timestamp_seconds / TEMPORAL_BUCKET_SECONDS).floor() as i64;
+        match self.history.back_mut() {
+            Some((last_bucket, last_base)) if *last_bucket == bucket => {
+                *last_base = base;
+            }
+            Some((last_bucket, _)) if bucket < *last_bucket => {
+                self.history.clear();
+                self.history.push_back((bucket, base));
+            }
+            Some((last_bucket, _)) => {
+                if bucket - *last_bucket >= TEMPORAL_WINDOW_BUCKETS {
+                    self.history.clear();
+                }
+                self.history.push_back((bucket, base));
+            }
+            None => self.history.push_back((bucket, base)),
+        }
+
+        while self
+            .history
+            .front()
+            .is_some_and(|(oldest, _)| bucket - *oldest >= TEMPORAL_WINDOW_BUCKETS)
+        {
+            self.history.pop_front();
+        }
+
+        if self.history.len() < TEMPORAL_MIN_CONTEXT_BUCKETS {
+            return None;
+        }
+        let span = self.history.back()?.0 - self.history.front()?.0;
+        if span < (TEMPORAL_MIN_CONTEXT_BUCKETS - 1) as i64 {
+            return None;
+        }
+
+        let mut output = [0.0; N_FEATURES];
+        output[..N_BASE_FEATURES].copy_from_slice(&base);
+        for (temporal_index, feature_index) in TEMPORAL_FEATURE_INDICES.iter().copied().enumerate()
+        {
+            let mean = self
+                .history
+                .iter()
+                .map(|(_, values)| values[feature_index])
+                .sum::<f64>()
+                / self.history.len() as f64;
+            let variance = self
+                .history
+                .iter()
+                .map(|(_, values)| (values[feature_index] - mean).powi(2))
+                .sum::<f64>()
+                / self.history.len() as f64;
+            let mean_abs_velocity = self
+                .history
+                .iter()
+                .zip(self.history.iter().skip(1))
+                .map(|((before_bucket, before), (after_bucket, after))| {
+                    (after[feature_index] - before[feature_index]).abs()
+                        / (*after_bucket - *before_bucket) as f64
+                })
+                .sum::<f64>()
+                / (self.history.len() - 1) as f64;
+            output[N_BASE_FEATURES + temporal_index] = mean_abs_velocity;
+            output[N_BASE_FEATURES + N_TEMPORAL_FEATURES + temporal_index] = variance.sqrt();
+        }
+        Some(output)
+    }
+
+    /// Add a live observation using a process-local monotonic clock.
+    pub fn observe_runtime(
+        &mut self,
+        feature_json: &serde_json::Value,
+        amplitudes: &[f64],
+    ) -> Option<[f64; N_FEATURES]> {
+        let origin = *self.runtime_origin.get_or_insert_with(Instant::now);
+        self.observe_at(
+            features_from_runtime(feature_json, amplitudes),
+            origin.elapsed().as_secs_f64(),
+        )
+    }
+
+    /// A newly loaded model must never inherit temporal context from the old one.
+    pub fn reset(&mut self) {
+        self.history.clear();
+        self.runtime_origin = None;
+    }
+}
+
+/// Merge the learned presence stage with the high-rate heuristic motion stage.
+pub fn reconcile_presence_prediction(
+    learned_label: &str,
+    heuristic_motion: &str,
+) -> (String, bool) {
+    match learned_label {
+        "absent" => ("absent".to_string(), false),
+        "present" => {
+            let motion = if heuristic_motion == "absent" {
+                "present_still"
+            } else {
+                heuristic_motion
+            };
+            (motion.to_string(), true)
+        }
+        // Preserve compatibility with explicit activity classes in externally
+        // produced models while the built-in trainer remains hierarchical.
+        other => (other.to_string(), other != "absent"),
+    }
 }
 
 /// Compute statistical features from raw subcarrier amplitudes.
@@ -239,6 +377,9 @@ pub struct AdaptiveModel {
     /// Dynamically discovered class names (in index order).
     #[serde(default = "default_class_names")]
     pub class_names: Vec<String>,
+    /// Sensor topology this local specialist was fitted for.
+    #[serde(default)]
+    pub expected_node_count: Option<usize>,
     /// Session-held-out evaluation. Models saved before schema v2 do not have
     /// this field and are deliberately ineligible for automatic activation.
     #[serde(default)]
@@ -275,6 +416,7 @@ impl Default for AdaptiveModel {
             training_accuracy: 0.0,
             version: 1,
             class_names: default_class_names(),
+            expected_node_count: None,
             validation: None,
         }
     }
@@ -293,6 +435,9 @@ impl AdaptiveModel {
         }
         if self.trained_frames == 0 {
             return Err("model contains no fitted frames".into());
+        }
+        if self.expected_node_count == Some(0) {
+            return Err("model node topology cannot be zero".into());
         }
         if self.weights.len() != n_classes
             || self
@@ -435,22 +580,51 @@ struct Recording {
 }
 
 /// Load JSONL recording frames and assign a class label based on filename.
-fn load_recording(path: &Path, class_idx: usize) -> Vec<Sample> {
+fn load_recording(path: &Path, class_idx: usize) -> (Vec<Sample>, Option<usize>) {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
-        Err(_) => return Vec::new(),
+        Err(_) => return (Vec::new(), None),
     };
-    content
-        .lines()
-        .filter_map(|line| {
-            let v: serde_json::Value = serde_json::from_str(line).ok()?;
-            // Use extended features (server features + subcarrier stats).
-            Some(Sample {
-                features: features_from_frame(&v),
-                class_idx,
+    let mut temporal = AdaptiveFeatureExtractor::default();
+    let mut samples = Vec::new();
+    let mut topology_counts: HashMap<usize, usize> = HashMap::new();
+    for (index, line) in content.lines().enumerate() {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let envelope = v.get("payload").unwrap_or(&v);
+        if let Some(node_count) = envelope
+            .get("nodes")
+            .and_then(|nodes| nodes.as_array())
+            .map(Vec::len)
+            .filter(|count| *count > 0)
+        {
+            *topology_counts.entry(node_count).or_default() += 1;
+        }
+        let timestamp_seconds = envelope
+            .get("timestamp")
+            .and_then(|value| value.as_f64())
+            .or_else(|| {
+                v.get("captured_at")
+                    .and_then(|value| value.as_str())
+                    .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+                    .map(|value| value.timestamp_millis() as f64 / 1000.0)
             })
-        })
-        .collect()
+            // Old recordings without timestamps remain usable, but their
+            // ordering is made explicit as one sample per second.
+            .unwrap_or(index as f64);
+        if let Some(features) = temporal.observe_at(features_from_frame(&v), timestamp_seconds) {
+            samples.push(Sample {
+                features,
+                class_idx,
+            });
+        }
+    }
+    let node_count = topology_counts
+        .into_iter()
+        .max_by_key(|(node_count, observations)| (*observations, *node_count))
+        .map(|(node_count, _)| node_count);
+    (samples, node_count)
 }
 
 /// Map a recording filename to a class name (String).
@@ -466,14 +640,19 @@ fn classify_recording_name(name: &str) -> Option<String> {
     if lower.contains("empty") || lower.contains("absent") {
         return Some("absent".into());
     }
-    if lower.contains("still") || lower.contains("sitting") || lower.contains("standing") {
-        return Some("present_still".into());
-    }
-    if lower.contains("walking") || lower.contains("moving") {
-        return Some("present_moving".into());
-    }
-    if lower.contains("active") || lower.contains("exercise") || lower.contains("running") {
-        return Some("active".into());
+    if lower.contains("still")
+        || lower.contains("sitting")
+        || lower.contains("standing")
+        || lower.contains("walking")
+        || lower.contains("moving")
+        || lower.contains("active")
+        || lower.contains("exercise")
+        || lower.contains("running")
+    {
+        // Presence is the safety-critical first stage. Motion granularity stays
+        // with the high-rate heuristic until each activity has enough truly
+        // independent sessions to support its own held-out classifier.
+        return Some("present".into());
     }
 
     // Fallback: extract class from filename structure train_<class>_*.jsonl
@@ -493,11 +672,17 @@ fn classify_recording_name(name: &str) -> Option<String> {
 /// Recordings are matched to classes by filename pattern. Classes are discovered
 /// dynamically from the training data filenames:
 /// - `*empty*` / `*absent*`   → absent
-/// - `*still*` / `*sitting*`  → present_still
-/// - `*walking*` / `*moving*` → present_moving
-/// - `*active*` / `*exercise*`→ active
+/// - occupied still/walking/active patterns → present
 /// - Any other `train_<class>_*.jsonl` → <class>
 pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, String> {
+    train_from_recordings_for_node_count(recordings_dir, None)
+}
+
+/// Train only from sessions matching the active sensor topology when known.
+pub fn train_from_recordings_for_node_count(
+    recordings_dir: &Path,
+    expected_node_count: Option<usize>,
+) -> Result<AdaptiveModel, String> {
     // First pass: scan filenames to discover all unique class names.
     let entries: Vec<_> = std::fs::read_dir(recordings_dir)
         .map_err(|e| format!("Cannot read {}: {}", recordings_dir.display(), e))?
@@ -541,11 +726,18 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
     let mut recordings_per_class: HashMap<String, usize> = HashMap::new();
     for (path, fname, class_name) in file_classes {
         let class_idx = class_map[&class_name];
-        let samples = load_recording(&path, class_idx);
+        let (samples, observed_node_count) = load_recording(&path, class_idx);
         if samples.is_empty() {
             return Err(format!(
                 "Training recording '{fname}' contains no valid frames"
             ));
+        }
+        if expected_node_count.is_some() && observed_node_count != expected_node_count {
+            eprintln!(
+                "  Skipped {}: recorded topology {:?}, active topology {:?}",
+                fname, observed_node_count, expected_node_count
+            );
+            continue;
         }
         eprintln!(
             "  Loaded {}: {} frames → class '{}'",
@@ -577,7 +769,12 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
                 .enumerate()
                 .filter_map(|(index, recording)| (index != held_out_index).then_some(recording))
                 .collect();
-            let fold_model = fit_model(&training_recordings, &class_names, false)?;
+            let fold_model = fit_model(
+                &training_recordings,
+                &class_names,
+                expected_node_count,
+                false,
+            )?;
             let held_out = &recordings[held_out_index];
             eprintln!("  LOSO held out '{}'", held_out.name);
             for sample in &held_out.samples {
@@ -621,7 +818,7 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
     // Validation models are disposable. The deployed model is refit on every
     // accepted session so scarce local calibration data is not wasted.
     let all_recordings: Vec<&Recording> = recordings.iter().collect();
-    let mut model = fit_model(&all_recordings, &class_names, true)?;
+    let mut model = fit_model(&all_recordings, &class_names, expected_node_count, true)?;
     model.validation = validation;
     Ok(model)
 }
@@ -630,6 +827,7 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
 fn fit_model(
     recordings: &[&Recording],
     class_names: &[String],
+    expected_node_count: Option<usize>,
     print_progress: bool,
 ) -> Result<AdaptiveModel, String> {
     let n_classes = class_names.len();
@@ -889,8 +1087,9 @@ fn fit_model(
         global_std,
         trained_frames: n,
         training_accuracy: accuracy,
-        version: 2,
+        version: 3,
         class_names: class_names.to_vec(),
+        expected_node_count,
         validation: None,
     })
 }
@@ -907,7 +1106,7 @@ mod tests {
 
     fn model_with_validation(balanced_accuracy: f64, recalls: &[(&str, f64)]) -> AdaptiveModel {
         let mut model = AdaptiveModel::default();
-        model.version = 2;
+        model.version = 3;
         model.class_names = recalls
             .iter()
             .map(|(name, _)| (*name).to_string())
@@ -1001,8 +1200,26 @@ mod tests {
     }
 
     fn write_recording(dir: &Path, name: &str, variance: f64, amp: f64) {
+        write_recording_with_node_count(dir, name, variance, amp, 1);
+    }
+
+    fn write_recording_with_node_count(
+        dir: &Path,
+        name: &str,
+        variance: f64,
+        amp: f64,
+        node_count: usize,
+    ) {
         let mut file = std::fs::File::create(dir.join(name)).unwrap();
         for i in 0..40 {
+            let nodes: Vec<_> = (0..node_count)
+                .map(|node_id| {
+                    serde_json::json!({
+                        "node_id": node_id + 1,
+                        "amplitude": [amp, amp + 0.1, amp + 0.2, amp + 0.3]
+                    })
+                })
+                .collect();
             let frame = serde_json::json!({
                 "features": {
                     "variance": variance + (i % 3) as f64 * 0.01,
@@ -1013,10 +1230,99 @@ mod tests {
                     "change_points": if variance > 10.0 { 8 } else { 0 },
                     "mean_rssi": if variance > 10.0 { -45.0 } else { -60.0 }
                 },
-                "nodes": [{ "amplitude": [amp, amp + 0.1, amp + 0.2, amp + 0.3] }]
+                "nodes": nodes
             });
             writeln!(file, "{frame}").unwrap();
         }
+    }
+
+    #[test]
+    fn temporal_patch_is_rate_invariant_and_requires_context() {
+        let mut one_hz = AdaptiveFeatureExtractor::default();
+        let mut ten_hz = AdaptiveFeatureExtractor::default();
+
+        let base = |value: f64| {
+            let mut features = [0.0; N_BASE_FEATURES];
+            features[0] = value;
+            features
+        };
+
+        assert!(one_hz.observe_at(base(0.0), 0.0).is_none());
+        assert!(one_hz.observe_at(base(1.0), 1.0).is_none());
+        let slow = one_hz.observe_at(base(2.0), 2.0).expect("two-second patch");
+
+        let mut fast = None;
+        for step in 0..=20 {
+            let time = step as f64 / 10.0;
+            fast = ten_hz.observe_at(base(time.floor()), time);
+        }
+
+        assert_eq!(slow, fast.expect("two-second patch"));
+        assert_eq!(2.0, slow[0]);
+        assert_eq!(1.0, slow[N_BASE_FEATURES]);
+        assert!(
+            (slow[N_BASE_FEATURES + N_TEMPORAL_FEATURES] - (2.0_f64 / 3.0).sqrt()).abs() < 1e-9
+        );
+    }
+
+    #[test]
+    fn occupied_recording_names_share_the_presence_class() {
+        for name in [
+            "train_present_still_desk.jsonl",
+            "train_walking_room.jsonl",
+            "train_active_dressing.jsonl",
+        ] {
+            assert_eq!(Some("present".to_string()), classify_recording_name(name));
+        }
+        assert_eq!(
+            Some("absent".to_string()),
+            classify_recording_name("train_empty_room.jsonl")
+        );
+    }
+
+    #[test]
+    fn learned_presence_preserves_motion_granularity() {
+        assert_eq!(
+            ("active".to_string(), true),
+            reconcile_presence_prediction("present", "active")
+        );
+        assert_eq!(
+            ("present_still".to_string(), true),
+            reconcile_presence_prediction("present", "absent")
+        );
+        assert_eq!(
+            ("absent".to_string(), false),
+            reconcile_presence_prediction("absent", "active")
+        );
+    }
+
+    #[test]
+    fn topology_filter_excludes_incompatible_recordings() {
+        let dir = tempfile::tempdir().unwrap();
+        for session in 1..=2 {
+            write_recording_with_node_count(
+                dir.path(),
+                &format!("train_absent_dual{session}.jsonl"),
+                1.0,
+                1.0,
+                2,
+            );
+            write_recording_with_node_count(
+                dir.path(),
+                &format!("train_present_still_dual{session}.jsonl"),
+                100.0,
+                20.0,
+                2,
+            );
+        }
+        write_recording(dir.path(), "train_absent_single.jsonl", 50.0, 10.0);
+        write_recording(dir.path(), "train_present_still_single.jsonl", 50.0, 10.0);
+
+        let model = train_from_recordings_for_node_count(dir.path(), Some(2)).unwrap();
+
+        assert_eq!(Some(2), model.expected_node_count);
+        assert_eq!(152, model.trained_frames);
+        assert_eq!(4, model.validation.unwrap().held_out_recordings);
     }
 
     #[test]
@@ -1058,8 +1364,8 @@ mod tests {
         let validation = model.validation.as_ref().expect("held-out metrics");
 
         assert_eq!(validation.held_out_recordings, 4);
-        assert_eq!(validation.held_out_frames, 160);
-        assert_eq!(model.trained_frames, 160);
+        assert_eq!(validation.held_out_frames, 152);
+        assert_eq!(model.trained_frames, 152);
         assert!(validation.balanced_accuracy > 0.95);
         assert!(model.runtime_eligibility().is_ok());
     }

--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -3,7 +3,7 @@
 //! Learns environment-specific classification thresholds from labeled JSONL
 //! recordings.  Uses a lightweight approach:
 //!
-//! 1. **Feature statistics**: per-class mean/stddev for each of 7 CSI features
+//! 1. **Feature statistics**: per-class mean/stddev for each server-published CSI feature
 //! 2. **Mahalanobis-like distance**: weighted distance to each class centroid
 //! 3. **Logistic regression weights**: learned via gradient descent on the
 //!    labeled data for fine-grained boundary tuning
@@ -22,14 +22,17 @@ use std::time::Instant;
 
 // ── Feature vector ───────────────────────────────────────────────────────────
 
-/// Instantaneous feature vector: 7 server features + 8 subcarrier statistics.
-const N_BASE_FEATURES: usize = 15;
-/// The most dynamic server/subcarrier channels used by the temporal patch.
-const TEMPORAL_FEATURE_INDICES: [usize; 8] = [0, 1, 2, 3, 4, 5, 7, 8];
+/// Instantaneous feature vector published identically to the recorder and runtime.
+/// Raw amplitudes are intentionally excluded: recorders may omit/cap them while the
+/// runtime sees full internal vectors, which previously caused train/serve skew.
+const N_BASE_FEATURES: usize = 7;
+const TEMPORAL_FEATURE_INDICES: [usize; N_BASE_FEATURES] = [0, 1, 2, 3, 4, 5, 6];
 const N_TEMPORAL_FEATURES: usize = TEMPORAL_FEATURE_INDICES.len();
-/// Five-second patch: current features + selected velocity + selected stddev.
-/// Kept at 31 so the persisted fixed-size arrays remain natively serde-compatible.
+/// Five-second patch: current features + velocity + standard deviation.
 const N_FEATURES: usize = N_BASE_FEATURES + N_TEMPORAL_FEATURES * 2;
+const ADAPTIVE_FEATURE_SCHEMA_VERSION: u32 = 4;
+const MIN_RUNTIME_BALANCED_ACCURACY: f64 = 0.90;
+const MIN_RUNTIME_CLASS_RECALL: f64 = 0.90;
 const TEMPORAL_BUCKET_SECONDS: f64 = 1.0;
 const TEMPORAL_WINDOW_BUCKETS: i64 = 5;
 const TEMPORAL_MIN_CONTEXT_BUCKETS: usize = 3;
@@ -37,7 +40,7 @@ const TEMPORAL_MIN_CONTEXT_BUCKETS: usize = 3;
 /// Default class names for backward compatibility with old saved models.
 const DEFAULT_CLASSES: &[&str] = &["absent", "present"];
 
-/// Extract extended feature vector from a JSONL frame (features + raw amplitudes).
+/// Extract the server-published feature vector from a JSONL frame.
 pub fn features_from_frame(frame: &serde_json::Value) -> [f64; N_BASE_FEATURES] {
     // spatial-intelligence stores the original RuView envelope under
     // `payload`; RuView's own recorder writes the envelope at the root. Keep
@@ -48,72 +51,15 @@ pub fn features_from_frame(frame: &serde_json::Value) -> [f64; N_BASE_FEATURES] 
         .get("features")
         .cloned()
         .unwrap_or(serde_json::Value::Null);
-    let nodes = frame.get("nodes").and_then(|n| n.as_array());
-    let amps: Vec<f64> = nodes
-        .map(|ns| {
-            // The room-level adaptive model is trained over every link. Node
-            // order comes from a HashMap and is not stable across processes,
-            // so only order-invariant summary statistics are derived here.
-            ns.iter()
-                .filter_map(|node| node.get("amplitude").and_then(|a| a.as_array()))
-                .flatten()
-                .filter_map(|value| value.as_f64())
-                .collect()
-        })
-        .unwrap_or_default();
-
-    // Server-computed features (0-6).
-    let variance = feat.get("variance").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let mbp = feat
-        .get("motion_band_power")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.0);
-    let bbp = feat
-        .get("breathing_band_power")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.0);
-    let sp = feat
-        .get("spectral_power")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.0);
-    let df = feat
-        .get("dominant_freq_hz")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.0);
-    let cp = feat
-        .get("change_points")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.0);
-    let rssi = feat
-        .get("mean_rssi")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.0);
-
-    // Subcarrier-derived features (7-14).
-    let (amp_mean, amp_std, amp_skew, amp_kurt, amp_iqr, amp_entropy, amp_max, amp_range) =
-        subcarrier_stats(&amps);
-
-    [
-        variance,
-        mbp,
-        bbp,
-        sp,
-        df,
-        cp,
-        rssi,
-        amp_mean,
-        amp_std,
-        amp_skew,
-        amp_kurt,
-        amp_iqr,
-        amp_entropy,
-        amp_max,
-        amp_range,
-    ]
+    features_from_runtime(&feat, &[])
 }
 
-/// Also keep a simpler version for runtime (no JSONL, just FeatureInfo + amps).
-pub fn features_from_runtime(feat: &serde_json::Value, amps: &[f64]) -> [f64; N_BASE_FEATURES] {
+/// Runtime equivalent of [`features_from_frame`]. The amplitude argument remains for
+/// source compatibility but is excluded from schema v4 to guarantee train/serve parity.
+pub fn features_from_runtime(
+    feat: &serde_json::Value,
+    _amplitudes: &[f64],
+) -> [f64; N_BASE_FEATURES] {
     let variance = feat.get("variance").and_then(|v| v.as_f64()).unwrap_or(0.0);
     let mbp = feat
         .get("motion_band_power")
@@ -139,25 +85,8 @@ pub fn features_from_runtime(feat: &serde_json::Value, amps: &[f64]) -> [f64; N_
         .get("mean_rssi")
         .and_then(|v| v.as_f64())
         .unwrap_or(0.0);
-    let (amp_mean, amp_std, amp_skew, amp_kurt, amp_iqr, amp_entropy, amp_max, amp_range) =
-        subcarrier_stats(amps);
-    [
-        variance,
-        mbp,
-        bbp,
-        sp,
-        df,
-        cp,
-        rssi,
-        amp_mean,
-        amp_std,
-        amp_skew,
-        amp_kurt,
-        amp_iqr,
-        amp_entropy,
-        amp_max,
-        amp_range,
-    ]
+
+    [variance, mbp, bbp, sp, df, cp, rssi]
 }
 
 /// Rate-invariant short temporal patch shared by offline fitting and runtime.
@@ -330,66 +259,6 @@ impl AdaptivePresenceSmoother {
     }
 }
 
-/// Compute statistical features from raw subcarrier amplitudes.
-fn subcarrier_stats(amps: &[f64]) -> (f64, f64, f64, f64, f64, f64, f64, f64) {
-    // HashMap-backed node serialization has no stable order. Sorting makes all
-    // summary features bit-reproducible across process restarts; dropping
-    // non-finite hardware samples keeps one corrupt bin from poisoning every
-    // logit in the room model.
-    let mut sorted: Vec<f64> = amps
-        .iter()
-        .copied()
-        .filter(|value| value.is_finite())
-        .collect();
-    if sorted.is_empty() {
-        return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-    }
-    sorted.sort_by(f64::total_cmp);
-    let n = sorted.len() as f64;
-    let mean = sorted.iter().sum::<f64>() / n;
-    let var = sorted.iter().map(|a| (a - mean).powi(2)).sum::<f64>() / n;
-    let std = var.sqrt().max(1e-9);
-
-    // Skewness (asymmetry).
-    let skew = sorted
-        .iter()
-        .map(|a| ((a - mean) / std).powi(3))
-        .sum::<f64>()
-        / n;
-    // Kurtosis (peakedness).
-    let kurt = sorted
-        .iter()
-        .map(|a| ((a - mean) / std).powi(4))
-        .sum::<f64>()
-        / n
-        - 3.0;
-
-    // IQR (inter-quartile range).
-    let q1 = sorted[sorted.len() / 4];
-    let q3 = sorted[3 * sorted.len() / 4];
-    let iqr = q3 - q1;
-
-    // Spectral entropy (normalised).
-    let total_power: f64 = sorted.iter().map(|a| a * a).sum::<f64>().max(1e-9);
-    let entropy: f64 = sorted
-        .iter()
-        .map(|a| {
-            let p = (a * a) / total_power;
-            if p > 1e-12 {
-                -p * p.ln()
-            } else {
-                0.0
-            }
-        })
-        .sum::<f64>()
-        / n.ln().max(1e-9); // normalise to [0,1]
-
-    let max_val = sorted.last().copied().unwrap_or(0.0);
-    let range = max_val - sorted.first().copied().unwrap_or(0.0);
-
-    (mean, std, skew, kurt, iqr, entropy, max_val, range)
-}
-
 // ── Per-class statistics ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -456,7 +325,7 @@ impl Default for AdaptiveModel {
             global_std: [1.0; N_FEATURES],
             trained_frames: 0,
             training_accuracy: 0.0,
-            version: 1,
+            version: ADAPTIVE_FEATURE_SCHEMA_VERSION,
             class_names: default_class_names(),
             expected_node_count: None,
             validation: None,
@@ -468,6 +337,12 @@ impl AdaptiveModel {
     /// Whether this model has enough independent evidence to override the
     /// conservative threshold classifier in production.
     pub fn runtime_eligibility(&self) -> Result<(), String> {
+        if self.version != ADAPTIVE_FEATURE_SCHEMA_VERSION {
+            return Err(format!(
+                "model feature schema v{} is stale; runtime requires v{}",
+                self.version, ADAPTIVE_FEATURE_SCHEMA_VERSION
+            ));
+        }
         let metrics = self.validation.as_ref().ok_or_else(|| {
             "model has no session-held-out validation; automatic activation is unsafe".to_string()
         })?;
@@ -495,27 +370,23 @@ impl AdaptiveModel {
         {
             return Err("model normalization or class statistics are invalid".into());
         }
-        if metrics.held_out_recordings < n_classes {
+        if metrics.held_out_recordings < n_classes * 2 {
             return Err(format!(
-                "held-out validation needs at least one independent recording per class (have {}, need {n_classes})",
-                metrics.held_out_recordings
+                "held-out validation needs at least two independent recordings per class (have {}, need {})",
+                metrics.held_out_recordings,
+                n_classes * 2
             ));
         }
         if metrics.held_out_frames == 0 {
             return Err("held-out validation contains no frames".into());
         }
 
-        // Binary classifiers must clear a higher bar than four-way models
-        // because 50% is already random chance. The fixed 0.60 floor prevents
-        // a many-class model from activating on a superficially small margin.
-        let chance = 1.0 / n_classes as f64;
-        let required_balanced_accuracy = 0.60_f64.max(chance + 0.20);
         if !metrics.balanced_accuracy.is_finite()
-            || metrics.balanced_accuracy < required_balanced_accuracy
+            || metrics.balanced_accuracy < MIN_RUNTIME_BALANCED_ACCURACY
         {
             return Err(format!(
                 "held-out balanced accuracy {:.3} is below activation floor {:.3}",
-                metrics.balanced_accuracy, required_balanced_accuracy
+                metrics.balanced_accuracy, MIN_RUNTIME_BALANCED_ACCURACY
             ));
         }
 
@@ -525,9 +396,9 @@ impl AdaptiveModel {
                 .get(class_name)
                 .copied()
                 .ok_or_else(|| format!("held-out recall missing for class '{class_name}'"))?;
-            if !recall.is_finite() || recall < 0.50 {
+            if !recall.is_finite() || recall < MIN_RUNTIME_CLASS_RECALL {
                 return Err(format!(
-                    "held-out recall for class '{class_name}' is {recall:.3}, below 0.500"
+                    "held-out recall for class '{class_name}' is {recall:.3}, below {MIN_RUNTIME_CLASS_RECALL:.3}"
                 ));
             }
         }
@@ -1129,7 +1000,7 @@ fn fit_model(
         global_std,
         trained_frames: n,
         training_accuracy: accuracy,
-        version: 3,
+        version: ADAPTIVE_FEATURE_SCHEMA_VERSION,
         class_names: class_names.to_vec(),
         expected_node_count,
         validation: None,
@@ -1155,7 +1026,7 @@ mod tests {
 
     fn model_with_validation(balanced_accuracy: f64, recalls: &[(&str, f64)]) -> AdaptiveModel {
         let mut model = AdaptiveModel::default();
-        model.version = 3;
+        model.version = 4;
         model.class_names = recalls
             .iter()
             .map(|(name, _)| (*name).to_string())
@@ -1172,7 +1043,7 @@ mod tests {
             })
             .collect();
         model.validation = Some(ValidationMetrics {
-            held_out_recordings: recalls.len(),
+            held_out_recordings: recalls.len() * 2,
             held_out_frames: 400,
             balanced_accuracy,
             per_class_recall: recalls
@@ -1194,16 +1065,45 @@ mod tests {
     }
 
     #[test]
-    fn model_must_beat_dynamic_chance_margin_and_each_class_floor() {
-        let weak_binary = model_with_validation(0.69, &[("absent", 0.70), ("present_still", 0.68)]);
+    fn model_must_clear_product_balanced_accuracy_and_each_class_floor() {
+        let weak_binary = model_with_validation(0.89, &[("absent", 0.95), ("present_still", 0.83)]);
         assert!(weak_binary.runtime_eligibility().is_err());
 
         let collapsed_class =
-            model_with_validation(0.75, &[("absent", 0.98), ("present_still", 0.49)]);
+            model_with_validation(0.94, &[("absent", 0.98), ("present_still", 0.89)]);
         assert!(collapsed_class.runtime_eligibility().is_err());
 
-        let eligible = model_with_validation(0.80, &[("absent", 0.82), ("present_still", 0.78)]);
+        let eligible = model_with_validation(0.94, &[("absent", 0.95), ("present_still", 0.93)]);
         assert!(eligible.runtime_eligibility().is_ok());
+    }
+
+    #[test]
+    fn stale_feature_schema_is_never_activated() {
+        let mut stale = model_with_validation(0.95, &[("absent", 0.95), ("present", 0.95)]);
+        stale.version = 3;
+
+        let error = stale.runtime_eligibility().unwrap_err();
+
+        assert!(error.contains("schema"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn offline_and_runtime_features_do_not_depend_on_private_amplitude_payloads() {
+        let features = serde_json::json!({
+            "variance": 1.0,
+            "motion_band_power": 2.0,
+            "breathing_band_power": 0.3,
+            "spectral_power": 4.0,
+            "dominant_freq_hz": 0.25,
+            "change_points": 5,
+            "mean_rssi": -45.0
+        });
+        let frame = serde_json::json!({"features": features.clone(), "nodes": []});
+
+        assert_eq!(
+            features_from_frame(&frame),
+            features_from_runtime(&features, &[100.0, 200.0, 300.0])
+        );
     }
 
     #[test]
@@ -1242,7 +1142,7 @@ mod tests {
     fn runtime_loader_accepts_session_validated_model() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("model.json");
-        let model = model_with_validation(0.80, &[("absent", 0.82), ("present_still", 0.78)]);
+        let model = model_with_validation(0.95, &[("absent", 0.96), ("present_still", 0.94)]);
         model.save(&path).unwrap();
 
         assert!(AdaptiveModel::load_runtime(&path).is_ok());
@@ -1447,7 +1347,7 @@ mod tests {
     }
 
     #[test]
-    fn recorded_feature_extraction_uses_every_node_and_is_order_invariant() {
+    fn recorded_feature_extraction_is_independent_of_node_payload_order() {
         let frame_ab = serde_json::json!({
             "features": { "variance": 1.0 },
             "nodes": [
@@ -1467,8 +1367,7 @@ mod tests {
         let ba = features_from_frame(&frame_ba);
 
         assert_eq!(ab, ba, "node serialization order must not change features");
-        assert!((ab[7] - 5.5).abs() < 1e-9, "all-node amplitude mean");
-        assert!((ab[14] - 9.0).abs() < 1e-9, "all-node amplitude range");
+        assert_eq!(ab.len(), N_BASE_FEATURES);
     }
 
     #[test]
@@ -1484,6 +1383,6 @@ mod tests {
         let features = features_from_frame(&wrapped);
 
         assert_eq!(features[0], 3.0);
-        assert_eq!(features[7], 3.0);
+        assert_eq!(features[1..], [0.0; N_BASE_FEATURES - 1]);
     }
 }

--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -29,16 +29,27 @@ const DEFAULT_CLASSES: &[&str] = &["absent", "present_still", "present_moving", 
 
 /// Extract extended feature vector from a JSONL frame (features + raw amplitudes).
 pub fn features_from_frame(frame: &serde_json::Value) -> [f64; N_FEATURES] {
+    // spatial-intelligence stores the original RuView envelope under
+    // `payload`; RuView's own recorder writes the envelope at the root. Keep
+    // one feature contract so offline evaluation cannot silently turn every
+    // wrapped feature into zero.
+    let frame = frame.get("payload").unwrap_or(frame);
     let feat = frame
         .get("features")
         .cloned()
         .unwrap_or(serde_json::Value::Null);
     let nodes = frame.get("nodes").and_then(|n| n.as_array());
     let amps: Vec<f64> = nodes
-        .and_then(|ns| ns.first())
-        .and_then(|n| n.get("amplitude"))
-        .and_then(|a| a.as_array())
-        .map(|arr| arr.iter().filter_map(|v| v.as_f64()).collect())
+        .map(|ns| {
+            // The room-level adaptive model is trained over every link. Node
+            // order comes from a HashMap and is not stable across processes,
+            // so only order-invariant summary statistics are derived here.
+            ns.iter()
+                .filter_map(|node| node.get("amplitude").and_then(|a| a.as_array()))
+                .flatten()
+                .filter_map(|value| value.as_f64())
+                .collect()
+        })
         .unwrap_or_default();
 
     // Server-computed features (0-6).
@@ -141,33 +152,46 @@ pub fn features_from_runtime(feat: &serde_json::Value, amps: &[f64]) -> [f64; N_
 
 /// Compute statistical features from raw subcarrier amplitudes.
 fn subcarrier_stats(amps: &[f64]) -> (f64, f64, f64, f64, f64, f64, f64, f64) {
-    if amps.is_empty() {
+    // HashMap-backed node serialization has no stable order. Sorting makes all
+    // summary features bit-reproducible across process restarts; dropping
+    // non-finite hardware samples keeps one corrupt bin from poisoning every
+    // logit in the room model.
+    let mut sorted: Vec<f64> = amps
+        .iter()
+        .copied()
+        .filter(|value| value.is_finite())
+        .collect();
+    if sorted.is_empty() {
         return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     }
-    let n = amps.len() as f64;
-    let mean = amps.iter().sum::<f64>() / n;
-    let var = amps.iter().map(|a| (a - mean).powi(2)).sum::<f64>() / n;
+    sorted.sort_by(f64::total_cmp);
+    let n = sorted.len() as f64;
+    let mean = sorted.iter().sum::<f64>() / n;
+    let var = sorted.iter().map(|a| (a - mean).powi(2)).sum::<f64>() / n;
     let std = var.sqrt().max(1e-9);
 
     // Skewness (asymmetry).
-    let skew = amps.iter().map(|a| ((a - mean) / std).powi(3)).sum::<f64>() / n;
+    let skew = sorted
+        .iter()
+        .map(|a| ((a - mean) / std).powi(3))
+        .sum::<f64>()
+        / n;
     // Kurtosis (peakedness).
-    let kurt = amps.iter().map(|a| ((a - mean) / std).powi(4)).sum::<f64>() / n - 3.0;
+    let kurt = sorted
+        .iter()
+        .map(|a| ((a - mean) / std).powi(4))
+        .sum::<f64>()
+        / n
+        - 3.0;
 
     // IQR (inter-quartile range).
-    let mut sorted = amps.to_vec();
-    // partial_cmp returns None on NaN — fall back to Equal so a single NaN
-    // frame from real ESP32 hardware (silent DSP div-by-zero, empty buffer)
-    // can't panic the whole sensing server (#611). The same file already
-    // uses unwrap_or(Equal) at lines 149-150 and 155; this was an oversight.
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let q1 = sorted[sorted.len() / 4];
     let q3 = sorted[3 * sorted.len() / 4];
     let iqr = q3 - q1;
 
     // Spectral entropy (normalised).
-    let total_power: f64 = amps.iter().map(|a| a * a).sum::<f64>().max(1e-9);
-    let entropy: f64 = amps
+    let total_power: f64 = sorted.iter().map(|a| a * a).sum::<f64>().max(1e-9);
+    let entropy: f64 = sorted
         .iter()
         .map(|a| {
             let p = (a * a) / total_power;
@@ -987,5 +1011,46 @@ mod tests {
         assert_eq!(validation.held_out_frames, 80);
         assert!(validation.balanced_accuracy > 0.95);
         assert!(model.runtime_eligibility().is_ok());
+    }
+
+    #[test]
+    fn recorded_feature_extraction_uses_every_node_and_is_order_invariant() {
+        let frame_ab = serde_json::json!({
+            "features": { "variance": 1.0 },
+            "nodes": [
+                { "node_id": 1, "amplitude": [1.0, 2.0] },
+                { "node_id": 2, "amplitude": [9.0, 10.0] }
+            ]
+        });
+        let frame_ba = serde_json::json!({
+            "features": { "variance": 1.0 },
+            "nodes": [
+                { "node_id": 2, "amplitude": [9.0, 10.0] },
+                { "node_id": 1, "amplitude": [1.0, 2.0] }
+            ]
+        });
+
+        let ab = features_from_frame(&frame_ab);
+        let ba = features_from_frame(&frame_ba);
+
+        assert_eq!(ab, ba, "node serialization order must not change features");
+        assert!((ab[7] - 5.5).abs() < 1e-9, "all-node amplitude mean");
+        assert!((ab[14] - 9.0).abs() < 1e-9, "all-node amplitude range");
+    }
+
+    #[test]
+    fn spatial_intelligence_payload_wrapper_uses_the_same_feature_contract() {
+        let wrapped = serde_json::json!({
+            "captured_at": "2026-08-10T00:00:00Z",
+            "payload": {
+                "features": { "variance": 3.0 },
+                "nodes": [{ "node_id": 1, "amplitude": [2.0, 4.0] }]
+            }
+        });
+
+        let features = features_from_frame(&wrapped);
+
+        assert_eq!(features[0], 3.0);
+        assert_eq!(features[7], 3.0);
     }
 }

--- a/v2/crates/wifi-densepose-sensing-server/src/csi.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/csi.rs
@@ -401,59 +401,16 @@ pub fn extract_features_from_frame(
     let variance = intra_variance.max(temporal_variance);
 
     let spectral_power: f64 = frame.amplitudes.iter().map(|a| a * a).sum::<f64>() / n;
-    let half = frame.amplitudes.len() / 2;
-    let motion_band_power = if half > 0 {
-        frame.amplitudes[half..]
-            .iter()
-            .map(|a| (a - mean_amp).powi(2))
-            .sum::<f64>()
-            / (frame.amplitudes.len() - half) as f64
-    } else {
-        0.0
-    };
-    let breathing_band_power = if half > 0 {
-        frame.amplitudes[..half]
-            .iter()
-            .map(|a| (a - mean_amp).powi(2))
-            .sum::<f64>()
-            / half as f64
-    } else {
-        0.0
-    };
-
-    let peak_idx = frame
-        .amplitudes
-        .iter()
-        .enumerate()
-        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(i, _)| i)
-        .unwrap_or(0);
-    let dominant_freq_hz = peak_idx as f64 * 0.05;
-
-    let threshold = mean_amp * 1.2;
-    let change_points = frame
-        .amplitudes
-        .windows(2)
-        .filter(|w| (w[0] < threshold) != (w[1] < threshold))
-        .count();
-
-    let temporal_motion_score = if let Some(prev_frame) = frame_history.back() {
-        let n_cmp = n_sub.min(prev_frame.len());
-        if n_cmp > 0 {
-            let diff_energy: f64 = (0..n_cmp)
-                .map(|k| (frame.amplitudes[k] - prev_frame[k]).powi(2))
-                .sum::<f64>()
-                / n_cmp as f64;
-            let ref_energy = mean_amp * mean_amp + 1e-9;
-            (diff_energy / ref_energy).sqrt().clamp(0.0, 1.0)
-        } else {
-            0.0
-        }
-    } else {
-        (intra_variance / (mean_amp * mean_amp + 1e-9))
-            .sqrt()
-            .clamp(0.0, 1.0)
-    };
+    let temporal = crate::temporal_features::extract_temporal_frequency_features(
+        frame_history,
+        &frame.amplitudes,
+        sample_rate_hz,
+    );
+    let motion_band_power = temporal.motion_band_power;
+    let breathing_band_power = temporal.breathing_band_power;
+    let dominant_freq_hz = temporal.dominant_freq_hz;
+    let change_points = temporal.change_points;
+    let temporal_motion_score = motion_band_power / 100.0;
 
     let variance_motion = (temporal_variance / 10.0).clamp(0.0, 1.0);
     let mbp_motion = (motion_band_power / 25.0).clamp(0.0, 1.0);
@@ -470,7 +427,7 @@ pub fn extract_features_from_frame(
         (1.0 - (temporal_variance / (mean_amp * mean_amp + 1e-9)).clamp(0.0, 1.0)).max(0.0);
     let signal_quality = (snr_quality * 0.6 + stability * 0.4).clamp(0.0, 1.0);
 
-    let breathing_rate_hz = estimate_breathing_rate_hz(frame_history, sample_rate_hz);
+    let breathing_rate_hz = temporal.breathing_rate_hz;
 
     let features = FeatureInfo {
         mean_rssi,

--- a/v2/crates/wifi-densepose-sensing-server/src/csi.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/csi.rs
@@ -578,31 +578,46 @@ pub fn smooth_and_classify_node(ns: &mut NodeState, raw: &mut ClassificationInfo
 }
 
 pub fn adaptive_override(
-    state: &AppStateInner,
+    state: &mut AppStateInner,
     features: &FeatureInfo,
     classification: &mut ClassificationInfo,
 ) {
-    if let Some(ref model) = state.adaptive_model {
-        let amps = state
-            .frame_history
-            .back()
-            .map(|v| v.as_slice())
-            .unwrap_or(&[]);
-        let feat_arr = adaptive_classifier::features_from_runtime(
-            &serde_json::json!({
-                "variance": features.variance,
-                "motion_band_power": features.motion_band_power,
-                "breathing_band_power": features.breathing_band_power,
-                "spectral_power": features.spectral_power,
-                "dominant_freq_hz": features.dominant_freq_hz,
-                "change_points": features.change_points,
-                "mean_rssi": features.mean_rssi,
-            }),
-            amps,
-        );
+    if state.adaptive_model.is_some() {
+        if state
+            .adaptive_model
+            .as_ref()
+            .and_then(|model| model.expected_node_count)
+            .is_some_and(|expected| expected != 1)
+        {
+            state.adaptive_feature_extractor.reset();
+            return;
+        }
+        let amps = state.frame_history.back().cloned().unwrap_or_default();
+        let feature_json = serde_json::json!({
+            "variance": features.variance,
+            "motion_band_power": features.motion_band_power,
+            "breathing_band_power": features.breathing_band_power,
+            "spectral_power": features.spectral_power,
+            "dominant_freq_hz": features.dominant_freq_hz,
+            "change_points": features.change_points,
+            "mean_rssi": features.mean_rssi,
+        });
+        let Some(feat_arr) = state
+            .adaptive_feature_extractor
+            .observe_runtime(&feature_json, &amps)
+        else {
+            return;
+        };
+        let model = state
+            .adaptive_model
+            .as_ref()
+            .expect("adaptive model presence checked above");
         let (label, conf) = model.classify(&feat_arr);
-        classification.motion_level = label.to_string();
-        classification.presence = label != "absent";
+        (classification.motion_level, classification.presence) =
+            adaptive_classifier::reconcile_presence_prediction(
+                &label,
+                &classification.motion_level,
+            );
         classification.confidence = (conf * 0.7 + classification.confidence * 0.3).clamp(0.0, 1.0);
     }
 }

--- a/v2/crates/wifi-densepose-sensing-server/src/csi.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/csi.rs
@@ -590,6 +590,7 @@ pub fn adaptive_override(
             .is_some_and(|expected| expected != 1)
         {
             state.adaptive_feature_extractor.reset();
+            state.adaptive_presence_smoother.reset();
             return;
         }
         let amps = state.frame_history.back().cloned().unwrap_or_default();
@@ -613,9 +614,14 @@ pub fn adaptive_override(
             .as_ref()
             .expect("adaptive model presence checked above");
         let (label, conf) = model.classify(&feat_arr);
+        let stable_label = if state.adaptive_presence_smoother.update(&label, conf) {
+            "present"
+        } else {
+            "absent"
+        };
         (classification.motion_level, classification.presence) =
             adaptive_classifier::reconcile_presence_prediction(
-                &label,
+                stable_label,
                 &classification.motion_level,
             );
         classification.confidence = (conf * 0.7 + classification.confidence * 0.3).clamp(0.0, 1.0);

--- a/v2/crates/wifi-densepose-sensing-server/src/engine_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/engine_bridge.rs
@@ -38,6 +38,7 @@ use wifi_densepose_bfld::{PrivacyClass, PrivacyMode};
 use wifi_densepose_engine::{AdapterInfo, EngineError, StreamingEngine, TrustedOutput};
 use wifi_densepose_geo::types::GeoRegistration;
 use wifi_densepose_signal::ruvsense::fusion_quality::CalibrationId;
+use wifi_densepose_signal::ruvsense::multiband::MultiBandCsiFrame;
 use wifi_densepose_signal::ruvsense::multistatic::MultistaticConfig;
 use wifi_densepose_worldgraph::WorldId;
 
@@ -75,6 +76,26 @@ pub struct EngineBridge {
     engine_error_count: u64,
     /// Last time an engine error was actually logged (rate limiter).
     last_error_warn_at: Option<Instant>,
+    /// Hard timestamp guard mirrored from the engine's multistatic fuser.
+    fusion_guard_us: u64,
+}
+
+/// Keep the freshest time-consistent cohort instead of mixing adjacent cycles.
+///
+/// Wi-Fi delivery can briefly delay one link while the other continues. Passing
+/// both frames downstream either fails the whole governed cycle or tempts an
+/// operator to widen the fusion guard beyond one sensing cycle. Favoring the
+/// newest cohort preserves temporal integrity and lets the engine's documented
+/// single-node fallback produce a witnessed result for that cycle.
+fn newest_time_consistent_frames(
+    mut frames: Vec<MultiBandCsiFrame>,
+    guard_interval_us: u64,
+) -> Vec<MultiBandCsiFrame> {
+    let Some(newest) = frames.iter().map(|frame| frame.timestamp_us).max() else {
+        return frames;
+    };
+    frames.retain(|frame| newest.saturating_sub(frame.timestamp_us) <= guard_interval_us);
+    frames
 }
 
 impl EngineBridge {
@@ -95,6 +116,10 @@ impl EngineBridge {
         multistatic_cfg: Option<MultistaticConfig>,
     ) -> Self {
         let mut engine = StreamingEngine::new(mode, model_version, GeoRegistration::default());
+        let fusion_guard_us = multistatic_cfg.as_ref().map_or_else(
+            || MultistaticConfig::default().guard_interval_us,
+            |cfg| cfg.guard_interval_us,
+        );
         if let Some(cfg) = multistatic_cfg {
             engine.set_multistatic_config(cfg);
         }
@@ -110,6 +135,7 @@ impl EngineBridge {
             demoted: false,
             engine_error_count: 0,
             last_error_warn_at: None,
+            fusion_guard_us,
         }
     }
 
@@ -165,7 +191,10 @@ impl EngineBridge {
         node_states: &HashMap<u8, NodeState>,
         now_ms: i64,
     ) -> Option<Result<TrustedOutput, EngineError>> {
-        let frames = node_frames_from_states(node_states);
+        let frames = newest_time_consistent_frames(
+            node_frames_from_states(node_states),
+            self.fusion_guard_us,
+        );
         if frames.is_empty() {
             return None;
         }
@@ -419,22 +448,10 @@ mod tests {
         assert!(!bridge.suppress_raw_outputs());
     }
 
-    /// Error wiring (review finding 1a): a live cycle that fails fusion yields
-    /// an `EngineError` — previously dropped by `if let Some(Ok(..))` at the
-    /// call sites. The counter must increment and the last good trust state
-    /// must survive a later failure.
-    ///
-    /// Originally this forced the failure with a 56-vs-30 subcarrier mismatch
-    /// (`DimensionMismatch`). Since #1170 the live bridge canonicalizes every
-    /// node onto the 56-tone grid, so heterogeneous counts now fuse cleanly —
-    /// a frame-timestamp spread wider than the fuser's 60 ms guard interval is
-    /// the remaining deterministic way to provoke a fusion error here.
+    /// A delayed link belongs to an earlier sensing cycle and must not make the
+    /// current governed cycle fail or be fused as if it were simultaneous.
     #[test]
-    fn observe_cycle_counts_engine_errors() {
-        // Both nodes are 56-subcarrier (canonicalization-clean), but their
-        // frame timestamps are 500 ms apart — far beyond the 60 ms guard —
-        // so the fuser rejects the cycle with TimestampMismatch. Future
-        // offsets keep both instants safely after the bridge's lazy EPOCH.
+    fn observe_cycle_uses_the_freshest_time_consistent_cohort() {
         fn mismatched_states() -> HashMap<u8, NodeState> {
             let now = Instant::now();
             let mut a = node_state_with_history(1.0, 56);
@@ -450,26 +467,16 @@ mod tests {
         let mut bridge = EngineBridge::new(PrivacyMode::PrivateHome, 1, "r", "R", None);
         let mismatched = mismatched_states();
 
-        assert!(bridge.observe_cycle(&mismatched, 1_000).is_none());
-        assert_eq!(bridge.engine_error_count(), 1);
-        assert!(
-            bridge.last_trust_witness().is_none(),
-            "no witness from a failed cycle"
-        );
-
-        assert!(bridge.observe_cycle(&mismatched, 2_000).is_none());
-        assert_eq!(bridge.engine_error_count(), 2);
-
-        // A later good cycle records trust state; the audit count is kept.
-        let out = bridge.observe_cycle(&two_node_states(), 3_000);
-        assert!(out.is_some());
+        let out = bridge.observe_cycle(&mismatched, 1_000);
+        assert!(out.is_some(), "the newest link keeps the cycle observable");
+        assert_eq!(bridge.engine_error_count(), 0);
         assert!(bridge.last_trust_witness().is_some());
-        assert_eq!(bridge.engine_error_count(), 2);
+        assert_eq!(bridge.registered_node_count(), 1);
 
-        // And a subsequent failure keeps the last good witness readable.
-        assert!(bridge.observe_cycle(&mismatched, 4_000).is_none());
-        assert_eq!(bridge.engine_error_count(), 3);
-        assert!(bridge.last_trust_witness().is_some());
+        // Once both links are aligned, the following cycle uses and registers
+        // the full topology again rather than permanently dropping a node.
+        assert!(bridge.observe_cycle(&two_node_states(), 2_000).is_some());
+        assert_eq!(bridge.registered_node_count(), 2);
     }
 
     /// ADR-141 mapping (review finding 1c): a cycle emitted at class

--- a/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
@@ -139,7 +139,8 @@ pub fn maybe_feed_calibration(field: &mut FieldModel, frame_history: &VecDeque<V
 /// Parse node positions from a semicolon-delimited string.
 ///
 /// Format: `"x,y,z;x,y,z;..."` where each coordinate is an `f32`.
-/// Malformed entries are skipped with a warning log.
+/// The full configuration is rejected if any entry is malformed. Skipping an
+/// entry would shift every later coordinate onto the wrong physical node ID.
 pub fn parse_node_positions(input: &str) -> Vec<[f32; 3]> {
     if input.is_empty() {
         return Vec::new();
@@ -147,11 +148,11 @@ pub fn parse_node_positions(input: &str) -> Vec<[f32; 3]> {
     input
         .split(';')
         .enumerate()
-        .filter_map(|(idx, triplet)| {
+        .map(|(idx, triplet)| {
             let parts: Vec<&str> = triplet.split(',').collect();
             if parts.len() != 3 {
                 tracing::warn!(
-                    "Skipping malformed node position entry {idx}: '{triplet}' (expected x,y,z)"
+                    "Rejecting node positions: malformed entry {idx}: '{triplet}' (expected x,y,z)"
                 );
                 return None;
             }
@@ -160,14 +161,29 @@ pub fn parse_node_positions(input: &str) -> Vec<[f32; 3]> {
                 parts[1].parse::<f32>(),
                 parts[2].parse::<f32>(),
             ) {
-                (Ok(x), Ok(y), Ok(z)) => Some([x, y, z]),
+                (Ok(x), Ok(y), Ok(z)) if x.is_finite() && y.is_finite() && z.is_finite() => {
+                    Some([x, y, z])
+                }
                 _ => {
-                    tracing::warn!("Skipping unparseable node position entry {idx}: '{triplet}'");
+                    tracing::warn!("Rejecting node positions: invalid entry {idx}: '{triplet}'");
                     None
                 }
             }
         })
-        .collect()
+        .collect::<Option<Vec<_>>>()
+        .unwrap_or_default()
+}
+
+/// Resolve the configured position for a physical node ID.
+///
+/// CLI positions are ordered for Node 1, Node 2, and so on. Keep the historical
+/// default for unconfigured IDs so existing deployments retain their API shape.
+pub fn node_position(positions: &[[f32; 3]], node_id: u8) -> [f64; 3] {
+    node_id
+        .checked_sub(1)
+        .and_then(|index| positions.get(usize::from(index)))
+        .map(|position| position.map(f64::from))
+        .unwrap_or([2.0, 0.0, 1.5])
 }
 
 #[cfg(test)]
@@ -192,15 +208,28 @@ mod tests {
     #[test]
     fn test_parse_node_positions_invalid() {
         let positions = parse_node_positions("abc;1,2,3");
-        assert_eq!(positions.len(), 1);
-        assert_eq!(positions[0], [1.0, 2.0, 3.0]);
+        assert!(positions.is_empty());
     }
 
     #[test]
     fn test_parse_node_positions_partial_triplet() {
         let positions = parse_node_positions("1,2;3,4,5");
-        assert_eq!(positions.len(), 1);
-        assert_eq!(positions[0], [3.0, 4.0, 5.0]);
+        assert!(positions.is_empty());
+    }
+
+    #[test]
+    fn test_parse_node_positions_rejects_non_finite_coordinates() {
+        assert!(parse_node_positions("NaN,0,1.5;1,0,1.5").is_empty());
+        assert!(parse_node_positions("0,0,1.5;inf,0,1.5").is_empty());
+    }
+
+    #[test]
+    fn configured_position_is_mapped_from_one_based_node_id() {
+        let positions = vec![[0.0, 0.0, 1.5], [1.5, 0.0, 1.5]];
+
+        assert_eq!(node_position(&positions, 1), [0.0, 0.0, 1.5]);
+        assert_eq!(node_position(&positions, 2), [1.5, 0.0, 1.5]);
+        assert_eq!(node_position(&positions, 3), [2.0, 0.0, 1.5]);
     }
 
     /// Regression: a freshly-started (`Uncalibrated`) field model must begin

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -2435,13 +2435,31 @@ fn adaptive_override(
     features: &FeatureInfo,
     classification: &mut ClassificationInfo,
 ) {
-    if let Some(ref model) = state.adaptive_model {
-        // Get current frame amplitudes from the latest history entry.
-        let amps = state
-            .frame_history
-            .back()
-            .map(|v| v.as_slice())
-            .unwrap_or(&[]);
+    // Get current frame amplitudes from the latest history entry.
+    let amps = state
+        .frame_history
+        .back()
+        .map(|v| v.as_slice())
+        .unwrap_or(&[]);
+    adaptive_override_with_amplitudes(
+        state.adaptive_model.as_ref(),
+        features,
+        amps,
+        classification,
+    );
+}
+
+/// Apply a room-level adaptive model to an explicitly selected amplitude set.
+/// Keeping amplitude selection outside the classifier prevents the ESP32
+/// multi-node path from accidentally training on one link and inferring on a
+/// different one.
+fn adaptive_override_with_amplitudes(
+    model: Option<&adaptive_classifier::AdaptiveModel>,
+    features: &FeatureInfo,
+    amps: &[f64],
+    classification: &mut ClassificationInfo,
+) {
+    if let Some(model) = model {
         let feat_arr = adaptive_classifier::features_from_runtime(
             &serde_json::json!({
                 "variance": features.variance,
@@ -2459,6 +2477,50 @@ fn adaptive_override(
         classification.presence = label != "absent";
         // Blend model confidence with existing smoothed confidence.
         classification.confidence = (conf * 0.7 + classification.confidence * 0.3).clamp(0.0, 1.0);
+    }
+}
+
+/// At 10 Hz, 500 ms spans roughly five expected frames. Older link samples
+/// describe a different sensing instant and must not enter the room-level
+/// adaptive decision. This is the heuristic-path counterpart to the learned
+/// multiplicative freshness gate used by RuView's universal RF encoder.
+const ADAPTIVE_FUSION_MAX_SAMPLE_AGE: Duration = Duration::from_millis(500);
+
+fn collect_fresh_node_amplitudes(
+    node_states: &HashMap<u8, NodeState>,
+    now: std::time::Instant,
+) -> Vec<f64> {
+    node_states
+        .values()
+        .filter(|node| {
+            node.last_frame_time.is_some_and(|received_at| {
+                now.saturating_duration_since(received_at) <= ADAPTIVE_FUSION_MAX_SAMPLE_AGE
+            })
+        })
+        .filter_map(|node| node.frame_history.back())
+        .flatten()
+        .copied()
+        .collect()
+}
+
+#[cfg(test)]
+mod adaptive_fusion_amplitude_tests {
+    use super::*;
+
+    #[test]
+    fn room_level_adaptive_input_excludes_old_links() {
+        let now = std::time::Instant::now();
+        let mut fresh = NodeState::new();
+        fresh.frame_history.push_back(vec![1.0, 2.0]);
+        fresh.last_frame_time = Some(now);
+        let mut old = NodeState::new();
+        old.frame_history.push_back(vec![90.0, 100.0]);
+        old.last_frame_time = Some(now - Duration::from_secs(2));
+        let mut nodes = HashMap::new();
+        nodes.insert(1, fresh);
+        nodes.insert(2, old);
+
+        assert_eq!(collect_fresh_node_amplitudes(&nodes, now), vec![1.0, 2.0]);
     }
 }
 
@@ -3711,8 +3773,8 @@ async fn ingest_vendor_events(
 ///
 /// When multiple ESP32 nodes observe the same room, their CSI features
 /// can be combined:
-/// - Variance: use max (most sensitive node dominates)
-/// - Motion/breathing/spectral power: weighted average by RSSI (closer node = higher weight)
+/// - Variance: freshness- and link-quality-weighted average
+/// - Motion/breathing/spectral power: weighted by link quality and sample freshness
 /// - Dominant frequency: weighted average
 /// - Change points: keep current node's value (not meaningful to average)
 /// - Mean RSSI: use max (best signal)
@@ -3721,16 +3783,29 @@ fn fuse_multi_node_features(
     node_states: &HashMap<u8, NodeState>,
 ) -> FeatureInfo {
     let now = std::time::Instant::now();
-    let active: Vec<(&FeatureInfo, f64)> = node_states
+    let active: Vec<(&FeatureInfo, f64, f64)> = node_states
         .values()
-        .filter(|ns| {
-            ns.last_frame_time
-                .is_some_and(|t| now.duration_since(t).as_secs() < 10)
-        })
         .filter_map(|ns| {
+            let received_at = ns.last_frame_time?;
+            let age = now.saturating_duration_since(received_at);
+            if age > ADAPTIVE_FUSION_MAX_SAMPLE_AGE {
+                return None;
+            }
             let feat = ns.latest_features.as_ref()?;
             let rssi = ns.rssi_history.back().copied().unwrap_or(-80.0);
-            Some((feat, rssi))
+            let expected_interval_ms = if ns.csi_fps_samples >= 5
+                && ns.csi_fps_ema.is_finite()
+                && ns.csi_fps_ema > 0.0
+            {
+                1000.0 / ns.csi_fps_ema
+            } else {
+                100.0
+            };
+            // Multiplicative age gate: one expected interval retains half the
+            // weight, four intervals retain one fifth. This preserves a usable
+            // packet without treating it as simultaneous with a fresh link.
+            let freshness = 1.0 / (1.0 + age.as_secs_f64() * 1000.0 / expected_interval_ms);
+            Some((feat, rssi, freshness))
         })
         .collect();
 
@@ -3742,11 +3817,16 @@ fn fuse_multi_node_features(
     // Map RSSI relative to best node into [0.1, 1.0].
     let max_rssi = active
         .iter()
-        .map(|(_, r)| *r)
+        .map(|(_, r, _)| *r)
         .fold(f64::NEG_INFINITY, f64::max);
     let weights: Vec<f64> = active
         .iter()
-        .map(|(_, r)| (1.0 + (r - max_rssi + 20.0) / 20.0).clamp(0.1, 1.0))
+        .map(|(_, r, freshness)| {
+            // 20 dB RSSI loss means one tenth the link-quality weight. Age and
+            // link quality are independent reliability terms, so multiply.
+            let link_quality = 10.0_f64.powf((r - max_rssi) / 20.0).clamp(0.1, 1.0);
+            link_quality * freshness
+        })
         .collect();
     let w_sum: f64 = weights.iter().sum::<f64>().max(1e-9);
 
@@ -3756,40 +3836,97 @@ fn fuse_multi_node_features(
         variance: active
             .iter()
             .zip(&weights)
-            .map(|((f, _), w)| f.variance * w)
+            .map(|((f, _, _), w)| f.variance * w)
             .sum::<f64>()
             / w_sum,
         // Weighted average for motion/breathing/spectral
         motion_band_power: active
             .iter()
             .zip(&weights)
-            .map(|((f, _), w)| f.motion_band_power * w)
+            .map(|((f, _, _), w)| f.motion_band_power * w)
             .sum::<f64>()
             / w_sum,
         breathing_band_power: active
             .iter()
             .zip(&weights)
-            .map(|((f, _), w)| f.breathing_band_power * w)
+            .map(|((f, _, _), w)| f.breathing_band_power * w)
             .sum::<f64>()
             / w_sum,
         spectral_power: active
             .iter()
             .zip(&weights)
-            .map(|((f, _), w)| f.spectral_power * w)
+            .map(|((f, _, _), w)| f.spectral_power * w)
             .sum::<f64>()
             / w_sum,
         dominant_freq_hz: active
             .iter()
             .zip(&weights)
-            .map(|((f, _), w)| f.dominant_freq_hz * w)
+            .map(|((f, _, _), w)| f.dominant_freq_hz * w)
             .sum::<f64>()
             / w_sum,
         change_points: current_features.change_points, // keep current node's value
         // Best RSSI across nodes
         mean_rssi: active
             .iter()
-            .map(|(f, _)| f.mean_rssi)
+            .map(|(f, _, _)| f.mean_rssi)
             .fold(f64::NEG_INFINITY, f64::max),
+    }
+}
+
+#[cfg(test)]
+mod freshness_weighted_feature_fusion_tests {
+    use super::*;
+
+    fn node(now: std::time::Instant, age: Duration, variance: f64) -> NodeState {
+        let mut node = NodeState::new();
+        node.last_frame_time = Some(now - age);
+        node.csi_fps_ema = 10.0;
+        node.csi_fps_samples = 20;
+        node.rssi_history.push_back(-50.0);
+        node.latest_features = Some(FeatureInfo {
+            mean_rssi: -50.0,
+            variance,
+            motion_band_power: variance,
+            breathing_band_power: variance,
+            dominant_freq_hz: variance,
+            change_points: variance as usize,
+            spectral_power: variance,
+        });
+        node
+    }
+
+    #[test]
+    fn stale_link_cannot_influence_room_features() {
+        let now = std::time::Instant::now();
+        let mut nodes = HashMap::new();
+        nodes.insert(1, node(now, Duration::ZERO, 10.0));
+        nodes.insert(2, node(now, Duration::from_secs(2), 100.0));
+
+        let fused = fuse_multi_node_features(
+            nodes.get(&1).unwrap().latest_features.as_ref().unwrap(),
+            &nodes,
+        );
+
+        assert_eq!(fused.variance, 10.0);
+    }
+
+    #[test]
+    fn older_but_usable_link_is_multiplicatively_downweighted() {
+        let now = std::time::Instant::now();
+        let mut nodes = HashMap::new();
+        nodes.insert(1, node(now, Duration::ZERO, 10.0));
+        nodes.insert(2, node(now, Duration::from_millis(400), 100.0));
+
+        let fused = fuse_multi_node_features(
+            nodes.get(&1).unwrap().latest_features.as_ref().unwrap(),
+            &nodes,
+        );
+
+        assert!(
+            fused.variance < 30.0,
+            "400 ms sample should contribute less than a fresh sample: {}",
+            fused.variance
+        );
     }
 }
 
@@ -6007,8 +6144,10 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         .node_states
                         .iter()
                         .filter(|(_, n)| {
-                            n.last_frame_time
-                                .is_some_and(|t| now.duration_since(t).as_secs() < 10)
+                            n.last_frame_time.is_some_and(|t| {
+                                now.saturating_duration_since(t)
+                                    <= ADAPTIVE_FUSION_MAX_SAMPLE_AGE
+                            })
                         })
                         .map(|(&id, n)| NodeInfo {
                             node_id: id,
@@ -6048,8 +6187,10 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         .node_states
                         .values()
                         .filter(|ns| {
-                            ns.last_frame_time
-                                .is_some_and(|t| now.duration_since(t).as_secs() < 10)
+                            ns.last_frame_time.is_some_and(|t| {
+                                now.saturating_duration_since(t)
+                                    <= ADAPTIVE_FUSION_MAX_SAMPLE_AGE
+                            })
                         })
                         .count();
                     if n_active > 1 {
@@ -6301,10 +6442,6 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     // We scope the mutable borrow of node_states so we can
                     // access other AppStateInner fields afterward.
                     let node_id = frame.node_id;
-                    // Clone adaptive model before mutable borrow of node_states
-                    // to avoid unsafe raw pointer (review finding #2).
-                    let adaptive_model_clone = s.adaptive_model.clone();
-
                     let ns = s.node_states.entry(node_id).or_insert_with(NodeState::new);
                     // ADR-110 iter 19 — feed the per-node fps EMA from real
                     // CSI arrivals. The helper sets `last_frame_time` as a
@@ -6336,28 +6473,6 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         raw_motion,
                     ) = extract_features_from_frame(&frame, &ns.frame_history, sample_rate_hz);
                     smooth_and_classify_node(ns, &mut classification, raw_motion);
-
-                    // Adaptive override using cloned model (safe, no raw pointers).
-                    if let Some(ref model) = adaptive_model_clone {
-                        let amps = ns.frame_history.back().map(|v| v.as_slice()).unwrap_or(&[]);
-                        let feat_arr = adaptive_classifier::features_from_runtime(
-                            &serde_json::json!({
-                                "variance": features.variance,
-                                "motion_band_power": features.motion_band_power,
-                                "breathing_band_power": features.breathing_band_power,
-                                "spectral_power": features.spectral_power,
-                                "dominant_freq_hz": features.dominant_freq_hz,
-                                "change_points": features.change_points,
-                                "mean_rssi": features.mean_rssi,
-                            }),
-                            amps,
-                        );
-                        let (label, conf) = model.classify(&feat_arr);
-                        classification.motion_level = label.to_string();
-                        classification.presence = label != "absent";
-                        classification.confidence =
-                            (conf * 0.7 + classification.confidence * 0.3).clamp(0.0, 1.0);
-                    }
 
                     ns.rssi_history.push_back(features.mean_rssi);
                     if ns.rssi_history.len() > 60 {
@@ -6401,6 +6516,14 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
 
                     // Cross-node fusion: combine features from all active nodes.
                     let fused_features = fuse_multi_node_features(&features, &s.node_states);
+                    let adaptive_amps =
+                        collect_fresh_node_amplitudes(&s.node_states, std::time::Instant::now());
+                    adaptive_override_with_amplitudes(
+                        s.adaptive_model.as_ref(),
+                        &fused_features,
+                        &adaptive_amps,
+                        &mut classification,
+                    );
 
                     s.tick += 1;
                     let tick = s.tick;
@@ -6486,8 +6609,10 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         .node_states
                         .iter()
                         .filter(|(_, n)| {
-                            n.last_frame_time
-                                .is_some_and(|t| now.duration_since(t).as_secs() < 10)
+                            n.last_frame_time.is_some_and(|t| {
+                                now.saturating_duration_since(t)
+                                    <= ADAPTIVE_FUSION_MAX_SAMPLE_AGE
+                            })
                         })
                         .map(|(&id, n)| NodeInfo {
                             node_id: id,

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1200,6 +1200,8 @@ struct AppStateInner {
     adaptive_model: Option<adaptive_classifier::AdaptiveModel>,
     /// Rate-normalized short temporal context for the adaptive classifier.
     adaptive_feature_extractor: adaptive_classifier::AdaptiveFeatureExtractor,
+    /// Hysteresis over learned presence probabilities prevents one-frame flips.
+    adaptive_presence_smoother: adaptive_classifier::AdaptivePresenceSmoother,
     // ── Per-node state (issue #249) ─────────────────────────────────────
     /// Per-node sensing state for multi-node deployments.
     /// Keyed by `node_id` from the ESP32 frame header.
@@ -1380,6 +1382,7 @@ impl AppStateInner {
             training_progress_tx: broadcast::channel::<String>(256).0,
             adaptive_model: None,
             adaptive_feature_extractor: adaptive_classifier::AdaptiveFeatureExtractor::default(),
+            adaptive_presence_smoother: adaptive_classifier::AdaptivePresenceSmoother::default(),
             node_states: HashMap::new(),
             pose_tracker: PoseTracker::new(),
             last_tracker_instant: None,
@@ -2461,6 +2464,7 @@ fn adaptive_override_with_amplitudes(
             .and_then(|model| model.expected_node_count);
         if expected_node_count.is_some_and(|expected| expected != observed_node_count) {
             state.adaptive_feature_extractor.reset();
+            state.adaptive_presence_smoother.reset();
             return;
         }
         let feature_json = serde_json::json!({
@@ -2483,9 +2487,14 @@ fn adaptive_override_with_amplitudes(
             .as_ref()
             .expect("adaptive model presence checked above");
         let (label, conf) = model.classify(&feat_arr);
+        let stable_label = if state.adaptive_presence_smoother.update(&label, conf) {
+            "present"
+        } else {
+            "absent"
+        };
         (classification.motion_level, classification.presence) =
             adaptive_classifier::reconcile_presence_prediction(
-                &label,
+                stable_label,
                 &classification.motion_level,
             );
         // Blend model confidence with existing smoothed confidence.
@@ -5453,6 +5462,7 @@ async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Va
             let mut s = state.write().await;
             s.adaptive_model = Some(model);
             s.adaptive_feature_extractor.reset();
+            s.adaptive_presence_smoother.reset();
 
             Json(serde_json::json!({
                 "success": true,
@@ -5499,6 +5509,7 @@ async fn adaptive_unload(State(state): State<SharedState>) -> Json<serde_json::V
     let mut s = state.write().await;
     s.adaptive_model = None;
     s.adaptive_feature_extractor.reset();
+    s.adaptive_presence_smoother.reset();
     Json(serde_json::json!({ "success": true, "message": "Adaptive model unloaded." }))
 }
 
@@ -8323,6 +8334,7 @@ async fn main() {
             }
         },
         adaptive_feature_extractor: adaptive_classifier::AdaptiveFeatureExtractor::default(),
+        adaptive_presence_smoother: adaptive_classifier::AdaptivePresenceSmoother::default(),
         node_states: HashMap::new(),
         // Accuracy sprint
         pose_tracker: PoseTracker::new(),

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -31,6 +31,7 @@ mod training_api;
 mod rvf_pipeline;
 mod tracker_bridge;
 pub mod types;
+mod temporal_features;
 mod vital_signs;
 
 // Training pipeline modules (exposed via lib.rs)
@@ -1319,8 +1320,9 @@ impl AppStateInner {
 }
 
 /// Number of frames retained in `frame_history` for temporal analysis.
-/// At 500 ms ticks this covers ~50 seconds; at 100 ms ticks ~10 seconds.
-const FRAME_HISTORY_CAPACITY: usize = 100;
+/// 1,200 frames preserve a 30-second window at the measured ~40 FPS ESP32 rate,
+/// which resolves slow 0.1 Hz dynamics without unbounded memory growth.
+const FRAME_HISTORY_CAPACITY: usize = 1_200;
 
 type SharedState = Arc<RwLock<AppStateInner>>;
 
@@ -1938,93 +1940,6 @@ fn generate_signal_field(
 
 // ── Feature extraction from ESP32 frame ──────────────────────────────────────
 
-/// Estimate breathing rate in Hz from the amplitude time series stored in `frame_history`.
-///
-/// Approach:
-/// 1. Build a scalar time series by computing the mean amplitude of each historical frame.
-/// 2. Run a peak-detection pass: count rising-edge zero-crossings of the de-meaned signal.
-/// 3. Convert the crossing rate to Hz, clipped to the physiological range 0.1–0.5 Hz
-///    (12–30 breaths/min).
-///
-/// For accuracy the function additionally applies a simple 3-tap Goertzel-style power
-/// estimate at evenly-spaced candidate frequencies in the breathing band and returns
-/// the candidate with the highest energy.
-fn estimate_breathing_rate_hz(frame_history: &VecDeque<Vec<f64>>, sample_rate_hz: f64) -> f64 {
-    let n = frame_history.len();
-    if n < 6 {
-        return 0.0;
-    }
-
-    // Build scalar time series: mean amplitude per frame.
-    let series: Vec<f64> = frame_history
-        .iter()
-        .map(|amps| {
-            if amps.is_empty() {
-                0.0
-            } else {
-                amps.iter().sum::<f64>() / amps.len() as f64
-            }
-        })
-        .collect();
-
-    let mean_s = series.iter().sum::<f64>() / n as f64;
-    // De-mean.
-    let detrended: Vec<f64> = series.iter().map(|x| x - mean_s).collect();
-
-    // Goertzel power at candidate frequencies in the breathing band [0.1, 0.5] Hz.
-    // We evaluate 9 candidate frequencies uniformly spaced in that band.
-    let n_candidates = 9usize;
-    let f_low = 0.1f64;
-    let f_high = 0.5f64;
-    let mut best_freq = 0.0f64;
-    let mut best_power = 0.0f64;
-
-    for i in 0..n_candidates {
-        let freq = f_low + (f_high - f_low) * i as f64 / (n_candidates - 1).max(1) as f64;
-        let omega = 2.0 * std::f64::consts::PI * freq / sample_rate_hz;
-        let coeff = 2.0 * omega.cos();
-        let mut s_prev2 = 0.0f64;
-        let mut s_prev1 = 0.0f64;
-        for &x in &detrended {
-            let s = x + coeff * s_prev1 - s_prev2;
-            s_prev2 = s_prev1;
-            s_prev1 = s;
-        }
-        // Goertzel magnitude squared.
-        let power = s_prev2 * s_prev2 + s_prev1 * s_prev1 - coeff * s_prev1 * s_prev2;
-        if power > best_power {
-            best_power = power;
-            best_freq = freq;
-        }
-    }
-
-    // Only report a breathing rate if the Goertzel energy is meaningfully above noise.
-    // Threshold: power must exceed 10× the average power across all candidates.
-    let avg_power = {
-        let mut total = 0.0f64;
-        for i in 0..n_candidates {
-            let freq = f_low + (f_high - f_low) * i as f64 / (n_candidates - 1).max(1) as f64;
-            let omega = 2.0 * std::f64::consts::PI * freq / sample_rate_hz;
-            let coeff = 2.0 * omega.cos();
-            let mut s_prev2 = 0.0f64;
-            let mut s_prev1 = 0.0f64;
-            for &x in &detrended {
-                let s = x + coeff * s_prev1 - s_prev2;
-                s_prev2 = s_prev1;
-                s_prev1 = s;
-            }
-            total += s_prev2 * s_prev2 + s_prev1 * s_prev1 - coeff * s_prev1 * s_prev2;
-        }
-        total / n_candidates as f64
-    };
-
-    if best_power > avg_power * 3.0 {
-        best_freq.clamp(f_low, f_high)
-    } else {
-        0.0
-    }
-}
-
 /// Compute per-subcarrier variance across the sliding window of `frame_history`.
 ///
 /// For each subcarrier index `k`, returns `Var[A_k]` over all stored frames.
@@ -2171,69 +2086,19 @@ fn extract_features_from_frame(
     // ── Spectral power ──
     let spectral_power: f64 = frame.amplitudes.iter().map(|a| a * a).sum::<f64>() / n;
 
-    // ── Motion band power (upper half of subcarriers, high spatial frequency) ──
-    let half = frame.amplitudes.len() / 2;
-    let motion_band_power = if half > 0 {
-        frame.amplitudes[half..]
-            .iter()
-            .map(|a| (a - mean_amp).powi(2))
-            .sum::<f64>()
-            / (frame.amplitudes.len() - half) as f64
-    } else {
-        0.0
-    };
-
-    // ── Breathing band power (lower half of subcarriers, low spatial frequency) ──
-    let breathing_band_power = if half > 0 {
-        frame.amplitudes[..half]
-            .iter()
-            .map(|a| (a - mean_amp).powi(2))
-            .sum::<f64>()
-            / half as f64
-    } else {
-        0.0
-    };
-
-    // ── Dominant frequency via peak subcarrier index ──
-    let peak_idx = frame
-        .amplitudes
-        .iter()
-        .enumerate()
-        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(i, _)| i)
-        .unwrap_or(0);
-    let dominant_freq_hz = peak_idx as f64 * 0.05;
-
-    // ── Change point detection (threshold-crossing count in current frame) ──
-    let threshold = mean_amp * 1.2;
-    let change_points = frame
-        .amplitudes
-        .windows(2)
-        .filter(|w| (w[0] < threshold) != (w[1] < threshold))
-        .count();
-
-    // ── Motion score: sliding-window temporal difference ──
-    // Compare current frame against the most recent historical frame.
-    // The difference is normalised by the mean amplitude to be scale-invariant.
-    let temporal_motion_score = if let Some(prev_frame) = frame_history.back() {
-        let n_cmp = n_sub.min(prev_frame.len());
-        if n_cmp > 0 {
-            let diff_energy: f64 = (0..n_cmp)
-                .map(|k| (frame.amplitudes[k] - prev_frame[k]).powi(2))
-                .sum::<f64>()
-                / n_cmp as f64;
-            // Normalise by mean squared amplitude to get a dimensionless ratio.
-            let ref_energy = mean_amp * mean_amp + 1e-9;
-            (diff_energy / ref_energy).sqrt().clamp(0.0, 1.0)
-        } else {
-            0.0
-        }
-    } else {
-        // No history yet — fall back to intra-frame variance-based estimate.
-        (intra_variance / (mean_amp * mean_amp + 1e-9))
-            .sqrt()
-            .clamp(0.0, 1.0)
-    };
+    // Frequency-band features must be calculated over elapsed time. The previous
+    // subcarrier-half split and peak-index-as-Hz encoding made quiet rooms look
+    // consistently occupied because spatial statistics were given temporal names.
+    let temporal = temporal_features::extract_temporal_frequency_features(
+        frame_history,
+        &frame.amplitudes,
+        sample_rate_hz,
+    );
+    let motion_band_power = temporal.motion_band_power;
+    let breathing_band_power = temporal.breathing_band_power;
+    let dominant_freq_hz = temporal.dominant_freq_hz;
+    let change_points = temporal.change_points;
+    let temporal_motion_score = motion_band_power / 100.0;
 
     // Blend temporal motion with variance-based motion for robustness.
     // Also factor in motion_band_power and change_points for ESP32 real-world sensitivity.
@@ -2255,8 +2120,7 @@ fn extract_features_from_frame(
         (1.0 - (temporal_variance / (mean_amp * mean_amp + 1e-9)).clamp(0.0, 1.0)).max(0.0);
     let signal_quality = (snr_quality * 0.6 + stability * 0.4).clamp(0.0, 1.0);
 
-    // ── Breathing rate estimation ──
-    let breathing_rate_hz = estimate_breathing_rate_hz(frame_history, sample_rate_hz);
+    let breathing_rate_hz = temporal.breathing_rate_hz;
 
     let features = FeatureInfo {
         mean_rssi,
@@ -2283,6 +2147,52 @@ fn extract_features_from_frame(
         sub_variances,
         motion_score,
     )
+}
+
+/// Preserve causality: compare the current frame with prior history, then record it.
+/// Keeping the ordering in one helper prevents callers from silently comparing a
+/// sample with itself and zeroing all frame-to-frame motion.
+fn extract_features_and_record_frame(
+    frame: &Esp32Frame,
+    frame_history: &mut VecDeque<Vec<f64>>,
+    sample_rate_hz: f64,
+) -> (FeatureInfo, ClassificationInfo, f64, Vec<f64>, f64) {
+    let extracted = extract_features_from_frame(frame, frame_history, sample_rate_hz);
+    frame_history.push_back(frame.amplitudes.clone());
+    if frame_history.len() > FRAME_HISTORY_CAPACITY {
+        frame_history.pop_front();
+    }
+    extracted
+}
+
+#[cfg(test)]
+mod temporal_history_order_tests {
+    use super::*;
+
+    #[test]
+    fn records_current_frame_only_after_feature_extraction() {
+        let mut history = VecDeque::from([vec![10.0; 4]]);
+        let current = Esp32Frame {
+            magic: 0xC511_0001,
+            node_id: 1,
+            n_antennas: 1,
+            n_subcarriers: 4,
+            freq_mhz: 2437,
+            sequence: 1,
+            rssi: -45,
+            noise_floor: -90,
+            ppdu_type: wifi_densepose_hardware::PpduType::HtLegacy,
+            amplitudes: vec![20.0; 4],
+            phases: vec![0.0; 4],
+        };
+
+        let (features, _, _, _, raw_motion) =
+            extract_features_and_record_frame(&current, &mut history, 20.0);
+
+        assert!(features.motion_band_power > 20.0);
+        assert!(raw_motion > 0.20);
+        assert_eq!(history.back(), Some(&current.amplitudes));
+    }
 }
 
 /// Simple threshold classification (no smoothing) — used as the "raw" input.
@@ -2444,20 +2354,14 @@ fn adaptive_override(
     features: &FeatureInfo,
     classification: &mut ClassificationInfo,
 ) {
-    // Get current frame amplitudes from the latest history entry.
-    let amps = state.frame_history.back().cloned().unwrap_or_default();
-    adaptive_override_with_amplitudes(state, 1, features, &amps, classification);
+    adaptive_override_with_topology(state, 1, features, classification);
 }
 
-/// Apply a room-level adaptive model to an explicitly selected amplitude set.
-/// Keeping amplitude selection outside the classifier prevents the ESP32
-/// multi-node path from accidentally training on one link and inferring on a
-/// different one.
-fn adaptive_override_with_amplitudes(
+/// Apply the room-level specialist only to its trained sensor topology.
+fn adaptive_override_with_topology(
     state: &mut AppStateInner,
     observed_node_count: usize,
     features: &FeatureInfo,
-    amps: &[f64],
     classification: &mut ClassificationInfo,
 ) {
     if state.adaptive_model.is_some() {
@@ -2481,7 +2385,7 @@ fn adaptive_override_with_amplitudes(
         });
         let Some(feat_arr) = state
             .adaptive_feature_extractor
-            .observe_runtime(&feature_json, amps)
+            .observe_runtime(&feature_json, &[])
         else {
             return;
         };
@@ -2511,23 +2415,6 @@ fn adaptive_override_with_amplitudes(
 /// multiplicative freshness gate used by RuView's universal RF encoder.
 const ADAPTIVE_FUSION_MAX_SAMPLE_AGE: Duration = Duration::from_millis(500);
 
-fn collect_fresh_node_amplitudes(
-    node_states: &HashMap<u8, NodeState>,
-    now: std::time::Instant,
-) -> Vec<f64> {
-    node_states
-        .values()
-        .filter(|node| {
-            node.last_frame_time.is_some_and(|received_at| {
-                now.saturating_duration_since(received_at) <= ADAPTIVE_FUSION_MAX_SAMPLE_AGE
-            })
-        })
-        .filter_map(|node| node.frame_history.back())
-        .flatten()
-        .copied()
-        .collect()
-}
-
 fn count_fresh_nodes(
     node_states: &HashMap<u8, NodeState>,
     now: std::time::Instant,
@@ -2543,11 +2430,11 @@ fn count_fresh_nodes(
 }
 
 #[cfg(test)]
-mod adaptive_fusion_amplitude_tests {
+mod adaptive_fusion_topology_tests {
     use super::*;
 
     #[test]
-    fn room_level_adaptive_input_excludes_old_links() {
+    fn room_level_adaptive_topology_excludes_old_links() {
         let now = std::time::Instant::now();
         let mut fresh = NodeState::new();
         fresh.frame_history.push_back(vec![1.0, 2.0]);
@@ -2559,7 +2446,7 @@ mod adaptive_fusion_amplitude_tests {
         nodes.insert(1, fresh);
         nodes.insert(2, old);
 
-        assert_eq!(collect_fresh_node_amplitudes(&nodes, now), vec![1.0, 2.0]);
+        assert_eq!(count_fresh_nodes(&nodes, now), 1);
     }
 }
 
@@ -2855,15 +2742,13 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
 
         // ── Step 4b: Update frame history and extract features ───────
         let mut s_write_pre = state.write().await;
-        s_write_pre
-            .frame_history
-            .push_back(frame.amplitudes.clone());
-        if s_write_pre.frame_history.len() > FRAME_HISTORY_CAPACITY {
-            s_write_pre.frame_history.pop_front();
-        }
         let sample_rate_hz = 1000.0 / tick_ms as f64;
         let (features, mut classification, breathing_rate_hz, sub_variances, raw_motion) =
-            extract_features_from_frame(&frame, &s_write_pre.frame_history, sample_rate_hz);
+            extract_features_and_record_frame(
+                &frame,
+                &mut s_write_pre.frame_history,
+                sample_rate_hz,
+            );
         smooth_and_classify(&mut s_write_pre, &mut classification, raw_motion);
         adaptive_override(&mut s_write_pre, &features, &mut classification);
         drop(s_write_pre);
@@ -3039,14 +2924,9 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
     };
 
     let mut s = state.write().await;
-    // Update frame history before extracting features.
-    s.frame_history.push_back(frame.amplitudes.clone());
-    if s.frame_history.len() > FRAME_HISTORY_CAPACITY {
-        s.frame_history.pop_front();
-    }
     let sample_rate_hz = 2.0_f64; // fallback tick ~ 500 ms => 2 Hz
     let (features, mut classification, breathing_rate_hz, sub_variances, raw_motion) =
-        extract_features_from_frame(&frame, &s.frame_history, sample_rate_hz);
+        extract_features_and_record_frame(&frame, &mut s.frame_history, sample_rate_hz);
     smooth_and_classify(&mut s, &mut classification, raw_motion);
     adaptive_override(&mut s, &features, &mut classification);
 
@@ -6556,19 +6436,25 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     // for downstream model-wake gating.
                     ns.update_novelty(&frame.amplitudes);
 
-                    ns.frame_history.push_back(frame.amplitudes.clone());
-                    if ns.frame_history.len() > FRAME_HISTORY_CAPACITY {
-                        ns.frame_history.pop_front();
-                    }
-
-                    let sample_rate_hz = 1000.0 / 500.0_f64;
+                    // Frequency bins only have physical meaning at the measured packet
+                    // cadence. The former 2 Hz constant compressed the observed
+                    // ~30–40 Hz stream and shifted every inferred frequency.
+                    let sample_rate_hz = if ns.csi_fps_samples >= 5 {
+                        ns.csi_fps_ema.clamp(1.0, 200.0)
+                    } else {
+                        20.0
+                    };
                     let (
                         features,
                         mut classification,
                         breathing_rate_hz,
                         sub_variances,
                         raw_motion,
-                    ) = extract_features_from_frame(&frame, &ns.frame_history, sample_rate_hz);
+                    ) = extract_features_and_record_frame(
+                        &frame,
+                        &mut ns.frame_history,
+                        sample_rate_hz,
+                    );
                     smooth_and_classify_node(ns, &mut classification, raw_motion);
 
                     ns.rssi_history.push_back(features.mean_rssi);
@@ -6576,6 +6462,7 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         ns.rssi_history.pop_front();
                     }
 
+                    ns.vital_detector.update_sample_rate(sample_rate_hz);
                     let raw_vitals = ns
                         .vital_detector
                         .process_frame(&frame.amplitudes, &frame.phases);
@@ -6614,14 +6501,11 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     // Cross-node fusion: combine features from all active nodes.
                     let fused_features = fuse_multi_node_features(&features, &s.node_states);
                     let adaptive_now = std::time::Instant::now();
-                    let adaptive_amps =
-                        collect_fresh_node_amplitudes(&s.node_states, adaptive_now);
                     let adaptive_node_count = count_fresh_nodes(&s.node_states, adaptive_now);
-                    adaptive_override_with_amplitudes(
+                    adaptive_override_with_topology(
                         &mut s,
                         adaptive_node_count,
                         &fused_features,
-                        &adaptive_amps,
                         &mut classification,
                     );
 
@@ -6930,15 +6814,9 @@ async fn simulated_data_task(state: SharedState, tick_ms: u64) {
 
         let frame = generate_simulated_frame(tick);
 
-        // Append current amplitudes to history before feature extraction.
-        s.frame_history.push_back(frame.amplitudes.clone());
-        if s.frame_history.len() > FRAME_HISTORY_CAPACITY {
-            s.frame_history.pop_front();
-        }
-
         let sample_rate_hz = 1000.0 / tick_ms as f64;
         let (features, mut classification, breathing_rate_hz, sub_variances, raw_motion) =
-            extract_features_from_frame(&frame, &s.frame_history, sample_rate_hz);
+            extract_features_and_record_frame(&frame, &mut s.frame_history, sample_rate_hz);
         smooth_and_classify(&mut s, &mut classification, raw_motion);
         adaptive_override(&mut s, &features, &mut classification);
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1198,6 +1198,8 @@ struct AppStateInner {
     // ── Adaptive classifier (environment-tuned) ──────────────────────────
     /// Trained adaptive model (loaded from data/adaptive_model.json or trained at runtime).
     adaptive_model: Option<adaptive_classifier::AdaptiveModel>,
+    /// Rate-normalized short temporal context for the adaptive classifier.
+    adaptive_feature_extractor: adaptive_classifier::AdaptiveFeatureExtractor,
     // ── Per-node state (issue #249) ─────────────────────────────────────
     /// Per-node sensing state for multi-node deployments.
     /// Keyed by `node_id` from the ESP32 frame header.
@@ -1377,6 +1379,7 @@ impl AppStateInner {
             training_state: training_api::TrainingState::default(),
             training_progress_tx: broadcast::channel::<String>(256).0,
             adaptive_model: None,
+            adaptive_feature_extractor: adaptive_classifier::AdaptiveFeatureExtractor::default(),
             node_states: HashMap::new(),
             pose_tracker: PoseTracker::new(),
             last_tracker_instant: None,
@@ -2429,24 +2432,15 @@ mod smoothed_classification_consistency_tests {
 }
 
 /// If an adaptive model is loaded, override the classification with the
-/// model's prediction.  Uses the full 15-feature vector for higher accuracy.
+/// model's prediction. Uses the same rate-normalized temporal patch as training.
 fn adaptive_override(
-    state: &AppStateInner,
+    state: &mut AppStateInner,
     features: &FeatureInfo,
     classification: &mut ClassificationInfo,
 ) {
     // Get current frame amplitudes from the latest history entry.
-    let amps = state
-        .frame_history
-        .back()
-        .map(|v| v.as_slice())
-        .unwrap_or(&[]);
-    adaptive_override_with_amplitudes(
-        state.adaptive_model.as_ref(),
-        features,
-        amps,
-        classification,
-    );
+    let amps = state.frame_history.back().cloned().unwrap_or_default();
+    adaptive_override_with_amplitudes(state, 1, features, &amps, classification);
 }
 
 /// Apply a room-level adaptive model to an explicitly selected amplitude set.
@@ -2454,27 +2448,46 @@ fn adaptive_override(
 /// multi-node path from accidentally training on one link and inferring on a
 /// different one.
 fn adaptive_override_with_amplitudes(
-    model: Option<&adaptive_classifier::AdaptiveModel>,
+    state: &mut AppStateInner,
+    observed_node_count: usize,
     features: &FeatureInfo,
     amps: &[f64],
     classification: &mut ClassificationInfo,
 ) {
-    if let Some(model) = model {
-        let feat_arr = adaptive_classifier::features_from_runtime(
-            &serde_json::json!({
-                "variance": features.variance,
-                "motion_band_power": features.motion_band_power,
-                "breathing_band_power": features.breathing_band_power,
-                "spectral_power": features.spectral_power,
-                "dominant_freq_hz": features.dominant_freq_hz,
-                "change_points": features.change_points,
-                "mean_rssi": features.mean_rssi,
-            }),
-            amps,
-        );
+    if state.adaptive_model.is_some() {
+        let expected_node_count = state
+            .adaptive_model
+            .as_ref()
+            .and_then(|model| model.expected_node_count);
+        if expected_node_count.is_some_and(|expected| expected != observed_node_count) {
+            state.adaptive_feature_extractor.reset();
+            return;
+        }
+        let feature_json = serde_json::json!({
+            "variance": features.variance,
+            "motion_band_power": features.motion_band_power,
+            "breathing_band_power": features.breathing_band_power,
+            "spectral_power": features.spectral_power,
+            "dominant_freq_hz": features.dominant_freq_hz,
+            "change_points": features.change_points,
+            "mean_rssi": features.mean_rssi,
+        });
+        let Some(feat_arr) = state
+            .adaptive_feature_extractor
+            .observe_runtime(&feature_json, amps)
+        else {
+            return;
+        };
+        let model = state
+            .adaptive_model
+            .as_ref()
+            .expect("adaptive model presence checked above");
         let (label, conf) = model.classify(&feat_arr);
-        classification.motion_level = label.to_string();
-        classification.presence = label != "absent";
+        (classification.motion_level, classification.presence) =
+            adaptive_classifier::reconcile_presence_prediction(
+                &label,
+                &classification.motion_level,
+            );
         // Blend model confidence with existing smoothed confidence.
         classification.confidence = (conf * 0.7 + classification.confidence * 0.3).clamp(0.0, 1.0);
     }
@@ -2501,6 +2514,20 @@ fn collect_fresh_node_amplitudes(
         .flatten()
         .copied()
         .collect()
+}
+
+fn count_fresh_nodes(
+    node_states: &HashMap<u8, NodeState>,
+    now: std::time::Instant,
+) -> usize {
+    node_states
+        .values()
+        .filter(|node| {
+            node.last_frame_time.is_some_and(|received_at| {
+                now.saturating_duration_since(received_at) <= ADAPTIVE_FUSION_MAX_SAMPLE_AGE
+            })
+        })
+        .count()
 }
 
 #[cfg(test)]
@@ -2826,7 +2853,7 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
         let (features, mut classification, breathing_rate_hz, sub_variances, raw_motion) =
             extract_features_from_frame(&frame, &s_write_pre.frame_history, sample_rate_hz);
         smooth_and_classify(&mut s_write_pre, &mut classification, raw_motion);
-        adaptive_override(&s_write_pre, &features, &mut classification);
+        adaptive_override(&mut s_write_pre, &features, &mut classification);
         drop(s_write_pre);
 
         // ── Step 5: Build enhanced fields from pipeline result ───────
@@ -3009,7 +3036,7 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
     let (features, mut classification, breathing_rate_hz, sub_variances, raw_motion) =
         extract_features_from_frame(&frame, &s.frame_history, sample_rate_hz);
     smooth_and_classify(&mut s, &mut classification, raw_motion);
-    adaptive_override(&s, &features, &mut classification);
+    adaptive_override(&mut s, &features, &mut classification);
 
     s.source = format!("wifi:{ssid}");
     s.rssi_history.push_back(rssi_dbm);
@@ -5321,8 +5348,16 @@ fn scan_recording_files() -> Vec<serde_json::Value> {
 /// POST /api/v1/adaptive/train — train the adaptive classifier from recordings.
 async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let rec_dir = PathBuf::from("data/recordings");
+    let expected_node_count = {
+        let s = state.read().await;
+        let count = count_fresh_nodes(&s.node_states, std::time::Instant::now());
+        (count > 0).then_some(count)
+    };
     eprintln!("=== Adaptive Classifier Training ===");
-    match adaptive_classifier::train_from_recordings(&rec_dir) {
+    match adaptive_classifier::train_from_recordings_for_node_count(
+        &rec_dir,
+        expected_node_count,
+    ) {
         Ok(model) => {
             let accuracy = model.training_accuracy;
             let frames = model.trained_frames;
@@ -5357,6 +5392,7 @@ async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Va
                     "validation": validation,
                     "activation_error": activation_error,
                     "class_stats": stats,
+                    "expected_node_count": expected_node_count,
                 }));
             }
 
@@ -5373,6 +5409,7 @@ async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Va
             // Load into runtime state.
             let mut s = state.write().await;
             s.adaptive_model = Some(model);
+            s.adaptive_feature_extractor.reset();
 
             Json(serde_json::json!({
                 "success": true,
@@ -5382,6 +5419,7 @@ async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Va
                 "training_accuracy": accuracy,
                 "validation": validation,
                 "class_stats": stats,
+                "expected_node_count": expected_node_count,
             }))
         }
         Err(e) => Json(serde_json::json!({
@@ -5404,6 +5442,7 @@ async fn adaptive_status(State(state): State<SharedState>) -> Json<serde_json::V
             "version": model.version,
             "classes": model.class_names,
             "class_stats": model.class_stats,
+            "expected_node_count": model.expected_node_count,
         })),
         None => Json(serde_json::json!({
             "loaded": false,
@@ -5416,6 +5455,7 @@ async fn adaptive_status(State(state): State<SharedState>) -> Json<serde_json::V
 async fn adaptive_unload(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let mut s = state.write().await;
     s.adaptive_model = None;
+    s.adaptive_feature_extractor.reset();
     Json(serde_json::json!({ "success": true, "message": "Adaptive model unloaded." }))
 }
 
@@ -6516,10 +6556,13 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
 
                     // Cross-node fusion: combine features from all active nodes.
                     let fused_features = fuse_multi_node_features(&features, &s.node_states);
+                    let adaptive_now = std::time::Instant::now();
                     let adaptive_amps =
-                        collect_fresh_node_amplitudes(&s.node_states, std::time::Instant::now());
+                        collect_fresh_node_amplitudes(&s.node_states, adaptive_now);
+                    let adaptive_node_count = count_fresh_nodes(&s.node_states, adaptive_now);
                     adaptive_override_with_amplitudes(
-                        s.adaptive_model.as_ref(),
+                        &mut s,
+                        adaptive_node_count,
                         &fused_features,
                         &adaptive_amps,
                         &mut classification,
@@ -6840,7 +6883,7 @@ async fn simulated_data_task(state: SharedState, tick_ms: u64) {
         let (features, mut classification, breathing_rate_hz, sub_variances, raw_motion) =
             extract_features_from_frame(&frame, &s.frame_history, sample_rate_hz);
         smooth_and_classify(&mut s, &mut classification, raw_motion);
-        adaptive_override(&s, &features, &mut classification);
+        adaptive_override(&mut s, &features, &mut classification);
 
         s.rssi_history.push_back(features.mean_rssi);
         if s.rssi_history.len() > 60 {
@@ -8236,6 +8279,7 @@ async fn main() {
                 None
             }
         },
+        adaptive_feature_extractor: adaptive_classifier::AdaptiveFeatureExtractor::default(),
         node_states: HashMap::new(),
         // Accuracy sprint
         pose_tracker: PoseTracker::new(),

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -5189,6 +5189,7 @@ async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Va
         Ok(model) => {
             let accuracy = model.training_accuracy;
             let frames = model.trained_frames;
+            let validation = model.validation.clone();
             let stats: Vec<_> = model
                 .class_stats
                 .iter()
@@ -5200,6 +5201,27 @@ async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Va
                     })
                 })
                 .collect();
+
+            // Never replace a working classifier with an unvalidated or weak
+            // candidate. CSI frames within one recording are autocorrelated;
+            // only whole-session held-out evidence is allowed to promote a
+            // model into the live path.
+            if let Err(activation_error) = model.runtime_eligibility() {
+                warn!(
+                    "Adaptive model trained but not activated: {}",
+                    activation_error
+                );
+                return Json(serde_json::json!({
+                    "success": true,
+                    "activated": false,
+                    "trained_frames": frames,
+                    "accuracy": accuracy,
+                    "training_accuracy": accuracy,
+                    "validation": validation,
+                    "activation_error": activation_error,
+                    "class_stats": stats,
+                }));
+            }
 
             // Save to disk.
             if let Err(e) = model.save(&adaptive_classifier::model_path()) {
@@ -5217,8 +5239,11 @@ async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Va
 
             Json(serde_json::json!({
                 "success": true,
+                "activated": true,
                 "trained_frames": frames,
                 "accuracy": accuracy,
+                "training_accuracy": accuracy,
+                "validation": validation,
                 "class_stats": stats,
             }))
         }
@@ -5237,6 +5262,8 @@ async fn adaptive_status(State(state): State<SharedState>) -> Json<serde_json::V
             "loaded": true,
             "trained_frames": model.trained_frames,
             "accuracy": model.training_accuracy,
+            "training_accuracy": model.training_accuracy,
+            "validation": model.validation,
             "version": model.version,
             "classes": model.class_names,
             "class_stats": model.class_stats,
@@ -8064,16 +8091,26 @@ async fn main() {
         // Training (ADR-186 TRAIN-RECONNECT)
         training_state: training_api::TrainingState::default(),
         training_progress_tx: broadcast::channel::<String>(256).0,
-        adaptive_model:
-            adaptive_classifier::AdaptiveModel::load(&adaptive_classifier::model_path())
-                .ok()
-                .inspect(|m| {
-                    info!(
-                        "Loaded adaptive classifier: {} frames, {:.1}% accuracy",
-                        m.trained_frames,
-                        m.training_accuracy * 100.0
-                    );
-                }),
+        adaptive_model: match adaptive_classifier::AdaptiveModel::load_runtime(
+            &adaptive_classifier::model_path(),
+        ) {
+            Ok(model) => {
+                info!(
+                    "Loaded adaptive classifier: {} frames, {:.1}% training accuracy, session-validated",
+                    model.trained_frames,
+                    model.training_accuracy * 100.0
+                );
+                Some(model)
+            }
+            Err(error) => {
+                warn!(
+                    "Adaptive classifier not auto-loaded from {}: {}",
+                    adaptive_classifier::model_path().display(),
+                    error
+                );
+                None
+            }
+        },
         node_states: HashMap::new(),
         // Accuracy sprint
         pose_tracker: PoseTracker::new(),

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1098,6 +1098,8 @@ struct AppStateInner {
     frame_history: VecDeque<Vec<f64>>,
     tick: u64,
     source: String,
+    /// Physical coordinates ordered by one-based ESP32 node ID.
+    node_positions: Vec<[f32; 3]>,
     /// Instant of the last ESP32 UDP frame received (for offline detection).
     last_esp32_frame: Option<std::time::Instant>,
     /// Latest validated RTL8720F summary; raw radar samples are not retained here.
@@ -1335,6 +1337,7 @@ impl AppStateInner {
             frame_history: VecDeque::new(),
             tick: 0,
             source: "test".to_string(),
+            node_positions: Vec::new(),
             last_esp32_frame: None,
             latest_realtek_radar: None,
             last_realtek_frame: None,
@@ -6246,7 +6249,7 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         .map(|(&id, n)| NodeInfo {
                             node_id: id,
                             rssi_dbm: n.rssi_history.back().copied().unwrap_or(0.0),
-                            position: [2.0, 0.0, 1.5],
+                            position: field_bridge::node_position(&s.node_positions, id),
                             amplitude: vec![],
                             subcarrier_count: 0,
                             // Vitals-only path; still expose the sync snapshot
@@ -6714,7 +6717,7 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         .map(|(&id, n)| NodeInfo {
                             node_id: id,
                             rssi_dbm: n.rssi_history.back().copied().unwrap_or(0.0),
-                            position: [2.0, 0.0, 1.5],
+                            position: field_bridge::node_position(&s.node_positions, id),
                             amplitude: if suppress_raw {
                                 vec![]
                             } else {
@@ -8062,6 +8065,11 @@ async fn main() {
     // Vital sign sample rate derives from tick interval (e.g. 500ms tick => 2 Hz)
     let vital_sample_rate = 1000.0 / args.tick_ms as f64;
     info!("Vital sign detector sample rate: {vital_sample_rate:.1} Hz");
+    let configured_node_positions = args
+        .node_positions
+        .as_deref()
+        .map(field_bridge::parse_node_positions)
+        .unwrap_or_default();
 
     // Load RVF container if --load-rvf was specified
     let rvf_info = if let Some(ref rvf_path) = args.load_rvf {
@@ -8265,6 +8273,7 @@ async fn main() {
         frame_history: VecDeque::new(),
         tick: 0,
         source: source.into(),
+        node_positions: configured_node_positions.clone(),
         last_esp32_frame: None,
         latest_realtek_radar: None,
         last_realtek_frame: None,
@@ -8354,15 +8363,12 @@ async fn main() {
                 min_nodes: 1, // single-node passthrough
                 ..cfg.clone()
             });
-            if let Some(ref pos_str) = args.node_positions {
-                let positions = field_bridge::parse_node_positions(pos_str);
-                if !positions.is_empty() {
-                    info!(
-                        "Configured {} node positions for multistatic fusion",
-                        positions.len()
-                    );
-                    fuser.set_node_positions(positions);
-                }
+            if !configured_node_positions.is_empty() {
+                info!(
+                    "Configured {} node positions for multistatic fusion and sensing output",
+                    configured_node_positions.len()
+                );
+                fuser.set_node_positions(configured_node_positions.clone());
             }
             engine_bridge_multistatic_cfg = Some(MultistaticConfig {
                 min_nodes: 1,

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -2344,7 +2344,9 @@ fn smooth_and_classify(state: &mut AppStateInner, raw: &mut ClassificationInfo, 
 
     // 6. Write the smoothed result back into the classification.
     raw.motion_level = state.current_motion_level.clone();
-    raw.presence = sm > 0.03;
+    // Keep the public classification contract internally consistent during
+    // hysteresis: the accepted state, not a second threshold, owns presence.
+    raw.presence = raw.motion_level != "absent";
     raw.confidence = (0.4 + sm * 0.6).clamp(0.0, 1.0);
 }
 
@@ -2382,8 +2384,48 @@ fn smooth_and_classify_node(ns: &mut NodeState, raw: &mut ClassificationInfo, ra
     }
 
     raw.motion_level = ns.current_motion_level.clone();
-    raw.presence = sm > 0.03;
+    // Match the aggregate path so consumers never receive absent + present.
+    raw.presence = raw.motion_level != "absent";
     raw.confidence = (0.4 + sm * 0.6).clamp(0.0, 1.0);
+}
+
+#[cfg(test)]
+mod smoothed_classification_consistency_tests {
+    use super::*;
+
+    fn raw_absent() -> ClassificationInfo {
+        ClassificationInfo {
+            motion_level: "absent".to_string(),
+            presence: false,
+            confidence: 0.0,
+        }
+    }
+
+    #[test]
+    fn aggregate_absent_state_cannot_report_presence() {
+        let mut state = AppStateInner::minimal();
+        state.baseline_frames = BASELINE_WARMUP;
+        state.smoothed_motion = 0.035;
+
+        let mut classification = raw_absent();
+        smooth_and_classify(&mut state, &mut classification, 0.035);
+
+        assert_eq!(classification.motion_level, "absent");
+        assert!(!classification.presence);
+    }
+
+    #[test]
+    fn per_node_absent_state_cannot_report_presence() {
+        let mut state = NodeState::new();
+        state.baseline_frames = BASELINE_WARMUP;
+        state.smoothed_motion = 0.035;
+
+        let mut classification = raw_absent();
+        smooth_and_classify_node(&mut state, &mut classification, 0.035);
+
+        assert_eq!(classification.motion_level, "absent");
+        assert!(!classification.presence);
+    }
 }
 
 /// If an adaptive model is loaded, override the classification with the

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -5345,14 +5345,57 @@ fn scan_recording_files() -> Vec<serde_json::Value> {
 
 // ── Adaptive classifier endpoints ────────────────────────────────────────────
 
+fn adaptive_recordings_dir_from(configured: Option<std::ffi::OsString>) -> PathBuf {
+    configured
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("data/recordings"))
+}
+
+fn adaptive_recordings_dir() -> PathBuf {
+    // The path is process configuration, not request input. This lets a private
+    // product keep household captures outside the upstream RuView checkout.
+    adaptive_recordings_dir_from(std::env::var_os("RUVIEW_ADAPTIVE_RECORDINGS_DIR"))
+}
+
+fn adaptive_node_count_from(configured: Option<std::ffi::OsString>) -> Option<usize> {
+    configured
+        .and_then(|value| value.into_string().ok())
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|count| *count > 0)
+}
+
+#[cfg(test)]
+mod adaptive_recordings_directory_tests {
+    use super::*;
+
+    #[test]
+    fn configured_directory_is_used_without_changing_the_default() {
+        assert_eq!(
+            PathBuf::from("/private/training-view"),
+            adaptive_recordings_dir_from(Some("/private/training-view".into()))
+        );
+        assert_eq!(
+            PathBuf::from("data/recordings"),
+            adaptive_recordings_dir_from(None)
+        );
+        assert_eq!(Some(2), adaptive_node_count_from(Some("2".into())));
+        assert_eq!(None, adaptive_node_count_from(Some("0".into())));
+    }
+}
+
 /// POST /api/v1/adaptive/train — train the adaptive classifier from recordings.
 async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    let rec_dir = PathBuf::from("data/recordings");
-    let expected_node_count = {
+    let rec_dir = adaptive_recordings_dir();
+    let active_node_count = {
         let s = state.read().await;
         let count = count_fresh_nodes(&s.node_states, std::time::Instant::now());
         (count > 0).then_some(count)
     };
+    let expected_node_count = adaptive_node_count_from(std::env::var_os(
+        "RUVIEW_ADAPTIVE_NODE_COUNT",
+    ))
+    .or(active_node_count);
     eprintln!("=== Adaptive Classifier Training ===");
     match adaptive_classifier::train_from_recordings_for_node_count(
         &rec_dir,

--- a/v2/crates/wifi-densepose-sensing-server/src/multistatic_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/multistatic_bridge.rs
@@ -16,8 +16,10 @@ use wifi_densepose_signal::ruvsense::multistatic::{FusedSensingFrame, Multistati
 
 use super::NodeState;
 
-/// Maximum age for a node frame to be considered active (10 seconds).
-const STALE_THRESHOLD: Duration = Duration::from_secs(10);
+/// Maximum age for a node frame to enter the same fusion cycle. At the
+/// measured ~10 Hz cadence this tolerates roughly five missed frames while
+/// preventing seconds-old evidence from being fused or counted as current.
+const STALE_THRESHOLD: Duration = Duration::from_millis(500);
 
 /// Default WiFi channel frequency (MHz) used for single-channel frames.
 const DEFAULT_FREQ_MHZ: u32 = 2437; // Channel 6
@@ -283,6 +285,29 @@ mod tests {
         let frames = node_frames_from_states(&states);
         assert_eq!(frames.len(), 1, "stale node should be excluded");
         assert_eq!(frames[0].node_id, 1);
+    }
+
+    #[test]
+    fn half_second_freshness_boundary_excludes_old_count_evidence() {
+        let mut states: HashMap<u8, NodeState> = HashMap::new();
+        let mut old_history = VecDeque::new();
+        old_history.push_back(vec![3.0, 4.0]);
+        states.insert(
+            2,
+            make_node_state(
+                old_history,
+                Some(Instant::now() - Duration::from_millis(600)),
+                3,
+            ),
+        );
+
+        let frames = node_frames_from_states(&states);
+        let fuser = MultistaticFuser::new();
+        let (fused, fallback) = fuse_or_fallback(&fuser, &states, 3.0);
+
+        assert!(frames.is_empty());
+        assert!(fused.is_none());
+        assert_eq!(fallback, Some(0), "old person count must not linger");
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-sensing-server/src/temporal_features.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/temporal_features.rs
@@ -1,0 +1,226 @@
+//! Causal, time-axis CSI features for the lightweight presence path.
+
+use std::collections::VecDeque;
+
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct TemporalFrequencyFeatures {
+    /// Frame-to-frame normalized RMS change, reported as a percentage.
+    pub(crate) motion_band_power: f64,
+    /// Fraction of temporal spectral power in the physiological 0.1–0.5 Hz band.
+    pub(crate) breathing_band_power: f64,
+    pub(crate) dominant_freq_hz: f64,
+    pub(crate) breathing_rate_hz: f64,
+    pub(crate) change_points: usize,
+}
+
+/// Extract features on the time axis. CSI subcarrier indices are spatial/frequency
+/// bins, not elapsed time, so treating an index as Hz creates physically meaningless
+/// signals. The bounded, decimated periodogram keeps this path cheap enough for ESP32
+/// streaming while retaining the 0.1–5 Hz band used by CSI presence/vital pipelines.
+pub(crate) fn extract_temporal_frequency_features(
+    frame_history: &VecDeque<Vec<f64>>,
+    current_amplitudes: &[f64],
+    sample_rate_hz: f64,
+) -> TemporalFrequencyFeatures {
+    let sample_rate_hz = sample_rate_hz.clamp(1.0, 200.0);
+    let previous = frame_history.back();
+    let n_cmp = previous
+        .map(|frame| frame.len().min(current_amplitudes.len()))
+        .unwrap_or(0);
+    let current_energy = if current_amplitudes.is_empty() {
+        0.0
+    } else {
+        current_amplitudes
+            .iter()
+            .map(|value| value * value)
+            .sum::<f64>()
+            / current_amplitudes.len() as f64
+    };
+    let (motion_ratio, change_points) = previous.map_or((0.0, 0), |previous| {
+        if n_cmp == 0 {
+            return (0.0, 0);
+        }
+        let diff_energy = (0..n_cmp)
+            .map(|index| (current_amplitudes[index] - previous[index]).powi(2))
+            .sum::<f64>()
+            / n_cmp as f64;
+        let changed = (0..n_cmp)
+            .filter(|&index| {
+                let reference = previous[index]
+                    .abs()
+                    .max(current_amplitudes[index].abs())
+                    .max(1e-6);
+                (current_amplitudes[index] - previous[index]).abs() / reference >= 0.03
+            })
+            .count();
+        (
+            (diff_energy / (current_energy + 1e-9))
+                .sqrt()
+                .clamp(0.0, 1.0),
+            changed,
+        )
+    });
+
+    let max_source_samples = (sample_rate_hz * 30.0).ceil() as usize;
+    let start = frame_history.len().saturating_sub(max_source_samples);
+    let mut source: Vec<f64> = frame_history
+        .iter()
+        .skip(start)
+        .map(|amplitudes| mean_amplitude(amplitudes))
+        .collect();
+    source.push(mean_amplitude(current_amplitudes));
+
+    // Frequencies above 5 Hz are irrelevant to this feature contract. Downsampling
+    // makes periodogram cost nearly independent of high CSI packet rates.
+    let decimation = (sample_rate_hz / 10.0).ceil().max(1.0) as usize;
+    if decimation > 1 {
+        source = source
+            .chunks(decimation)
+            .map(|chunk| chunk.iter().sum::<f64>() / chunk.len() as f64)
+            .collect();
+    }
+    let effective_rate_hz = sample_rate_hz / decimation as f64;
+    let minimum_samples = (effective_rate_hz * 8.0).ceil() as usize;
+    if source.len() < minimum_samples.max(16) {
+        return motion_only(motion_ratio, change_points);
+    }
+
+    let sample_count = source.len();
+    let mean = source.iter().sum::<f64>() / sample_count as f64;
+    let detrended: Vec<f64> = source
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let hann = 0.5
+                - 0.5
+                    * (std::f64::consts::TAU * index as f64
+                        / sample_count.saturating_sub(1) as f64)
+                        .cos();
+            (value - mean) * hann
+        })
+        .collect();
+    if detrended.iter().map(|value| value * value).sum::<f64>() <= 1e-9 {
+        return motion_only(motion_ratio, change_points);
+    }
+
+    let first_bin = ((0.1 * sample_count as f64 / effective_rate_hz).ceil() as usize).max(1);
+    let max_frequency_hz = 5.0_f64.min(effective_rate_hz * 0.45);
+    let last_bin = (max_frequency_hz * sample_count as f64 / effective_rate_hz).floor() as usize;
+    let mut total_power = 0.0;
+    let mut breathing_power = 0.0;
+    let mut breathing_bins = 0usize;
+    let mut best_power = 0.0;
+    let mut best_frequency_hz = 0.0;
+    let mut best_breathing_power = 0.0;
+    let mut best_breathing_hz = 0.0;
+
+    for bin in first_bin..=last_bin.max(first_bin) {
+        let omega = std::f64::consts::TAU * bin as f64 / sample_count as f64;
+        let (real, imaginary) =
+            detrended
+                .iter()
+                .enumerate()
+                .fold((0.0, 0.0), |(real, imaginary), (index, value)| {
+                    let angle = omega * index as f64;
+                    (real + value * angle.cos(), imaginary - value * angle.sin())
+                });
+        let power = real * real + imaginary * imaginary;
+        let frequency_hz = bin as f64 * effective_rate_hz / sample_count as f64;
+        total_power += power;
+        if power > best_power {
+            best_power = power;
+            best_frequency_hz = frequency_hz;
+        }
+        if (0.1..=0.5).contains(&frequency_hz) {
+            breathing_power += power;
+            breathing_bins += 1;
+            if power > best_breathing_power {
+                best_breathing_power = power;
+                best_breathing_hz = frequency_hz;
+            }
+        }
+    }
+
+    let breathing_band_power = if total_power > 0.0 {
+        (breathing_power / total_power).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let average_breathing_power = if breathing_bins > 0 {
+        breathing_power / breathing_bins as f64
+    } else {
+        0.0
+    };
+    let breathing_rate_hz =
+        if breathing_band_power >= 0.25 && best_breathing_power >= average_breathing_power * 1.5 {
+            best_breathing_hz
+        } else {
+            0.0
+        };
+
+    TemporalFrequencyFeatures {
+        motion_band_power: motion_ratio * 100.0,
+        breathing_band_power,
+        dominant_freq_hz: best_frequency_hz,
+        breathing_rate_hz,
+        change_points,
+    }
+}
+
+fn mean_amplitude(amplitudes: &[f64]) -> f64 {
+    if amplitudes.is_empty() {
+        0.0
+    } else {
+        amplitudes.iter().sum::<f64>() / amplitudes.len() as f64
+    }
+}
+
+fn motion_only(motion_ratio: f64, change_points: usize) -> TemporalFrequencyFeatures {
+    TemporalFrequencyFeatures {
+        motion_band_power: motion_ratio * 100.0,
+        change_points,
+        ..TemporalFrequencyFeatures::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compares_current_frame_with_previous_frame() {
+        let history = VecDeque::from([vec![10.0; 4]]);
+        let temporal = extract_temporal_frequency_features(&history, &[20.0; 4], 20.0);
+
+        assert!(temporal.motion_band_power > 20.0);
+        assert_eq!(temporal.change_points, 4);
+    }
+
+    #[test]
+    fn reports_temporal_hertz_instead_of_subcarrier_indices() {
+        let sample_rate_hz = 20.0;
+        let breathing_hz = 0.25;
+        let history = (0..400)
+            .map(|index| {
+                let time = index as f64 / sample_rate_hz;
+                let amplitude = 20.0 + (std::f64::consts::TAU * breathing_hz * time).sin();
+                vec![amplitude; 8]
+            })
+            .collect();
+
+        let temporal = extract_temporal_frequency_features(&history, &[20.0; 8], sample_rate_hz);
+
+        assert!((temporal.dominant_freq_hz - breathing_hz).abs() <= 0.05);
+        assert!(temporal.breathing_band_power > 0.50);
+        assert!((temporal.breathing_rate_hz - breathing_hz).abs() <= 0.05);
+    }
+
+    #[test]
+    fn rejects_frequency_claims_until_enough_time_has_elapsed() {
+        let history = std::iter::repeat_with(|| vec![20.0; 8]).take(10).collect();
+        let temporal = extract_temporal_frequency_features(&history, &[20.0; 8], 20.0);
+
+        assert_eq!(temporal.dominant_freq_hz, 0.0);
+        assert_eq!(temporal.breathing_rate_hz, 0.0);
+    }
+}

--- a/v2/crates/wifi-densepose-sensing-server/src/types.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/types.rs
@@ -518,6 +518,7 @@ pub struct AppStateInner {
     pub training_config: Option<serde_json::Value>,
     pub adaptive_model: Option<adaptive_classifier::AdaptiveModel>,
     pub adaptive_feature_extractor: adaptive_classifier::AdaptiveFeatureExtractor,
+    pub adaptive_presence_smoother: adaptive_classifier::AdaptivePresenceSmoother,
     pub node_states: HashMap<u8, NodeState>,
     pub pose_tracker: PoseTracker,
     pub last_tracker_instant: Option<std::time::Instant>,

--- a/v2/crates/wifi-densepose-sensing-server/src/types.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/types.rs
@@ -517,6 +517,7 @@ pub struct AppStateInner {
     pub training_status: String,
     pub training_config: Option<serde_json::Value>,
     pub adaptive_model: Option<adaptive_classifier::AdaptiveModel>,
+    pub adaptive_feature_extractor: adaptive_classifier::AdaptiveFeatureExtractor,
     pub node_states: HashMap<u8, NodeState>,
     pub pose_tracker: PoseTracker,
     pub last_tracker_instant: Option<std::time::Instant>,

--- a/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
@@ -24,9 +24,10 @@ const BREATHING_MAX_HZ: f64 = 0.5; // 30 BPM
 const HEARTBEAT_MIN_HZ: f64 = 0.667; // 40 BPM
 const HEARTBEAT_MAX_HZ: f64 = 2.0; // 120 BPM
 
-/// Minimum number of samples before attempting extraction.
-const MIN_BREATHING_SAMPLES: usize = 40; // ~2s at 20 Hz
-const MIN_HEARTBEAT_SAMPLES: usize = 30; // ~1.5s at 20 Hz
+/// Minimum elapsed context before attempting extraction. Sample-count constants
+/// silently change meaning when CSI packet rate changes.
+const MIN_BREATHING_WINDOW_SECS: f64 = 8.0;
+const MIN_HEARTBEAT_WINDOW_SECS: f64 = 4.0;
 
 /// Peak-to-mean ratio threshold for confident detection.
 const CONFIDENCE_THRESHOLD: f64 = 2.0;
@@ -109,6 +110,35 @@ impl VitalSignDetector {
         }
     }
 
+    /// Reconfigure the detector from a measured CSI packet rate.
+    ///
+    /// A material rate change invalidates the time axis of buffered samples, so those
+    /// samples are discarded instead of being interpreted at a new frequency scale.
+    /// Small EMA drift updates capacities in place to avoid repeated warm-up resets.
+    pub fn update_sample_rate(&mut self, measured_rate_hz: f64) -> bool {
+        if !measured_rate_hz.is_finite() || measured_rate_hz <= 0.0 {
+            return false;
+        }
+        let measured_rate_hz = measured_rate_hz.clamp(1.0, 200.0);
+        let relative_change =
+            (measured_rate_hz - self.sample_rate).abs() / self.sample_rate.max(1.0);
+        self.sample_rate = measured_rate_hz;
+        self.breathing_capacity = (measured_rate_hz * self.breathing_window_secs).ceil() as usize;
+        self.heartbeat_capacity = (measured_rate_hz * self.heartbeat_window_secs).ceil() as usize;
+        if relative_change >= 0.10 {
+            self.reset();
+            true
+        } else {
+            while self.breathing_buffer.len() > self.breathing_capacity {
+                self.breathing_buffer.pop_front();
+            }
+            while self.heartbeat_buffer.len() > self.heartbeat_capacity {
+                self.heartbeat_buffer.pop_front();
+            }
+            false
+        }
+    }
+
     /// Process one CSI frame and return updated vital signs.
     ///
     /// `amplitude` - per-subcarrier amplitude values for this frame.
@@ -188,7 +218,8 @@ impl VitalSignDetector {
     /// Extract breathing rate from the breathing buffer via FFT.
     /// Returns (rate_bpm, confidence).
     pub fn extract_breathing(&self) -> (Option<f64>, f64) {
-        if self.breathing_buffer.len() < MIN_BREATHING_SAMPLES {
+        let minimum_samples = (self.sample_rate * MIN_BREATHING_WINDOW_SECS).ceil() as usize;
+        if self.breathing_buffer.len() < minimum_samples {
             return (None, 0.0);
         }
 
@@ -200,7 +231,8 @@ impl VitalSignDetector {
     /// Extract heart rate from the heartbeat buffer via FFT.
     /// Returns (rate_bpm, confidence).
     pub fn extract_heartbeat(&self) -> (Option<f64>, f64) {
-        if self.heartbeat_buffer.len() < MIN_HEARTBEAT_SAMPLES {
+        let minimum_samples = (self.sample_rate * MIN_HEARTBEAT_WINDOW_SECS).ceil() as usize;
+        if self.heartbeat_buffer.len() < minimum_samples {
             return (None, 0.0);
         }
 
@@ -840,6 +872,22 @@ mod tests {
         let (br_len, _, hb_len, _) = detector.buffer_status();
         assert_eq!(br_len, 0);
         assert_eq!(hb_len, 0);
+    }
+
+    #[test]
+    fn measured_sample_rate_rebuilds_the_time_axis_and_capacities() {
+        let mut detector = VitalSignDetector::new(10.0);
+        for _ in 0..20 {
+            detector.process_frame(&[10.0; 8], &[0.0; 8]);
+        }
+
+        assert!(detector.update_sample_rate(40.0));
+        assert_eq!(detector.sample_rate, 40.0);
+        assert_eq!(detector.buffer_status(), (0, 1_200, 0, 600));
+
+        detector.process_frame(&[10.0; 8], &[0.0; 8]);
+        assert!(!detector.update_sample_rate(41.0));
+        assert_eq!(detector.buffer_status().0, 1);
     }
 
     #[test]


### PR DESCRIPTION
## 背景

2台のESP32-C6を固定配置した実環境で、adaptive presenceがEMPTYを約20分間ほぼ常時PRESENTと判定しました。同一baselineの結果はEMPTY recall 0.0%、PRESENT recall 98.99%、balanced accuracy 49.50%です。旧modelはtraining accuracy 94.19%に対しLOSO balanced accuracy 71.00%で、session固有条件へ過適合していました。

WiFi-JEPA / WiFlow等の高いPCKは姿勢キーポイント指標でありpresence accuracyではありません。一方、TCD-FERNやDeepCPDが共通して使う時間差、物理時間、独立環境評価に照らすと、現runtimeには信号処理とmodel採用契約の直接的な欠陥がありました。

関連する製品evidence gateと調査記録: https://github.com/albert-einshutoin/spatial-intelligence/pull/2

## 変更前

- current frameを履歴へ追加してからhistory.backと比較し、連続フレーム差分が自己比較になる
- 実測約30〜38 HzのESP32到着を2 Hz固定で解釈する
- 1 frame内のsubcarrier indexを時間周波数Hzとして扱う
- offline学習は欠損/56件制限のREST amplitude、runtimeは内部full amplitudeを使いtrain/serve skewがある
- schema v3、LOSO 71%、各class recall約70%のmodelがaggregate presenceを全面上書きできる
- トポロジ、stale link、公開node座標の契約が内部fusionと一致しない

## 変更後

- 全ESP32入力経路を、特徴抽出後にcurrent frameを履歴へ追加するcausal helperへ統一
- node別`csi_fps_ema`から実測sample rateを取得し、vitalsの時間軸・buffer容量もrate変更時に再構成
- 最大30秒の時系列を計算上限10 Hzへdecimateし、Hann periodogramで0.1〜5 Hzを計算
- 呼吸帯0.1〜0.5 Hzのpower ratioと実際のdominant Hzを算出し、8秒未満は周波数claimを拒否
- schema v4を、公開server特徴7個と5秒velocity/stddevだけの21特徴へ変更し、学習/推論からprivate amplitudeを完全除外
- v3 modelを明示拒否
- runtime上書きをLOSO balanced accuracy 90%以上、全class recall 90%以上、各class最低2独立sessionへ強化
- stale/weak/malformed modelはheuristic判定を上書きしない
- fresh linkだけの融合、1-based node座標mapping、NaN/Infinity/部分座標のfail-closedを維持

## なぜこの実装か

現在の2リンク・2.4 GHz・約30〜38 Hz・少数sessionへ大規模JEPA/Transformerを追加しても、論文の9〜18アンテナlink、600〜810 Hz、数万〜数十万教師sampleは再現できません。まず物理時間とtrain/serve parityを正し、小さいモデルが独立sessionで90/90 Gateを通るか検証します。

30秒historyは0.1 Hz近傍を扱う最小実用窓です。最大10 Hzへのdecimationはpresence/呼吸帯を保持しつつ、各frameのperiodogram計算量とmemoryを制限するためです。周波数warm-up中は推測値を出さずfail closedにします。

## 検証

- `cargo test -p wifi-densepose-sensing-server --lib --bin sensing-server`
  - lib: 487 passed / 1 ignored
  - binary: 259 passed
  - total: 746 passed
- causal previous/current、0.25 Hz sine、rate不変、warm-up拒否をTDDで追加
- REST amplitude有無でoffline/runtime feature vectorが同一になる回帰test
- stale schema、弱いbalanced accuracy、class collapse、独立session不足の拒否test
- `git diff --check`: passed
- `cargo clippy --no-deps`: 変更箇所の新規指摘なし。ただし既存`training_api.rs`の`approx_constant` denyで全体exitは非0

## セキュリティと既知の境界

- `cargo audit --ignore RUSTSEC-2023-0071`でworkspace既存依存に4 vulnerabilitiesを検出
- 対象はlocked quick-xml 0.36.2 / 0.38.4の2 advisoryで、今回のsignal-processing差分とは独立
- event-listener、lru等のwarningも残るため、依存更新はworkspace全体の互換性を確認する別PRで扱う
- コード契約の修正は実環境精度90%の証明ではない
- ローカルservice停止中のため、修正後binaryによるfresh hardware captureは未実施
- 次は旧v3 modelをロードせず、EMPTY、A/中央/B、OUTSIDE_ZONE、別日の順でschema-v4 evidenceを取得する
- 2F APで境界分離に失敗した場合だけ、対象室を横切る専用3F transmitterを対照実験する
