### PR TITLE
chore: untrack harness session-scheduler lock file

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"905385c4-b13f-5091-96df-5752fb109cf5","pid":509,"procStart":"527","acquiredAt":1786922977672}

--- a/.gitignore
+++ b/.gitignore
@@ -311,3 +311,7 @@ v2/crates/wifi-densepose-sensing-server/data/
 # ADR-324: wasm-bindgen output for ruview-offaxis is generated locally
 # (see the crate README); never commit generated artifacts.
 v2/crates/ruview-offaxis/pkg/
+
+# Harness session-scheduler lock: per-session runtime state (session id + pid),
+# rewritten by every session; never useful in history.
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Follow-up cleanup after #1624 merged. `.claude/scheduled_tasks.lock` is per-session harness runtime state (session id + pid) that gets rewritten or deleted by every Claude session, dirtying the worktree after each run — it has already required two churn commits. This removes it from tracking and adds it to `.gitignore` so session state never lands in history again.

## Changes

- `git rm --cached .claude/scheduled_tasks.lock` (file stays local, just untracked)
- `.gitignore`: ignore `.claude/scheduled_tasks.lock`

## Validation

- Docs/ignore-only change; no code paths touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BU3NcEgTpAVvu5QGtw4czT)_