### PR TITLE
fix(observatory): synchronize scenario caption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
         node-version: '22'
 
     - name: Run UI unit tests
-      run: node --test ui/sw.test.mjs ui/services/ws-ticket.test.mjs ui/services/websocket.service.test.mjs
+      run: find ui v2/crates/wifi-densepose-desktop/ui -type f -name '*.test.mjs' -print0 | xargs -0 node --test
 
   # Unit and Integration Tests
   # Python pytest matrix — runs against the archived v1 Python tree.

--- a/ui/observatory/js/hud-controller.js
+++ b/ui/observatory/js/hud-controller.js
@@ -438,11 +438,15 @@ export class HudController {
     const fallEl = document.getElementById('fall-alert');
     if (fallEl) fallEl.style.display = cls.fall_detected ? 'block' : 'none';
 
-    // Scenario description and edge modules
-    const scenarioKey = demoData._autoMode ? (demoData.currentScenario || 'auto') : (demoData.currentScenario || 'auto');
+    // Keep the caption derived from the same current-scenario value as the
+    // rendered HUD on every frame. The DOM can otherwise retain stale startup
+    // text even when the cached scenario key already matches.
+    const scenarioKey = demoData.currentScenario || 'auto';
+    this._updateScenarioDescription(scenarioKey);
+
+    // Edge-module markup only needs rebuilding when the scenario changes.
     if (scenarioKey !== this._currentScenarioKey) {
       this._currentScenarioKey = scenarioKey;
-      this._updateScenarioDescription(scenarioKey);
       this._updateEdgeModules(scenarioKey);
     }
   }
@@ -546,7 +550,8 @@ export class HudController {
   _updateScenarioDescription(scenarioKey) {
     const el = document.getElementById('scenario-description');
     if (!el) return;
-    el.textContent = SCENARIO_DESCRIPTIONS[scenarioKey] || '';
+    const description = SCENARIO_DESCRIPTIONS[scenarioKey] || '';
+    if (el.textContent !== description) el.textContent = description;
   }
 
   _updateEdgeModules(scenarioKey) {

--- a/ui/observatory/js/hud-controller.test.mjs
+++ b/ui/observatory/js/hud-controller.test.mjs
@@ -1,0 +1,67 @@
+// Regression coverage for issue #1527.
+//
+// This exercises HudController against a minimal DOM boundary. It verifies
+// rendered text synchronization, not a browser, animation timing, or hardware.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+function makeElement() {
+  const classes = new Set();
+  return {
+    textContent: '',
+    innerHTML: '',
+    value: '',
+    className: '',
+    style: {},
+    classList: {
+      add: (...names) => names.forEach((name) => classes.add(name)),
+      remove: (...names) => names.forEach((name) => classes.delete(name)),
+      contains: (name) => classes.has(name),
+    },
+  };
+}
+
+const elements = new Map();
+function element(id) {
+  if (!elements.has(id)) elements.set(id, makeElement());
+  return elements.get(id);
+}
+
+globalThis.document = {
+  getElementById(id) {
+    if (id === 'rssi-sparkline') return { getContext: () => null };
+    return element(id);
+  },
+};
+
+const { HudController } = await import('./hud-controller.js');
+
+test('each HUD frame repairs a stale scenario caption even when the key is unchanged', () => {
+  elements.clear();
+  const hud = new HudController({ settings: {} });
+  const demoData = {
+    _autoMode: true,
+    currentScenario: 'single_breathing',
+  };
+  const data = {
+    vital_signs: { heart_rate_bpm: 72, breathing_rate_bpm: 14 },
+    features: { mean_rssi: -48, variance: 0.3, motion_band_power: 0.02 },
+    classification: { confidence: 0.9, presence: true, motion_level: 'present' },
+    estimated_persons: 1,
+  };
+
+  // Reproduce the stale-load state: internal scenario tracking already agrees
+  // with the frame, while the visible caption still describes an empty room.
+  hud._currentScenarioKey = 'single_breathing';
+  element('scenario-description').textContent =
+    'Baseline calibration with no human presence in the monitored zone.';
+
+  hud.updateHUD(data, demoData);
+
+  assert.equal(
+    element('scenario-description').textContent,
+    'Detecting vital signs through WiFi signal micro-variations.',
+  );
+  assert.equal(element('persons-value').textContent, 1);
+});


### PR DESCRIPTION
## Summary

- derive the Observatory caption from `demoData.currentScenario` on every HUD frame
- repair stale startup text even when the internal scenario key already matches
- avoid redundant DOM writes and keep edge-module rebuilding change-only
- add the initialization regression to the blocking PR UI job

## Validation

- `node --check ui/observatory/js/hud-controller.js`
- PR UI command — 27/27 passed
- `git diff --check upstream/main...HEAD`

This covers the HUD/DOM boundary; no browser animation or hardware run is claimed.

Closes #1527
