### PR TITLE
fix(homecore): enable standalone Arc serialization

### DIFF
--- a/.github/workflows/sensing-server-docker.yml
+++ b/.github/workflows/sensing-server-docker.yml
@@ -28,6 +28,7 @@ on:
       - 'v2/crates/wifi-densepose-wifiscan/**'
       - 'v2/crates/wifi-densepose-bfld/**'
       - 'v2/crates/cog-ha-matter/**'
+      - 'v2/crates/homecore*/**'
       - 'v2/Cargo.toml'
       - 'v2/Cargo.lock'
       - 'ui/**'

--- a/v2/crates/homecore-server/Cargo.toml
+++ b/v2/crates/homecore-server/Cargo.toml
@@ -50,7 +50,7 @@ tower-http = { version = "0.6", features = ["fs", "trace", "cors"] }
 # requires every crate that pulls reqwest to align on rustls-only (tracked in
 # CHANGELOG / ADR-131 security note).
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_yaml = "0.9"
 # Concurrent fan-out of per-bank RoomState fetches in the gateway (§11 perf).
 futures = "0.3"


### PR DESCRIPTION
## Summary
- enable Serde `rc` support in `homecore-server` so its direct `Arc<State>` serialization compiles in a standalone Docker build
- make the sensing-server image workflow watch Homecore source changes, since the Dockerfile compiles and ships `homecore-server`

## Failure fixed
The post-merge image publication failed while compiling `homecore-server` in [workflow run 32592370048](https://github.com/ruvnet/RuView/actions/runs/32592370048). Workspace-wide builds masked the missing direct feature through Cargo feature unification.

## Verification
- `cargo build --release -p homecore-server` — PASS
- `cargo test -p homecore-server` — PASS (22 tests)
- `cargo tree -p homecore-server -e features -i serde` — confirms `serde/rc`
- `git diff --check` — PASS
- `cargo audit --file v2/Cargo.lock --json` — 0 vulnerabilities; 30 pre-existing warnings