### PR TITLE
feat: surface the associated-AP BSSID as node telemetry (#1542 ask 1)

### DIFF
--- a/firmware/esp32-csi-node/README.md
+++ b/firmware/esp32-csi-node/README.md
@@ -203,6 +203,29 @@ All packets are sent over UDP to the configured aggregator. The magic number in 
 | `0xC5110001` | CSI Frame (ADR-018) | ~20 Hz | Variable | Raw I/Q per subcarrier per antenna |
 | `0xC5110002` | Vitals Packet | 1 Hz | 32 bytes | Presence, breathing BPM, heart rate, fall flag, occupancy |
 | `0xC5110004` | WASM Output | Event-driven | Variable | Custom events from WASM modules (u8 type + f32 value) |
+| `0xC511A111` | Link Status (#1542) | ~30 s + on BSSID change | 32 bytes | Associated-AP BSSID, channel, AP RSSI, reassoc count |
+
+### Link Status Packet Format (#1542)
+
+The associated AP is the sensing-link geometry; a roam silently changes what a
+node senses, and frame RSSI cannot reveal it. This packet surfaces the BSSID.
+Sent every `CONFIG_LINK_STATUS_EVERY_N_FRAMES` CSI callbacks (default 600, or
+about 30 s at 20 Hz) plus immediately whenever the BSSID observed via
+`esp_wifi_sta_get_ap_info()` differs from the last reported one.
+
+```
+Offset  Size  Field
+0       4     Magic: 0xC511A111 (LE u32)
+4       1     Node ID
+5       1     Protocol version (0x01)
+6       1     Flags: bit 0 = ap_info_valid
+7       1     Primary channel (0 when not associated)
+8       6     BSSID (all-zero when not associated)
+14      1     AP RSSI as seen by the station, dBm (i8)
+15      1     Reserved
+16      4     Reassoc count: WIFI_EVENT_STA_CONNECTED events since boot (LE u32)
+20      12    Reserved
+```
 
 ### ADR-018 Binary Frame Format
 

--- a/firmware/esp32-csi-node/main/csi_collector.c
+++ b/firmware/esp32-csi-node/main/csi_collector.c
@@ -357,6 +357,55 @@ static void wifi_csi_callback(void *ctx, wifi_csi_info_t *info)
             }
         }
     }
+
+    /* #1542 ask 1 — Link-status packet: the associated AP IS the sensing-link
+     * geometry, and published RSSI is provably blind to a roam (field data on
+     * the issue: -47.7 vs -48.2 dBm across two completely different link
+     * geometries). Emit every CONFIG_LINK_STATUS_EVERY_N_FRAMES CSI callbacks
+     * (default 600 = ~30 s at 20 Hz) PLUS immediately when the observed BSSID
+     * differs from the last reported one, so a roam is visible within one
+     * callback rather than one cadence period. Same 32-byte auxiliary-packet
+     * family as the ADR-110 sync packet (magic 0xC511A111). */
+    {
+#ifndef CONFIG_LINK_STATUS_EVERY_N_FRAMES
+#define CONFIG_LINK_STATUS_EVERY_N_FRAMES 600
+#endif
+        extern volatile uint32_t g_wifi_reassoc_count;
+        static uint8_t s_link_last_bssid[6] = {0};
+        static bool    s_link_ever_sent = false;
+
+        wifi_ap_record_t ap = {0};
+        bool ap_ok = (esp_wifi_sta_get_ap_info(&ap) == ESP_OK);
+        bool changed = ap_ok && (!s_link_ever_sent ||
+                       memcmp(ap.bssid, s_link_last_bssid, 6) != 0);
+        if (changed || (s_cb_count % CONFIG_LINK_STATUS_EVERY_N_FRAMES) == 0) {
+            uint8_t pkt[32] = {0};
+            uint32_t link_magic = 0xC511A111u;   /* #1542 link-status packet */
+            memcpy(&pkt[0], &link_magic, 4);
+            pkt[4] = s_node_id;
+            pkt[5] = 0x01;                        /* protocol version */
+            pkt[6] = ap_ok ? 0x01 : 0x00;         /* flags: ap_info_valid */
+            pkt[7] = ap_ok ? ap.primary : 0;
+            if (ap_ok) memcpy(&pkt[8], ap.bssid, 6);
+            pkt[14] = ap_ok ? (uint8_t)ap.rssi : 0;
+            /* pkt[15] reserved */
+            uint32_t reassoc = g_wifi_reassoc_count;
+            memcpy(&pkt[16], &reassoc, 4);
+            /* pkt[20..31] reserved */
+            int lr = stream_sender_send_priority(pkt, sizeof(pkt));
+            if (ap_ok) {
+                memcpy(s_link_last_bssid, ap.bssid, 6);
+                s_link_ever_sent = true;
+            }
+            if (changed) {
+                ESP_LOGI(TAG, "link-status: BSSID change -> "
+                              "%02x:%02x:%02x:%02x:%02x:%02x ch=%u reassoc=%lu (lr=%d)",
+                         ap.bssid[0], ap.bssid[1], ap.bssid[2],
+                         ap.bssid[3], ap.bssid[4], ap.bssid[5],
+                         (unsigned)ap.primary, (unsigned long)reassoc, lr);
+            }
+        }
+    }
 }
 
 /**

--- a/firmware/esp32-csi-node/main/main.c
+++ b/firmware/esp32-csi-node/main/main.c
@@ -61,11 +61,18 @@ static EventGroupHandle_t s_wifi_event_group;
 static int s_retry_num = 0;
 #define MAX_RETRY 10
 
+/* #1542: WIFI_EVENT_STA_CONNECTED events since boot, read by the
+ * csi_collector link-status packet so the host can distinguish "stable
+ * association" from "re-associated to the same BSSID". Monotonic per boot. */
+volatile uint32_t g_wifi_reassoc_count = 0;
+
 static void event_handler(void *arg, esp_event_base_t event_base,
                           int32_t event_id, void *event_data)
 {
     if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
         esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_CONNECTED) {
+        g_wifi_reassoc_count++;
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
         wifi_event_sta_disconnected_t *disc = (wifi_event_sta_disconnected_t *)event_data;
         ESP_LOGW(TAG, "WiFi disconnected, reason=%d rssi=%d", disc->reason, disc->rssi);

--- a/v2/crates/wifi-densepose-hardware/src/lib.rs
+++ b/v2/crates/wifi-densepose-hardware/src/lib.rs
@@ -46,6 +46,7 @@ mod esp32_parser;
 // the OpportunisticCsiBridge maps today's ESP32 CSI extraction onto the
 // standardized report path until an OTA binding exists.
 pub mod ieee80211bf;
+pub mod link_packet;
 pub mod sync_packet;
 /// ADR-270 capability-safe vendor RF provider contract.
 pub mod vendor_rf;
@@ -98,6 +99,9 @@ pub use rtl8720f::{
     RadarFrame as Rtl8720fRadarFrame, RadarParseError as Rtl8720fRadarParseError,
     RadarPayload as Rtl8720fRadarPayload, ReportType as Rtl8720fReportType,
     RTL8720F_RADAR_HEADER_LEN, RTL8720F_RADAR_MAGIC, RTL8720F_RADAR_VERSION,
+};
+pub use link_packet::{
+    LinkStatusPacket, LINK_PACKET_MAGIC, LINK_PACKET_PROTO_VER, LINK_PACKET_SIZE,
 };
 pub use sync_packet::{
     SyncPacket, SyncPacketFlags, SYNC_PACKET_MAGIC, SYNC_PACKET_PROTO_VER, SYNC_PACKET_SIZE,

--- a/v2/crates/wifi-densepose-hardware/src/link_packet.rs
+++ b/v2/crates/wifi-densepose-hardware/src/link_packet.rs
@@ -1,0 +1,220 @@
+//! Link-status packet decoder (issue #1542 ask 1: BSSID telemetry).
+//!
+//! The associated AP *is* the sensing-link geometry: when a station roams,
+//! every downstream consumer of that node's CSI is silently looking at a
+//! different Fresnel volume. Field data on #1542 shows published RSSI cannot
+//! reveal the change (−47.7 vs −48.2 dBm across two completely different
+//! link geometries), so the BSSID itself is the only observable.
+//!
+//! Emitted by the firmware on the same UDP socket as ADR-018 CSI frames and
+//! ADR-110 sync packets, distinguished by leading magic `0xC511_A111` (next
+//! value in the ADR-110 auxiliary-packet family). Low rate: every
+//! `CONFIG_LINK_STATUS_EVERY_N_FRAMES` CSI callbacks (default 600 ≈ 30 s at
+//! 20 Hz) plus one immediate emission whenever the BSSID observed via
+//! `esp_wifi_sta_get_ap_info()` differs from the previously reported one —
+//! so a roam is visible within one CSI callback, not one cadence period.
+//!
+//! Wire format (32 bytes, little-endian, mirrors the sync-packet layout):
+//! ```text
+//! [0..3]   magic 0xC511A111 (LE u32)
+//! [4]      node_id
+//! [5]      proto_ver (currently 0x01)
+//! [6]      flags: bit 0 = ap_info_valid (esp_wifi_sta_get_ap_info() == ESP_OK)
+//! [7]      primary channel (0 when ap_info_valid = 0)
+//! [8..13]  bssid[6] (all-zero when ap_info_valid = 0)
+//! [14]     AP RSSI as seen by the station, dBm (i8; 0 when invalid)
+//! [15]     reserved
+//! [16..19] reassoc_count (LE u32) — WIFI_EVENT_STA_CONNECTED events since boot
+//! [20..31] reserved
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ParseError;
+
+/// Magic constant in the first 4 little-endian bytes of every link-status packet.
+pub const LINK_PACKET_MAGIC: u32 = 0xC511_A111;
+/// Total wire size of a link-status packet.
+pub const LINK_PACKET_SIZE: usize = 32;
+/// Wire protocol version currently emitted by firmware.
+pub const LINK_PACKET_PROTO_VER: u8 = 0x01;
+
+/// Decoded #1542 link-status packet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkStatusPacket {
+    pub node_id: u8,
+    pub proto_ver: u8,
+    /// False when the firmware's `esp_wifi_sta_get_ap_info()` call failed
+    /// (not associated); `bssid`/`channel`/`ap_rssi_dbm` are zero then.
+    pub ap_info_valid: bool,
+    /// Primary channel of the associated AP.
+    pub channel: u8,
+    /// BSSID of the associated AP — the sensing link's far endpoint identity.
+    pub bssid: [u8; 6],
+    /// RSSI of the AP as measured by the station (dBm). Complements the
+    /// frame-level RSSI already in ADR-018 headers; comes from the same
+    /// `wifi_ap_record_t` read as the BSSID.
+    pub ap_rssi_dbm: i8,
+    /// Count of `WIFI_EVENT_STA_CONNECTED` events since boot. Monotonic per
+    /// boot; a host observing an increment without a reboot marker knows a
+    /// re-association happened even if the BSSID ended up unchanged.
+    pub reassoc_count: u32,
+}
+
+impl LinkStatusPacket {
+    /// Decode a 32-byte link-status packet. Host should dispatch on the
+    /// leading magic before calling (same convention as `SyncPacket`).
+    pub fn from_bytes(buf: &[u8]) -> Result<Self, ParseError> {
+        if buf.len() < LINK_PACKET_SIZE {
+            return Err(ParseError::InsufficientData {
+                needed: LINK_PACKET_SIZE,
+                got: buf.len(),
+            });
+        }
+        let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+        if magic != LINK_PACKET_MAGIC {
+            return Err(ParseError::InvalidMagic { expected: LINK_PACKET_MAGIC, got: magic });
+        }
+        let node_id = buf[4];
+        let proto_ver = buf[5];
+        let ap_info_valid = (buf[6] & 0x01) != 0;
+        let channel = buf[7];
+        let mut bssid = [0u8; 6];
+        bssid.copy_from_slice(&buf[8..14]);
+        let ap_rssi_dbm = buf[14] as i8;
+        // buf[15] reserved
+        let reassoc_count = u32::from_le_bytes(buf[16..20].try_into().unwrap());
+        // buf[20..32] reserved
+        Ok(Self {
+            node_id,
+            proto_ver,
+            ap_info_valid,
+            channel,
+            bssid,
+            ap_rssi_dbm,
+            reassoc_count,
+        })
+    }
+
+    /// Serialize back to wire bytes (32 bytes, little-endian).
+    pub fn to_bytes(&self) -> [u8; LINK_PACKET_SIZE] {
+        let mut out = [0u8; LINK_PACKET_SIZE];
+        out[0..4].copy_from_slice(&LINK_PACKET_MAGIC.to_le_bytes());
+        out[4] = self.node_id;
+        out[5] = self.proto_ver;
+        out[6] = if self.ap_info_valid { 0x01 } else { 0x00 };
+        out[7] = self.channel;
+        out[8..14].copy_from_slice(&self.bssid);
+        out[14] = self.ap_rssi_dbm as u8;
+        // out[15] reserved zero
+        out[16..20].copy_from_slice(&self.reassoc_count.to_le_bytes());
+        // out[20..32] reserved zero
+        out
+    }
+
+    /// Canonical lowercase colon-separated BSSID string (`aa:bb:cc:dd:ee:ff`)
+    /// for JSON/MQTT surfaces.
+    pub fn bssid_string(&self) -> String {
+        let b = &self.bssid;
+        format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            b[0], b[1], b[2], b[3], b[4], b[5]
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn typical() -> LinkStatusPacket {
+        LinkStatusPacket {
+            node_id: 3,
+            proto_ver: 1,
+            ap_info_valid: true,
+            channel: 6,
+            bssid: [0x6c, 0xae, 0xf6, 0xb6, 0x52, 0xc7],
+            ap_rssi_dbm: -48,
+            reassoc_count: 2,
+        }
+    }
+
+    #[test]
+    fn typical_packet_roundtrips() {
+        let pkt = typical();
+        let wire = pkt.to_bytes();
+        let decoded = LinkStatusPacket::from_bytes(&wire).unwrap();
+        assert_eq!(decoded, pkt);
+        assert_eq!(decoded.bssid_string(), "6c:ae:f6:b6:52:c7");
+    }
+
+    #[test]
+    fn unassociated_packet_roundtrips_with_zero_fields() {
+        let pkt = LinkStatusPacket {
+            node_id: 5,
+            proto_ver: 1,
+            ap_info_valid: false,
+            channel: 0,
+            bssid: [0; 6],
+            ap_rssi_dbm: 0,
+            reassoc_count: 7,
+        };
+        let decoded = LinkStatusPacket::from_bytes(&pkt.to_bytes()).unwrap();
+        assert_eq!(decoded, pkt);
+        assert!(!decoded.ap_info_valid);
+        assert_eq!(decoded.bssid_string(), "00:00:00:00:00:00");
+    }
+
+    #[test]
+    fn magic_mismatch_is_typed_error() {
+        let mut wire = typical().to_bytes();
+        wire[0] = 0x01;
+        match LinkStatusPacket::from_bytes(&wire).unwrap_err() {
+            ParseError::InvalidMagic { got, .. } => assert_ne!(got, LINK_PACKET_MAGIC),
+            other => panic!("expected InvalidMagic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn short_packet_is_typed_error() {
+        let wire = [0u8; 16];
+        match LinkStatusPacket::from_bytes(&wire).unwrap_err() {
+            ParseError::InsufficientData { needed, got } => {
+                assert_eq!(needed, LINK_PACKET_SIZE);
+                assert_eq!(got, 16);
+            }
+            other => panic!("expected InsufficientData, got {other:?}"),
+        }
+    }
+
+    /// Hosts dispatch CSI vs sync vs link purely on the leading u32; the
+    /// three magics must never collide.
+    #[test]
+    fn link_magic_is_distinct_from_sync_and_csi() {
+        assert_ne!(LINK_PACKET_MAGIC, crate::sync_packet::SYNC_PACKET_MAGIC);
+        assert_ne!(LINK_PACKET_MAGIC, crate::esp32_parser::ESP32_CSI_MAGIC);
+    }
+
+    /// Canonical wire pin (same convention as the sync packet's
+    /// `canonical_wire_bytes_match_python_decoder`): if this hex stops
+    /// matching, a decoder drifted from the wire.
+    #[test]
+    fn canonical_wire_bytes_pin() {
+        let canonical: [u8; 32] = [
+            0x11, 0xa1, 0x11, 0xc5, // magic 0xC511A111 (LE u32)
+            0x03,                   // node_id = 3
+            0x01,                   // proto_ver = 1
+            0x01,                   // flags: ap_info_valid
+            0x06,                   // channel 6
+            0x6c, 0xae, 0xf6, 0xb6, 0x52, 0xc7, // bssid
+            0xd0,                   // ap_rssi = -48 dBm (i8)
+            0x00,                   // reserved
+            0x02, 0x00, 0x00, 0x00, // reassoc_count = 2
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let decoded = LinkStatusPacket::from_bytes(&canonical).unwrap();
+        assert_eq!(decoded, typical());
+        assert_eq!(decoded.to_bytes(), canonical,
+                   "to_bytes drifted from the canonical pin");
+    }
+}

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -376,6 +376,34 @@ struct NodeInfo {
     /// placeholder frames that carry no per-node classification.
     #[serde(skip_serializing_if = "Option::is_none")]
     node_inference: Option<NodeInference>,
+    /// #1542 ask 1 — the node's associated-AP link identity, from the
+    /// firmware's link-status packet (magic 0xC511_A111). The associated AP
+    /// IS the sensing-link geometry; published RSSI is provably blind to a
+    /// roam (field data on #1542: -47.7 vs -48.2 dBm across two completely
+    /// different link geometries). `None` until a link-status packet has
+    /// been observed for this node.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    link: Option<NodeLinkInfo>,
+}
+
+/// #1542 — per-node association telemetry embedded in NodeInfo. A downstream
+/// consumer that stores the previous `bssid` gets roam *events* for free by
+/// comparing successive snapshots; `reassoc_count` additionally reveals
+/// same-BSSID re-associations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NodeLinkInfo {
+    /// Lowercase colon-separated BSSID of the associated AP.
+    bssid: String,
+    /// Primary channel of the associated AP.
+    channel: u8,
+    /// AP RSSI as measured by the station (dBm), from the same
+    /// `wifi_ap_record_t` read as the BSSID.
+    ap_rssi_dbm: i8,
+    /// WIFI_EVENT_STA_CONNECTED count since node boot.
+    reassoc_count: u32,
+    /// Milliseconds since the host last received a link-status packet from
+    /// this node (staleness signal; cadence is ~30 s + on-change).
+    age_ms: u64,
 }
 
 /// ADR-110 iter 23 — per-node mesh-sync snapshot embedded in NodeInfo.
@@ -675,6 +703,10 @@ struct NodeState {
     latest_sync: Option<wifi_densepose_hardware::SyncPacket>,
     /// Last time a sync packet from this node was received (for staleness).
     latest_sync_at: Option<std::time::Instant>,
+    /// #1542: latest link-status packet (associated-AP identity) from this node.
+    latest_link: Option<wifi_densepose_hardware::LinkStatusPacket>,
+    /// Last time a link-status packet from this node was received.
+    latest_link_at: Option<std::time::Instant>,
     /// ADR-110 iter 18: EMA-tracked CSI frame rate for this node.
     /// Replaces the hardcoded 20 Hz fallback in
     /// `mesh_aligned_us_for_csi_frame` once `csi_fps_samples ≥ 5`.
@@ -888,6 +920,34 @@ impl NodeState {
     /// extracted here so tests can build a `NodeState`, populate
     /// `latest_sync`, and assert the snapshot shape without spinning up
     /// the axum router.
+    /// #1542: record a link-status packet from this node.
+    pub(crate) fn apply_link_packet(
+        &mut self,
+        pkt: wifi_densepose_hardware::LinkStatusPacket,
+        at: std::time::Instant,
+    ) {
+        self.latest_link = Some(pkt);
+        self.latest_link_at = Some(at);
+    }
+
+    /// #1542: project the latest link-status packet into the NodeInfo shape.
+    /// `None` until a packet has been seen, or while the node reports itself
+    /// unassociated (`ap_info_valid == false`).
+    pub(crate) fn link_snapshot(&self, now: std::time::Instant) -> Option<NodeLinkInfo> {
+        let link = self.latest_link.as_ref()?;
+        if !link.ap_info_valid {
+            return None;
+        }
+        let seen_at = self.latest_link_at?;
+        Some(NodeLinkInfo {
+            bssid: link.bssid_string(),
+            channel: link.channel,
+            ap_rssi_dbm: link.ap_rssi_dbm,
+            reassoc_count: link.reassoc_count,
+            age_ms: now.duration_since(seen_at).as_millis() as u64,
+        })
+    }
+
     pub(crate) fn sync_snapshot(&self) -> Option<NodeSyncSnapshot> {
         let sync = self.latest_sync.as_ref()?;
         Some(NodeSyncSnapshot {
@@ -951,6 +1011,8 @@ impl NodeState {
             edge_vitals: None,
             latest_sync: None,
             latest_sync_at: None,
+            latest_link: None,
+            latest_link_at: None,
             csi_fps_ema: 20.0,
             csi_fps_samples: 0,
             latest_features: None,
@@ -3036,6 +3098,7 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
                 amplitude: multi_ap_frame.amplitudes,
                 subcarrier_count: obs_count,
                 sync: None,  // multi-BSSID scan path — no mesh peer
+                link: None,
                 node_inference: None, // single aggregate frame; no per-node split
             }],
             features,
@@ -3199,6 +3262,7 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
             amplitude: vec![signal_pct],
             subcarrier_count: 1,
             sync: None,  // synthetic-RSSI fallback path — no mesh peer
+            link: None,
             node_inference: None, // synthetic fallback; no per-node inference
         }],
         features,
@@ -6413,6 +6477,7 @@ async fn udp_receiver_task(
                             sync: n.sync_snapshot(),
                             // ADR-297 — each node carries its own inference.
                             node_inference: Some(node_inference_for(n, now)),
+                            link: n.link_snapshot(now),
                         })
                         .collect();
 
@@ -6553,6 +6618,35 @@ async fn udp_receiver_task(
                             Err(e) => {
                                 debug!("Sync packet decode error from {src}: {e}");
                                 // Fall through — magic matched but decode failed; not a CSI frame.
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                // #1542 ask 1: Try link-status packet (magic 0xC511_A111).
+                // 32-byte datagram carrying the node's associated-AP identity
+                // (BSSID/channel/AP-RSSI/reassoc count). Stored per-node and
+                // surfaced through NodeInfo.link — the BSSID is the only
+                // observable that reveals a roam (RSSI provably isn't).
+                if len >= wifi_densepose_hardware::LINK_PACKET_SIZE {
+                    let magic = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+                    if magic == wifi_densepose_hardware::LINK_PACKET_MAGIC {
+                        match wifi_densepose_hardware::LinkStatusPacket::from_bytes(&buf[..len]) {
+                            Ok(link) => {
+                                debug!("ESP32 link-status from {src}: node={} bssid={} ch={} \
+                                        ap_rssi={} reassoc={} valid={}",
+                                       link.node_id, link.bssid_string(), link.channel,
+                                       link.ap_rssi_dbm, link.reassoc_count, link.ap_info_valid);
+                                let mut s = state.write().await;
+                                let node_id = link.node_id;
+                                let ns = s.node_states.entry(node_id)
+                                    .or_insert_with(NodeState::new);
+                                ns.apply_link_packet(link, std::time::Instant::now());
+                                continue;
+                            }
+                            Err(e) => {
+                                debug!("Link-status packet decode error from {src}: {e}");
                                 continue;
                             }
                         }
@@ -6903,6 +6997,7 @@ async fn udp_receiver_task(
                             sync: n.sync_snapshot(),
                             // ADR-297 — each node carries its own inference.
                             node_inference: Some(node_inference_for(n, now)),
+                            link: n.link_snapshot(now),
                         })
                         .collect();
 
@@ -7178,6 +7273,7 @@ async fn simulated_data_task(state: SharedState, tick_ms: u64) {
                 subcarrier_count: frame_n_sub as usize,
                 sync: None,  // simulated frame path — no mesh peer
                 node_inference: None, // simulated frame; source is synthetic
+                link: None,
             }],
             features: features.clone(),
             classification,
@@ -7358,13 +7454,20 @@ fn vitals_snapshots_from_sensing_json(
                     .unwrap_or(agg_presence);
                 let motion = motion_of(ninf["classification"].as_str(), agg_motion);
                 let conf = ninf["confidence"].as_f64().unwrap_or(agg_conf);
-                mk(
+                let mut vs = mk(
                     format!("{base_id}-node{n}"),
                     presence,
                     motion,
                     conf,
                     node["rssi_dbm"].as_f64(),
-                )
+                );
+                // #1542: ride the associated-AP identity on the per-node
+                // snapshot so the MQTT RSSI entity can surface it.
+                vs.link_bssid = node["link"]["bssid"].as_str().map(str::to_string);
+                vs.link_channel = node["link"]["channel"].as_u64().map(|c| c as u8);
+                vs.link_reassoc_count =
+                    node["link"]["reassoc_count"].as_u64().map(|c| c as u32);
+                vs
             })
             .collect(),
         _ => vec![mk(
@@ -9062,6 +9165,7 @@ mod node_sync_snapshot_serialization_tests {
             subcarrier_count: 0,
             sync,
             node_inference: None,
+            link: None,
         }
     }
 
@@ -9161,6 +9265,45 @@ mod sync_snapshot_helper_tests {
         assert_eq!(snap.sequence, 20);
         assert!((snap.csi_fps_ema - 10.5).abs() < 1e-9);
         assert_eq!(snap.csi_fps_samples, 42);
+    }
+
+    /// #1542: a link-status packet round-trips into NodeInfo.link via
+    /// NodeState, and an unassociated packet (ap_info_valid=false) projects
+    /// to None rather than an all-zero BSSID.
+    #[test]
+    fn apply_link_packet_projects_into_link_snapshot() {
+        use std::time::Duration;
+        let base = std::time::Instant::now();
+        let mut ns = NodeState::new();
+        assert!(ns.link_snapshot(base).is_none(), "no packet yet -> None");
+
+        let pkt = wifi_densepose_hardware::LinkStatusPacket {
+            node_id: 3,
+            proto_ver: 1,
+            ap_info_valid: true,
+            channel: 6,
+            bssid: [0x6c, 0xae, 0xf6, 0xb6, 0x52, 0xc7],
+            ap_rssi_dbm: -48,
+            reassoc_count: 2,
+        };
+        ns.apply_link_packet(pkt, base);
+        let snap = ns.link_snapshot(base + Duration::from_millis(1500)).unwrap();
+        assert_eq!(snap.bssid, "6c:ae:f6:b6:52:c7");
+        assert_eq!(snap.channel, 6);
+        assert_eq!(snap.ap_rssi_dbm, -48);
+        assert_eq!(snap.reassoc_count, 2);
+        assert_eq!(snap.age_ms, 1500);
+
+        // Node reports itself unassociated -> no link info surfaced.
+        let unassoc = wifi_densepose_hardware::LinkStatusPacket {
+            ap_info_valid: false,
+            bssid: [0; 6],
+            channel: 0,
+            ap_rssi_dbm: 0,
+            ..pkt
+        };
+        ns.apply_link_packet(unassoc, base);
+        assert!(ns.link_snapshot(base).is_none());
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-sensing-server/src/mqtt/state.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/mqtt/state.rs
@@ -164,6 +164,10 @@ pub struct VitalsSnapshot {
     pub n_persons: u32,
     pub rssi_dbm: Option<f64>,
     pub vital_confidence: f64,   // 0.0–1.0
+    /// #1542: associated-AP identity riding the RSSI entity's payload.
+    pub link_bssid: Option<String>,
+    pub link_channel: Option<u8>,
+    pub link_reassoc_count: Option<u32>,
 }
 
 #[derive(Serialize, Debug)]
@@ -201,6 +205,14 @@ struct PresenceScorePayload {
 struct RssiPayload {
     dbm: f64,
     ts: String,
+    /// #1542: associated-AP identity (lowercase colon-separated BSSID).
+    /// Optional so pre-link-firmware nodes keep the exact old payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bssid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    channel: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reassoc_count: Option<u32>,
 }
 
 #[derive(Serialize, Debug)]
@@ -278,7 +290,13 @@ impl<'a> StateEncoder<'a> {
             }).ok()?,
             EntityKind::Rssi => {
                 let dbm = snap.rssi_dbm?;
-                serde_json::to_value(RssiPayload { dbm, ts: ts.clone() }).ok()?
+                serde_json::to_value(RssiPayload {
+                    dbm,
+                    ts: ts.clone(),
+                    bssid: snap.link_bssid.clone(),
+                    channel: snap.link_channel,
+                    reassoc_count: snap.link_reassoc_count,
+                }).ok()?
             }
             _ => return None,
         };
@@ -363,7 +381,34 @@ mod tests {
             n_persons: 1,
             rssi_dbm: Some(-52.0),
             vital_confidence: 0.87,
+            link_bssid: None,
+            link_channel: None,
+            link_reassoc_count: None,
         }
+    }
+
+    /// #1542: with no link info the RSSI payload must be byte-identical to
+    /// the pre-link format (no new keys), and with link info present the
+    /// BSSID/channel/reassoc ride along.
+    #[test]
+    fn rssi_payload_link_fields_are_optional_and_additive() {
+        let b = builder();
+        let enc = StateEncoder { builder: &b };
+
+        let plain = enc.numeric(EntityKind::Rssi, &snap()).unwrap();
+        assert!(!plain.payload.contains("bssid"),
+                "pre-link nodes must keep the exact old payload");
+
+        let mut with_link = snap();
+        with_link.link_bssid = Some("6c:ae:f6:b6:52:c7".into());
+        with_link.link_channel = Some(6);
+        with_link.link_reassoc_count = Some(2);
+        let msg = enc.numeric(EntityKind::Rssi, &with_link).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&msg.payload).unwrap();
+        assert_eq!(v["bssid"], "6c:ae:f6:b6:52:c7");
+        assert_eq!(v["channel"], 6);
+        assert_eq!(v["reassoc_count"], 2);
+        assert_eq!(v["dbm"], -52.0);
     }
 
     // ─── Rate limiter ────────────────────────────────────────────────


### PR DESCRIPTION
## #1542 ask 1: surface the associated-AP BSSID as node telemetry

The associated AP **is** the sensing-link geometry: when a station roams, every
downstream consumer of that node's CSI is silently looking at a different
Fresnel volume. The field data on #1542 shows published RSSI cannot reveal the
change (−47.7 vs −48.2 dBm across two completely different link geometries), so
the BSSID itself is the only observable. This PR implements ask 1 exactly as
suggested there — the cheapest piece, with roam events and any future pinning
buildable downstream of it.

### What's in it

- **Firmware** (`esp32-csi-node`): a 32-byte link-status packet
  (magic `0xC511A111`, same auxiliary family as the ADR-110 sync packet)
  from `esp_wifi_sta_get_ap_info()`: BSSID, primary channel, AP RSSI, and a
  `WIFI_EVENT_STA_CONNECTED` counter. Cadence: every
  `CONFIG_LINK_STATUS_EVERY_N_FRAMES` CSI callbacks (default 600 ≈ 30 s at
  20 Hz) **plus** an immediate emission whenever the observed BSSID differs
  from the last reported one — a roam is visible within one callback, not one
  cadence period. Layout documented in the firmware README packet table.
- **`wifi-densepose-hardware`**: `LinkStatusPacket` decoder mirroring
  `SyncPacket` (typed errors, canonical wire-byte pin, magic-collision guard).
- **`wifi-densepose-sensing-server`**: dispatch on the new magic in the UDP
  receiver, per-node storage, `NodeInfo.link { bssid, channel, ap_rssi_dbm,
  reassoc_count, age_ms }` (skip-if-none), and the per-node MQTT RSSI entity's
  JSON payload gains optional `bssid` / `channel` / `reassoc_count`.
  **Nodes on pre-link firmware produce byte-identical payloads to today**
  (guarded by test).

Roam *events* derive downstream by comparing successive snapshots (the
layering suggested in the issue); `reassoc_count` additionally reveals
same-BSSID re-associations that a plain BSSID comparison would miss.

### Evidence

- Rust: MEASURED — `cargo test -p wifi-densepose-hardware -p
  wifi-densepose-sensing-server --no-default-features`: 0 failed
  (198 + 527 lib tests incl. 8 new).
- Firmware: MEASURED on real silicon — built for ESP32-S3 (Atom S3 Lite)
  and run on a live node in a 5-node CSI mesh (~40 pps, edge_tier=2):
  - Link-status packets decode correctly on the host; the reported BSSID
    matches the router's documented 2.4 GHz radio MAC exactly, with
    plausible channel/AP-RSSI and `reassoc_count = 1` per boot.
  - Cadence as designed: one immediate emission within seconds of boot
    (the on-change path — `s_link_ever_sent` starts false), then steady
    ~14 s intervals (600 CSI callbacks at the node's ~40 pps).
  - Verified across both a USB-flashed boot and an OTA-booted image
    (the OTA path needed its own fix — see the companion PR for the
    httpd stack overflow this validation uncovered).

Fixes the telemetry half of #1542; asks 2–3 intentionally not included per the
maintainer's suggested sequencing.
