### PR TITLE
fix(ui): render unscored pose keypoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
         node-version: '22'
 
     - name: Run UI unit tests
-      run: node --test ui/sw.test.mjs ui/services/ws-ticket.test.mjs ui/services/websocket.service.test.mjs
+      run: find ui v2/crates/wifi-densepose-desktop/ui -type f -name '*.test.mjs' -print0 | xargs -0 node --test
 
   # Unit and Integration Tests
   # Python pytest matrix — runs against the archived v1 Python tree.

--- a/ui/tests/pose-renderer.test.mjs
+++ b/ui/tests/pose-renderer.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const rendererSource = readFileSync(resolve(TEST_DIR, '../utils/pose-renderer.js'));
+const rendererModuleUrl = `data:text/javascript;base64,${rendererSource.toString('base64')}`;
+const { PoseRenderer, getRenderableKeypoints } = await import(rendererModuleUrl);
+
+function createCanvas() {
+  const calls = { fill: 0, stroke: 0 };
+  const gradient = { addColorStop() {} };
+  const context = {
+    arc() {},
+    beginPath() {},
+    clearRect() {},
+    createLinearGradient: () => gradient,
+    createRadialGradient: () => gradient,
+    fill() { calls.fill += 1; },
+    fillRect() {},
+    fillText() {},
+    lineTo() {},
+    moveTo() {},
+    stroke() { calls.stroke += 1; },
+    strokeRect() {},
+  };
+  const canvas = { width: 320, height: 240, getContext: () => context };
+  return { calls, canvas };
+}
+
+test('a completely unscored set gets display-only confidence', () => {
+  const source = [
+    { x: 0.25, y: 0.25, confidence: 0 },
+    { x: 0.75, y: 0.75, confidence: 0 },
+  ];
+
+  const renderable = getRenderableKeypoints(source);
+
+  assert.ok(renderable.every((keypoint) => keypoint.confidence === 0.5));
+  assert.ok(source.every((keypoint) => keypoint.confidence === 0));
+});
+
+test('a mixed scored set preserves rejected zero-confidence keypoints', () => {
+  const source = [
+    { x: 0.25, y: 0.25, confidence: 0 },
+    { x: 0.75, y: 0.75, confidence: 0.8 },
+  ];
+
+  assert.equal(getRenderableKeypoints(source), source);
+});
+
+test('default skeleton mode draws zero-confidence coordinates', () => {
+  const { calls, canvas } = createCanvas();
+  const keypoints = Array.from({ length: 17 }, (_, index) => ({
+    x: 80 + (index % 5) * 35,
+    y: 40 + Math.floor(index / 5) * 50,
+    confidence: 0,
+  }));
+  const renderer = new PoseRenderer(canvas, {
+    enableSmoothing: false,
+    showConfidence: false,
+    showZones: false,
+  });
+
+  renderer.renderSkeletonMode({ persons: [{ confidence: 0.9, keypoints }] });
+
+  assert.ok(calls.stroke > 0, 'expected visible skeleton connections');
+  assert.equal(calls.fill, keypoints.length, 'expected every unscored keypoint to render');
+  assert.ok(keypoints.every((keypoint) => keypoint.confidence === 0));
+});

--- a/ui/utils/pose-renderer.js
+++ b/ui/utils/pose-renderer.js
@@ -1,5 +1,24 @@
 // Pose Renderer Utility for WiFi-DensePose UI
 
+// A zero across the complete keypoint set means "unscored" on the
+// signal-derived path. This value is display-only and is never written back to
+// the source data or presented as a sensing confidence.
+const UNSCORED_KEYPOINT_RENDER_CONFIDENCE = 0.5;
+
+export function getRenderableKeypoints(keypoints) {
+  if (!Array.isArray(keypoints) || keypoints.length === 0) return keypoints;
+
+  const isUnscoredSet = keypoints.every((keypoint) =>
+    keypoint && typeof keypoint.confidence === 'number' && keypoint.confidence === 0
+  );
+
+  if (!isUnscoredSet) return keypoints;
+  return keypoints.map((keypoint) => ({
+    ...keypoint,
+    confidence: UNSCORED_KEYPOINT_RENDER_CONFIDENCE,
+  }));
+}
+
 export class PoseRenderer {
   constructor(canvas, options = {}) {
     this.canvas = canvas;
@@ -187,8 +206,13 @@ export class PoseRenderer {
         return; // Skip low confidence detections
       }
 
+      // The signal-derived path supplies coordinates without per-point scores.
+      // Give that complete unscored set a neutral display strength, while
+      // preserving zeroes in mixed scored sets as rejected keypoints.
+      const renderableKps = getRenderableKeypoints(person.keypoints);
+
       // Apply client-side lerp smoothing to reduce visual jitter
-      const smoothedKps = this._getSmoothedKeypoints(index, person.keypoints);
+      const smoothedKps = this._getSmoothedKeypoints(index, renderableKps);
 
       // Render skeleton connections
       if (this.config.showSkeleton && smoothedKps) {
@@ -225,7 +249,8 @@ export class PoseRenderer {
 
     persons.forEach((person, index) => {
       if (person.confidence >= this.config.confidenceThreshold && person.keypoints) {
-        this.renderKeypoints(person.keypoints, person.confidence, true);
+        const renderableKps = getRenderableKeypoints(person.keypoints);
+        this.renderKeypoints(renderableKps, person.confidence, true);
 
         // Render bounding box
         if (this.config.showBoundingBox && person.bbox) {
@@ -251,7 +276,8 @@ export class PoseRenderer {
 
       const hue = (personIdx * 60) % 360; // different hue per person
 
-      person.keypoints.forEach((kp) => {
+      const renderableKps = getRenderableKeypoints(person.keypoints);
+      renderableKps.forEach((kp) => {
         if (kp.confidence <= this.config.keypointConfidenceThreshold) return;
 
         const cx = this.scaleX(kp.x);
@@ -268,9 +294,9 @@ export class PoseRenderer {
       });
 
       // Light skeleton overlay so joints are connected
-      if (person.keypoints) {
+      if (renderableKps) {
         this.ctx.globalAlpha = 0.25;
-        this.renderSkeleton(person.keypoints, person.confidence);
+        this.renderSkeleton(renderableKps, person.confidence);
         this.ctx.globalAlpha = 1.0;
       }
 
@@ -301,7 +327,8 @@ export class PoseRenderer {
     persons.forEach((person, personIdx) => {
       if (person.confidence < this.config.confidenceThreshold || !person.keypoints) return;
 
-      const kps = this._getSmoothedKeypoints(personIdx, person.keypoints);
+      const renderableKps = getRenderableKeypoints(person.keypoints);
+      const kps = this._getSmoothedKeypoints(personIdx, renderableKps);
 
       bodyParts.forEach((part) => {
         // Collect valid keypoints for this body part


### PR DESCRIPTION
## Summary

- treat a completely zero-confidence keypoint set as unscored at the rendering boundary
- use a neutral display-only confidence copy across all four renderer modes
- preserve source data and continue rejecting zeroes in mixed scored/unscored sets
- add the canvas regression to the blocking PR UI job

This makes the shipped signal-derived/no-model coordinates visible without presenting the fallback value as sensing confidence.

## Validation

- `node --check ui/utils/pose-renderer.js`
- PR UI command — 29/29 passed, including 3 renderer regressions
- `git diff --check upstream/main...HEAD`

The renderer boundary is covered with a canvas stub; no Docker, hardware, or pixel-level browser claim is made.

Closes #1525
