### PR TITLE
fix(desktop): repair clean UI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
         node-version: '22'
 
     - name: Run UI unit tests
-      run: node --test ui/sw.test.mjs ui/services/ws-ticket.test.mjs ui/services/websocket.service.test.mjs
+      run: find ui v2/crates/wifi-densepose-desktop/ui -type f -name '*.test.mjs' -print0 | xargs -0 node --test
 
   # Unit and Integration Tests
   # Python pytest matrix — runs against the archived v1 Python tree.

--- a/v2/crates/wifi-densepose-desktop/tauri.conf.json
+++ b/v2/crates/wifi-densepose-desktop/tauri.conf.json
@@ -6,8 +6,14 @@
   "build": {
     "frontendDist": "ui/dist",
     "devUrl": "http://localhost:5173",
-    "beforeDevCommand": "cd ../ui && npm run dev",
-    "beforeBuildCommand": "cd ../ui && npm run build"
+    "beforeDevCommand": {
+      "cwd": "ui",
+      "script": "npm run dev"
+    },
+    "beforeBuildCommand": {
+      "cwd": "ui",
+      "script": "npm run build"
+    }
   },
   "app": {
     "windows": [

--- a/v2/crates/wifi-densepose-desktop/ui/build-config.test.mjs
+++ b/v2/crates/wifi-densepose-desktop/ui/build-config.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const uiDir = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(join(uiDir, "package.json"), "utf8"));
+const tauriConfig = JSON.parse(
+  readFileSync(join(uiDir, "..", "tauri.conf.json"), "utf8"),
+);
+
+function major(versionRange) {
+  const match = versionRange.match(/\d+/);
+  assert.ok(match, `Expected a semver range, got ${versionRange}`);
+  return Number(match[0]);
+}
+
+test("React runtime and type packages use the same major version", () => {
+  assert.equal(
+    major(packageJson.dependencies.react),
+    major(packageJson.dependencies["react-dom"]),
+  );
+  assert.equal(
+    major(packageJson.devDependencies["@types/react"]),
+    major(packageJson.devDependencies["@types/react-dom"]),
+  );
+  assert.equal(
+    major(packageJson.dependencies.react),
+    major(packageJson.devDependencies["@types/react"]),
+  );
+});
+
+test("Tauri frontend hooks run from the UI directory", () => {
+  assert.deepEqual(tauriConfig.build.beforeDevCommand, {
+    cwd: "ui",
+    script: "npm run dev",
+  });
+  assert.deepEqual(tauriConfig.build.beforeBuildCommand, {
+    cwd: "ui",
+    script: "npm run build",
+  });
+});
+
+test("Vite client types cover CSS side-effect imports", () => {
+  const declaration = readFileSync(join(uiDir, "src", "vite-env.d.ts"), "utf8");
+  assert.match(declaration, /reference types=["']vite\/client["']/);
+});

--- a/v2/crates/wifi-densepose-desktop/ui/package-lock.json
+++ b/v2/crates/wifi-densepose-desktop/ui/package-lock.json
@@ -11,12 +11,12 @@
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-shell": "^2.3.5",
-        "react": "^18.3.1",
-        "react-dom": "^19.2.5"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^19.2.3",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^4.3.0",
         "typescript": "^6.0.3",
         "vite": "^6.0.0"
@@ -1233,28 +1233,20 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1488,6 +1480,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -1514,18 +1507,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -1621,27 +1602,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-refresh": {

--- a/v2/crates/wifi-densepose-desktop/ui/package.json
+++ b/v2/crates/wifi-densepose-desktop/ui/package.json
@@ -6,18 +6,19 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "test": "node --test build-config.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-shell": "^2.3.5",
-    "react": "^18.3.1",
-    "react-dom": "^19.2.5"
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@types/react": "^18.3.0",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^6.0.3",
     "vite": "^6.0.0"

--- a/v2/crates/wifi-densepose-desktop/ui/src/vite-env.d.ts
+++ b/v2/crates/wifi-densepose-desktop/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

- align React, React DOM, and both type packages on React 19
- add Vite client declarations so TypeScript accepts CSS side-effect imports
- express Tauri frontend hooks with the supported `{ script, cwd: "ui" }` form
- add a regression test for dependency majors, hook working directories, and Vite declarations
- make the PR UI job discover all `.test.mjs` files so this and future UI regressions stay gated

## Validation

- `npm --prefix v2/crates/wifi-densepose-desktop/ui ci`
- `npm --prefix v2/crates/wifi-densepose-desktop/ui test` — 3/3 passed
- `npm --prefix v2/crates/wifi-densepose-desktop/ui run build`
- PR UI command — 29/29 passed
- `git diff --check upstream/main...HEAD`

The clean frontend install and production build were exercised locally. A full Tauri bundle and Windows runtime were not claimed.

Closes #1518
