### PR TITLE
fix(harness): keep manifest inputs on LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# The harness hashes generated provenance files byte-for-byte. Keep its text
+# files on LF even when a Windows checkout enables core.autocrlf.
+harness/ruview/** text=auto eol=lf

--- a/harness/ruview/test/line-endings.test.mjs
+++ b/harness/ruview/test/line-endings.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const PROVENANCE_FILES = [
+  'harness/ruview/package.json',
+  'harness/ruview/.harness/manifest.json',
+  'harness/ruview/.harness/manifest.sha256',
+];
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+test('harness provenance files are checked out with LF line endings', () => {
+  const attributes = git(['check-attr', 'text', 'eol', '--', ...PROVENANCE_FILES], REPO_ROOT);
+
+  for (const file of PROVENANCE_FILES) {
+    assert.match(attributes, new RegExp(`${file}: text: auto`));
+    assert.match(attributes, new RegExp(`${file}: eol: lf`));
+  }
+});
+
+test('core.autocrlf checkout preserves LF bytes for harness provenance', () => {
+  const scratch = mkdtempSync(join(tmpdir(), 'ruview-lf-checkout-'));
+  const source = join(scratch, 'source');
+  const checkout = join(scratch, 'checkout');
+
+  try {
+    mkdirSync(join(source, 'harness/ruview/.harness'), { recursive: true });
+    copyFileSync(join(REPO_ROOT, '.gitattributes'), join(source, '.gitattributes'));
+    writeFileSync(join(source, 'harness/ruview/.harness/manifest.json'), '{\n  "ok": true\n}\n');
+    writeFileSync(join(source, 'harness/ruview/.harness/manifest.sha256'), 'digest  manifest.json\n');
+
+    git(['init', '--quiet'], source);
+    git(['config', 'user.email', 'test@example.invalid'], source);
+    git(['config', 'user.name', 'RuView test'], source);
+    git(['add', '.'], source);
+    git(['commit', '--quiet', '-m', 'test fixture'], source);
+    execFileSync('git', ['-c', 'core.autocrlf=true', 'clone', '--quiet', source, checkout]);
+
+    for (const relativePath of PROVENANCE_FILES.slice(1)) {
+      const bytes = readFileSync(join(checkout, relativePath));
+      assert.equal(bytes.includes(Buffer.from('\r\n')), false, `${relativePath} must remain LF`);
+    }
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- force LF checkout semantics only for `harness/ruview/**`
- add a regression test that inspects Git attributes and performs a `core.autocrlf=true` clone
- verify the resulting provenance files contain no CRLF bytes

The rule is intentionally scoped to the byte-for-byte hashed harness instead of changing line-ending policy for the entire repository.

## Validation

- `node --test harness/ruview/test/line-endings.test.mjs` — 2/2 passed
- `npm --prefix harness/ruview run manifest:verify` — 41/41 files verified
- `git diff --check upstream/main...HEAD`

The Windows checkout is simulated with Git's Windows line-ending setting; no native Windows runner is claimed.

Closes #1519
