### PR TITLE
fix(esp32): OTA upload always crashes at esp_ota_end — httpd stack overflow

### DIFF
--- a/firmware/esp32-csi-node/main/ota_update.c
+++ b/firmware/esp32-csi-node/main/ota_update.c
@@ -217,6 +217,14 @@ static esp_err_t ota_start_server(httpd_handle_t *out_handle)
     config.max_uri_handlers = 12;  /* Extra slots for WASM endpoints (ADR-040). */
     /* Increase receive timeout for large uploads. */
     config.recv_wait_timeout = 30;
+    /* The upload handler runs esp_ota_end() -> esp_image_verify() on THIS
+     * task's stack; with the httpd default (4 KB) that overflows
+     * deterministically at the end of every upload ("stack overflow in task
+     * httpd", panic in vApplicationStackOverflowHook with bootloader_mmap on
+     * the stack) — the transfer completes, validation crashes the node, and
+     * the A/B scheme boots the old image. 12 KB gives the image-verification
+     * path comfortable headroom. */
+    config.stack_size = 12288;
 
     httpd_handle_t server = NULL;
     esp_err_t err = httpd_start(&server, &config);


### PR DESCRIPTION
## OTA upload crashes at validation — httpd task stack too small

Found while hardware-validating #1593 (the #1542 BSSID telemetry PR): our
first real OTA upload to a field node kept failing as a connection reset,
on every attempt, on two different ESP32-S3 Atom S3 Lite nodes.

**Mechanism:** the `/ota` handler calls `esp_ota_end()` → `esp_image_verify()`
on the httpd task's stack, and `HTTPD_DEFAULT_CONFIG()` gives that task 4 KB.
The verification path overflows it deterministically at the end of every
upload. Serial capture:

```
***ERROR*** A stack overflow in task httpd has been detected.
Backtrace: ... vApplicationStackOverflowHook ... bootloader_mmap ...
```

**Failure signature (why it hides):** the transfer completes (911,648 bytes,
~73 s), the node panics during validation, reboots, and the A/B partition
scheme boots the old image — the client just sees `Recv failure: Connection
reset by peer`, indistinguishable from a network problem. The `/ota` auth
probes (403/400) all pass, so the endpoint looks healthy until someone
attempts a real upload. Reproduced 5× across the two nodes.

**Fix:** `config.stack_size = 12288` for the OTA httpd server.

**Validated on real silicon** (node streaming CSI at ~40 pps, edge_tier=2,
throughout): the same 911,648-byte upload now returns
`HTTP 200 {"status":"ok"}` in 12.8 s, the node reboots into `ota_1`, and the
OTA'd app runs normally (verified streaming + auxiliary packets after boot).
