### PR TITLE
fix(security): close remaining sensing and firmware boundaries

### DIFF
--- a/archive/v1/src/api/dependencies.py
+++ b/archive/v1/src/api/dependencies.py
@@ -172,7 +172,7 @@ def require_permission(permission: str):
 # Zone access dependencies
 async def validate_zone_access(
     zone_id: str,
-    current_user: Optional[Dict[str, Any]] = Depends(get_current_user)
+    current_user: Dict[str, Any] = Depends(get_current_active_user)
 ) -> str:
     """Validate user access to a specific zone."""
     domain_config = get_domain_config()
@@ -193,18 +193,17 @@ async def validate_zone_access(
         )
     
     # If authentication is enabled, check user access
-    if current_user:
-        # Admin users have access to all zones
-        if current_user.get("is_admin", False):
-            return zone_id
-        
-        # Check user's zone permissions
-        user_zones = current_user.get("zones", [])
-        if user_zones and zone_id not in user_zones:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Access denied to zone '{zone_id}'"
-            )
+    # Admin users have access to all zones
+    if current_user.get("is_admin", False):
+        return zone_id
+
+    # Check user's zone permissions
+    user_zones = current_user.get("zones", [])
+    if user_zones and zone_id not in user_zones:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Access denied to zone '{zone_id}'"
+        )
     
     return zone_id
 

--- a/archive/v1/src/api/middleware/auth.py
+++ b/archive/v1/src/api/middleware/auth.py
@@ -125,10 +125,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
         public_patterns = [
             "/health",
             "/metrics",
-            "/api/v1/pose/current",  # Allow anonymous access to current pose data
-            "/api/v1/pose/zones/",   # Allow anonymous access to zone data
-            "/api/v1/pose/activities",  # Allow anonymous access to activities
-            "/api/v1/pose/stats",    # Allow anonymous access to stats
             "/api/v1/stream/status"  # Allow anonymous access to stream status
         ]
         
@@ -140,6 +136,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
     
     def _is_protected_path(self, path: str) -> bool:
         """Check if path requires authentication."""
+        if path.startswith("/api/") and not self._is_public_path(path):
+            return True
         # Exact match
         if path in self.protected_paths:
             return True

--- a/archive/v1/src/api/routers/pose.py
+++ b/archive/v1/src/api/routers/pose.py
@@ -14,6 +14,8 @@ from src.api.dependencies import (
     get_pose_service,
     get_hardware_service,
     get_current_user,
+    get_current_active_user,
+    validate_zone_access,
     require_auth
 )
 from src.services.pose_service import PoseService
@@ -116,7 +118,7 @@ class HistoricalDataRequest(BaseModel):
 async def get_current_pose_estimation(
     request: PoseEstimationRequest = Depends(),
     pose_service: PoseService = Depends(get_pose_service),
-    current_user: Optional[Dict] = Depends(get_current_user)
+    current_user: Dict = Depends(get_current_active_user)
 ):
     """Get current pose estimation from WiFi signals."""
     try:
@@ -180,9 +182,8 @@ async def analyze_pose_data(
 
 @router.get("/zones/{zone_id}/occupancy")
 async def get_zone_occupancy(
-    zone_id: str,
+    zone_id: str = Depends(validate_zone_access),
     pose_service: PoseService = Depends(get_pose_service),
-    current_user: Optional[Dict] = Depends(get_current_user)
 ):
     """Get current occupancy for a specific zone."""
     try:
@@ -215,7 +216,7 @@ async def get_zone_occupancy(
 @router.get("/zones/summary")
 async def get_zones_summary(
     pose_service: PoseService = Depends(get_pose_service),
-    current_user: Optional[Dict] = Depends(get_current_user)
+    current_user: Dict = Depends(get_current_active_user)
 ):
     """Get occupancy summary for all zones."""
     try:
@@ -294,7 +295,7 @@ async def get_detected_activities(
     zone_id: Optional[str] = Query(None, description="Filter by zone ID"),
     limit: int = Query(10, ge=1, le=100, description="Maximum number of activities"),
     pose_service: PoseService = Depends(get_pose_service),
-    current_user: Optional[Dict] = Depends(get_current_user)
+    current_user: Dict = Depends(get_current_active_user)
 ):
     """Get recently detected activities."""
     try:
@@ -391,7 +392,7 @@ async def get_calibration_status(
 async def get_pose_statistics(
     hours: int = Query(24, ge=1, le=168, description="Hours of data to analyze"),
     pose_service: PoseService = Depends(get_pose_service),
-    current_user: Optional[Dict] = Depends(get_current_user)
+    current_user: Dict = Depends(get_current_active_user)
 ):
     """Get pose estimation statistics."""
     try:

--- a/firmware/esp32-csi-node/main/ota_update.c
+++ b/firmware/esp32-csi-node/main/ota_update.c
@@ -45,7 +45,7 @@ static char s_ota_psk[OTA_PSK_MAX_LEN] = {0};
  * a reflash, but the upload endpoint will reject every request until
  * the PSK is set.
  */
-static bool ota_check_auth(httpd_req_t *req)
+bool ota_check_auth(httpd_req_t *req)
 {
     if (s_ota_psk[0] == '\0') {
         /* No PSK provisioned — fail closed. Previously this returned

--- a/firmware/esp32-csi-node/main/ota_update.h
+++ b/firmware/esp32-csi-node/main/ota_update.h
@@ -10,6 +10,7 @@
 #define OTA_UPDATE_H
 
 #include "esp_err.h"
+#include "esp_http_server.h"
 
 /**
  * Initialize the OTA update HTTP server.
@@ -29,5 +30,8 @@ esp_err_t ota_update_init(void);
  * @return ESP_OK on success.
  */
 esp_err_t ota_update_init_ex(void **out_server);
+
+/** Return true only when the request carries the provisioned OTA PSK. */
+bool ota_check_auth(httpd_req_t *req);
 
 #endif /* OTA_UPDATE_H */

--- a/firmware/esp32-csi-node/main/wasm_upload.c
+++ b/firmware/esp32-csi-node/main/wasm_upload.c
@@ -18,6 +18,7 @@
 
 #include "sdkconfig.h"
 #include "wasm_upload.h"
+#include "ota_update.h"
 
 #if defined(CONFIG_WASM_ENABLE)
 
@@ -31,6 +32,13 @@
 #include "esp_heap_caps.h"
 
 static const char *TAG = "wasm_upload";
+
+static bool wasm_require_ota_auth(httpd_req_t *req)
+{
+    if (ota_check_auth(req)) return true;
+    httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Authentication required");
+    return false;
+}
 
 /* Max upload size: RVF overhead + max WASM binary. */
 #define MAX_UPLOAD_SIZE (RVF_HEADER_SIZE + RVF_MANIFEST_SIZE + \
@@ -84,6 +92,7 @@ static uint8_t *receive_body(httpd_req_t *req, int *out_len)
 
 static esp_err_t wasm_upload_handler(httpd_req_t *req)
 {
+    if (!wasm_require_ota_auth(req)) return ESP_FAIL;
     int total = 0;
     uint8_t *buf = receive_body(req, &total);
     if (buf == NULL) return ESP_FAIL;
@@ -233,6 +242,7 @@ static const char *state_name(wasm_module_state_t state)
 
 static esp_err_t wasm_list_handler(httpd_req_t *req)
 {
+    if (!wasm_require_ota_auth(req)) return ESP_FAIL;
     wasm_module_info_t info[WASM_MAX_MODULES];
     uint8_t count = 0;
     wasm_runtime_get_info(info, &count);
@@ -289,6 +299,7 @@ static int parse_module_id_from_uri(const char *uri, const char *prefix)
 
 static esp_err_t wasm_start_handler(httpd_req_t *req)
 {
+    if (!wasm_require_ota_auth(req)) return ESP_FAIL;
     int id = parse_module_id_from_uri(req->uri, "/wasm/start/");
     if (id < 0) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid module ID");
@@ -315,6 +326,7 @@ static esp_err_t wasm_start_handler(httpd_req_t *req)
 
 static esp_err_t wasm_stop_handler(httpd_req_t *req)
 {
+    if (!wasm_require_ota_auth(req)) return ESP_FAIL;
     int id = parse_module_id_from_uri(req->uri, "/wasm/stop/");
     if (id < 0) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid module ID");
@@ -341,6 +353,7 @@ static esp_err_t wasm_stop_handler(httpd_req_t *req)
 
 static esp_err_t wasm_delete_handler(httpd_req_t *req)
 {
+    if (!wasm_require_ota_auth(req)) return ESP_FAIL;
     int id = parse_module_id_from_uri(req->uri, "/wasm/");
     if (id < 0) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid module ID");

--- a/firmware/esp32-csi-node/provision.py
+++ b/firmware/esp32-csi-node/provision.py
@@ -6,9 +6,9 @@ Writes WiFi credentials and aggregator target to the ESP32's NVS partition
 so users can configure a pre-built firmware binary without recompiling.
 
 Usage:
-    python provision.py --port COM7 --ssid "MyWiFi" --password "secret" --target-ip 192.168.1.20
+    python provision.py --port COM7 --ssid "MyWiFi" --target-ip 192.168.1.20
     python provision.py --port /dev/ttyUSB0 --chip esp32c6 --ssid "..." \\
-        --password "..." --target-ip 192.168.1.20
+        --target-ip 192.168.1.20  # password is read securely from the prompt
 
 Requirements:
     pip install 'esptool>=5.0' nvs-partition-gen
@@ -41,6 +41,7 @@ ADDITIVE-BY-DEFAULT (issue #391, #574 phase 1):
 
 import argparse
 import csv
+import getpass
 import io
 import json
 import os
@@ -88,6 +89,13 @@ def has_config_value(args):
         check(getattr(args, name, None))
         for name, check in CONFIG_VALUE_CHECKS
     )
+
+
+def read_wifi_password(current):
+    """Return an existing password or read it without exposing it in argv."""
+    if current is not None:
+        return current
+    return getpass.getpass("WiFi password: ")
 
 
 # ---------------------------------------------------------------------------
@@ -138,6 +146,8 @@ def load_state(port: str, state_dir: str) -> dict:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         if isinstance(data, dict):
+            # Passwords are never reused from or written to local state files.
+            data.pop("password", None)
             return data
     except (OSError, json.JSONDecodeError) as exc:
         print(f"WARNING: could not read state file {path}: {exc}", file=sys.stderr)
@@ -150,8 +160,9 @@ def save_state(port: str, state_dir: str, state: dict) -> str:
     path = _state_path_for(port, state_dir)
     # Sort keys for deterministic on-disk content (easier to diff).
     tmp = path + ".tmp"
+    safe_state = {key: value for key, value in state.items() if key != "password"}
     with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(state, f, indent=2, sort_keys=True)
+        json.dump(safe_state, f, indent=2, sort_keys=True)
         f.write("\n")
     os.replace(tmp, path)
     return path
@@ -310,7 +321,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Provision CSI node NVS (WiFi + aggregator); works on S3, C6, etc.",
         epilog=(
-            "Example: python provision.py --port COM7 --ssid MyWiFi --password secret "
+            "Example: python provision.py --port COM7 --ssid MyWiFi "
             "--target-ip 192.168.1.20\n"
             "ESP32-C6: same, or pass --chip esp32c6 if auto-detect fails "
             "(default chip is auto for esptool v5+)."
@@ -324,7 +335,6 @@ def main():
     )
     parser.add_argument("--baud", type=int, default=460800, help="Flash baud rate (default: 460800)")
     parser.add_argument("--ssid", help="WiFi SSID")
-    parser.add_argument("--password", help="WiFi password")
     parser.add_argument("--target-ip", help="Aggregator host IP (e.g. 192.168.1.20)")
     parser.add_argument("--target-port", type=int, help="Aggregator UDP port (default: 5005)")
     parser.add_argument("--node-id", type=int, help="Node ID 0-255 (default: 1)")
@@ -370,6 +380,7 @@ def main():
                         "Useful for debugging which keys are about to land on the device.")
 
     args = parser.parse_args()
+    args.password = None
 
     # --- Per-port state load + merge (additive-by-default, #391 / #574) ---
     if args.reset:
@@ -382,8 +393,12 @@ def main():
         prior = load_state(args.port, args.state_dir)
     merged = merge_state_into_args(args, prior)
 
+    if args.password is None and not args.force_partial and has_config_value(args) and not args.state:
+        args.password = read_wifi_password(None)
+
     if args.state:
-        print(json.dumps(merged, indent=2, sort_keys=True))
+        visible_state = {key: value for key, value in merged.items() if key != "password"}
+        print(json.dumps(visible_state, indent=2, sort_keys=True))
         return
 
     if not has_config_value(args):
@@ -398,7 +413,7 @@ def main():
     wifi_trio_missing = [
         name for name, val in [
             ("--ssid", args.ssid),
-            ("--password", args.password),
+            ("WiFi password prompt", args.password),
             ("--target-ip", args.target_ip),
         ] if val is None or val == ""
     ]
@@ -408,7 +423,7 @@ def main():
             f"{', '.join(wifi_trio_missing)}.\n"
             f"\n"
             f"  No per-port state file at {_state_path_for(args.port, args.state_dir)}\n"
-            f"  and the CLI didn't include them. Either pass --ssid + --password + --target-ip\n"
+            f"  and the CLI didn't include them. Provide --ssid + --target-ip and answer the password prompt,\n"
             f"  on this run, or add --force-partial to flash without WiFi.\n"
         )
     if args.force_partial and wifi_trio_missing:
@@ -485,14 +500,7 @@ def main():
         nvs_bin = generate_nvs_binary(csv_content, NVS_PARTITION_SIZE)
     except Exception as e:
         print(f"\nError generating NVS binary: {e}", file=sys.stderr)
-        print("\nFallback: save CSV and flash manually with ESP-IDF tools.", file=sys.stderr)
-        fallback_path = "nvs_config.csv"
-        with open(fallback_path, "w") as f:
-            f.write(csv_content)
-        print(f"Saved NVS CSV to {fallback_path}", file=sys.stderr)
-        print(f"Flash with: python $IDF_PATH/components/nvs_flash/"
-              f"nvs_partition_generator/nvs_partition_gen.py generate "
-              f"{fallback_path} nvs.bin 0x6000", file=sys.stderr)
+        print("No plaintext CSV fallback was written because it contains credentials.", file=sys.stderr)
         sys.exit(1)
 
     if args.dry_run:

--- a/firmware/esp32-csi-node/tests/test_provision.py
+++ b/firmware/esp32-csi-node/tests/test_provision.py
@@ -1,9 +1,12 @@
 import csv
 import importlib.util
 import io
+import json
 import types
+import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 PROVISION_PATH = Path(__file__).resolve().parents[1] / "provision.py"
@@ -24,6 +27,29 @@ def csv_rows(content):
 
 
 class ProvisionConfigValueTests(unittest.TestCase):
+    @patch("provision.getpass.getpass", return_value="prompted-secret")
+    def test_missing_password_uses_secure_prompt(self, getpass):
+        self.assertEqual(provision.read_wifi_password(None), "prompted-secret")
+        getpass.assert_called_once()
+
+    def test_provisioning_source_has_no_plaintext_fallback_file(self):
+        source = PROVISION_PATH.read_text(encoding="utf-8")
+        self.assertNotIn('fallback_path = "nvs_config.csv"', source)
+
+    def test_state_files_never_persist_or_reuse_passwords(self):
+        with tempfile.TemporaryDirectory() as state_dir:
+            path = provision.save_state(
+                "COM7", state_dir, {"password": "secret", "ssid": "wifi"}
+            )
+            saved = json.loads(Path(path).read_text(encoding="utf-8"))
+            self.assertNotIn("password", saved)
+
+            Path(path).write_text(
+                json.dumps({"password": "legacy-secret", "node_id": 2}),
+                encoding="utf-8",
+            )
+            self.assertNotIn("password", provision.load_state("COM7", state_dir))
+
     def test_swarm_and_hopping_flags_count_as_config_values(self):
         cases = [
             {"hop_channels": "1,6,11"},

--- a/firmware/esp32-csi-node/tests/test_provision_state.py
+++ b/firmware/esp32-csi-node/tests/test_provision_state.py
@@ -38,7 +38,7 @@ class TestStateFile(unittest.TestCase):
         provision.save_state("COM7", self.dir, {"ssid": "x", "password": "y"})
         self.assertEqual(
             provision.load_state("COM7", self.dir),
-            {"ssid": "x", "password": "y"},
+            {"ssid": "x"},
         )
 
     def test_save_creates_per_port_files(self):

--- a/firmware/esp32-csi-node/tests/test_wasm_auth_contract.py
+++ b/firmware/esp32-csi-node/tests/test_wasm_auth_contract.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "main" / "wasm_upload.c"
+
+
+class WasmAuthContractTests(unittest.TestCase):
+    def test_every_wasm_handler_checks_ota_auth_before_work(self):
+        source = SOURCE.read_text(encoding="utf-8")
+        self.assertIn("ota_check_auth(req)", source[source.index("wasm_require_ota_auth"):])
+        for handler in (
+            "wasm_upload_handler",
+            "wasm_list_handler",
+            "wasm_start_handler",
+            "wasm_stop_handler",
+            "wasm_delete_handler",
+        ):
+            start = source.index(handler)
+            body = source[start:source.find("\n}", start) + 2]
+            self.assertIn("wasm_require_ota_auth(req)", body, handler)

--- a/scripts/ruview-sensing-server.py
+++ b/scripts/ruview-sensing-server.py
@@ -26,9 +26,8 @@ by the watcher on every BFLD-gated feature_state packet. If absent
 or stale (> STALENESS_S seconds old), endpoints return 503 with a
 hint so the rvagent tool emits a graceful warn shape.
 
-Bearer-token auth is intentionally OFF in this dev surface — the
-Rust sensing-server adds it via the #443 middleware; that path is
-out of scope for the demo bridge.
+This development bridge binds to loopback only. Use the authenticated Rust
+sensing-server for network-accessible deployments.
 """
 from __future__ import annotations
 import json
@@ -265,8 +264,8 @@ class Handler(BaseHTTPRequestHandler):
 
 def main() -> int:
     port = DEFAULT_PORT
-    server = HTTPServer(("0.0.0.0", port), Handler)
-    print(f"[sensing-server] listening on 0.0.0.0:{port}", flush=True)
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    print(f"[sensing-server] listening on 127.0.0.1:{port}", flush=True)
     print(f"[sensing-server] feature source: {FEATURE_FILE}", flush=True)
     print(f"[sensing-server] staleness limit: {STALENESS_S} s", flush=True)
     try:

--- a/tools/ruview-mcp/src/http-transport.ts
+++ b/tools/ruview-mcp/src/http-transport.ts
@@ -88,6 +88,11 @@ const DEFAULT_PORT = 3001;
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
 const DEFAULT_MAX_SESSIONS = 64;
 const DEFAULT_SESSION_IDLE_MS = 5 * 60 * 1000;
+
+export function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  return normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/.test(normalized);
+}
 const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000;
 const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
@@ -336,8 +341,15 @@ export async function createHttpTransport(
 ): Promise<HttpTransportResult> {
   const host = opts.host ?? process.env["RVAGENT_HTTP_HOST"] ?? DEFAULT_HOST;
   const port = opts.port ?? Number(process.env["RVAGENT_HTTP_PORT"] ?? DEFAULT_PORT);
+  const bearerToken = opts.bearerToken ?? process.env["RVAGENT_HTTP_TOKEN"];
+  if (!isLoopbackHost(host) && !bearerToken) {
+    throw new Error("RVAGENT_HTTP_TOKEN is required when binding MCP HTTP to a non-loopback host");
+  }
 
-  const { httpServer, sessions } = buildHttpApp(serverFactory, opts);
+  const appOpts: HttpTransportOptions = bearerToken
+    ? { ...opts, bearerToken }
+    : opts;
+  const { httpServer, sessions } = buildHttpApp(serverFactory, appOpts);
 
   await new Promise<void>((resolve, reject) => {
     httpServer.once("error", reject);

--- a/tools/ruview-mcp/src/http.ts
+++ b/tools/ruview-mcp/src/http.ts
@@ -9,6 +9,7 @@
  */
 
 const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
 
 export type Ok<T> = { ok: true; data: T };
 export type Err = { ok: false; error: string };
@@ -20,6 +21,31 @@ export function ok<T>(data: T): Ok<T> {
 
 export function err(error: string): Err {
   return { ok: false, error };
+}
+
+async function readResponseBody(res: Response, url: string): Promise<Result<string>> {
+  const declared = Number(res.headers.get("content-length") ?? "0");
+  if (Number.isFinite(declared) && declared > MAX_RESPONSE_BYTES) {
+    await res.body?.cancel();
+    return err(`Response from ${url} exceeds ${MAX_RESPONSE_BYTES} bytes`);
+  }
+  if (!res.body) return ok("");
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let body = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      return err(`Response from ${url} exceeds ${MAX_RESPONSE_BYTES} bytes`);
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+  body += decoder.decode();
+  return ok(body);
 }
 
 /**
@@ -46,25 +72,24 @@ export async function sensingGet<T>(
       headers,
       signal: controller.signal,
     });
-    clearTimeout(timer);
-
-    if (!res.ok) {
-      return err(`HTTP ${res.status} from ${url}: ${await res.text().catch(() => "(no body)")}`);
-    }
+    const responseBody = await readResponseBody(res, url);
+    if (!responseBody.ok) return responseBody;
+    if (!res.ok) return err(`HTTP ${res.status} from ${url}: ${responseBody.data}`);
 
     let body: unknown;
     try {
-      body = await res.json();
+      body = JSON.parse(responseBody.data);
     } catch {
       return err(`Non-JSON response from ${url}`);
     }
 
     return ok(body as T);
   } catch (e: unknown) {
-    clearTimeout(timer);
     if (e instanceof Error && e.name === "AbortError") {
       return err(`Request to ${url} timed out after ${REQUEST_TIMEOUT_MS} ms`);
     }
     return err(`Network error fetching ${url}: ${String(e)}`);
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/tools/ruview-mcp/src/tools/bfld-last-scan.ts
+++ b/tools/ruview-mcp/src/tools/bfld-last-scan.ts
@@ -29,11 +29,6 @@ export const bfldLastScanSchema = z.object({
     .min(1)
     .optional()
     .describe("Target node id. Omit to use the single active node."),
-  sensing_server_url: z
-    .string()
-    .url()
-    .optional()
-    .describe("Override sensing-server URL for this call only."),
 });
 
 export type BfldLastScanInput = z.infer<typeof bfldLastScanSchema>;
@@ -65,7 +60,7 @@ export async function bfldLastScan(
   input: BfldLastScanInput,
   config: RuviewConfig
 ): Promise<object> {
-  const baseUrl = input.sensing_server_url ?? config.sensingServerUrl;
+  const baseUrl = config.sensingServerUrl;
   const nodeId = input.node_id ?? "default";
 
   const result = await sensingGet<BfldScanResponse>(

--- a/tools/ruview-mcp/src/tools/bfld-subscribe.ts
+++ b/tools/ruview-mcp/src/tools/bfld-subscribe.ts
@@ -36,11 +36,6 @@ export const bfldSubscribeSchema = z.object({
     .positive()
     .max(3600)
     .describe("Subscription duration in seconds (max 3600)."),
-  sensing_server_url: z
-    .string()
-    .url()
-    .optional()
-    .describe("Override sensing-server URL for this call only."),
 });
 
 export type BfldSubscribeInput = z.infer<typeof bfldSubscribeSchema>;
@@ -65,7 +60,7 @@ export async function bfldSubscribe(
   input: BfldSubscribeInput,
   config: RuviewConfig
 ): Promise<object> {
-  const baseUrl = input.sensing_server_url ?? config.sensingServerUrl;
+  const baseUrl = config.sensingServerUrl;
   const nodeId = input.node_id ?? "default";
   const topic = `ruview/${nodeId}/bfld/*`;
 

--- a/tools/ruview-mcp/src/tools/count-infer.ts
+++ b/tools/ruview-mcp/src/tools/count-infer.ts
@@ -24,11 +24,6 @@ export const countInferSchema = z.object({
     .string()
     .optional()
     .describe("Path to a CSI window JSON file. Omit to use the live sensing-server."),
-  /** Override the cog binary path for this call. */
-  cog_binary: z
-    .string()
-    .optional()
-    .describe("Path to cog-person-count binary. Default: RUVIEW_COUNT_COG_BINARY env var."),
   /**
    * Maximum number of persons to consider in the output distribution.
    * Capped at 7 per the count head's softmax over {0..7}.
@@ -84,7 +79,7 @@ export async function countInfer(
   input: CountInferInput,
   config: RuviewConfig
 ): Promise<object> {
-  const binary = input.cog_binary ?? config.countCogBinary;
+  const binary = config.countCogBinary;
   const t0 = Date.now();
 
   // M2: run `cog-person-count health` which does real inference on a synthetic

--- a/tools/ruview-mcp/src/tools/csi-latest.ts
+++ b/tools/ruview-mcp/src/tools/csi-latest.ts
@@ -13,16 +13,7 @@ import type { RuviewConfig, SensingLatestResponse } from "../types.js";
 import { sensingGet } from "../http.js";
 import { validateSensingLatestResponse } from "../validate.js";
 
-export const csiLatestSchema = z.object({
-  /** Override the sensing-server URL for this call only. */
-  sensing_server_url: z
-    .string()
-    .url()
-    .optional()
-    .describe(
-      "Base URL of the sensing-server (default: RUVIEW_SENSING_SERVER_URL or http://localhost:3000)"
-    ),
-});
+export const csiLatestSchema = z.object({});
 
 export type CsiLatestInput = z.infer<typeof csiLatestSchema>;
 
@@ -30,7 +21,7 @@ export async function csiLatest(
   input: CsiLatestInput,
   config: RuviewConfig
 ): Promise<object> {
-  const baseUrl = input.sensing_server_url ?? config.sensingServerUrl;
+  const baseUrl = config.sensingServerUrl;
 
   const result = await sensingGet<SensingLatestResponse>(
     baseUrl,

--- a/tools/ruview-mcp/src/tools/pose-infer.ts
+++ b/tools/ruview-mcp/src/tools/pose-infer.ts
@@ -27,11 +27,6 @@ export const poseInferSchema = z.object({
     .string()
     .optional()
     .describe("Path to a CSI window JSON file. Omit to use the live sensing-server."),
-  /** Override the cog binary path for this call. */
-  cog_binary: z
-    .string()
-    .optional()
-    .describe("Path to cog-pose-estimation binary. Default: RUVIEW_POSE_COG_BINARY env var."),
 });
 
 export type PoseInferInput = z.infer<typeof poseInferSchema>;
@@ -81,7 +76,7 @@ export async function poseInfer(
   input: PoseInferInput,
   config: RuviewConfig
 ): Promise<object> {
-  const binary = input.cog_binary ?? config.poseCogBinary;
+  const binary = config.poseCogBinary;
   const t0 = Date.now();
 
   // M2: run `cog-pose-estimation health` which does real inference on a synthetic

--- a/tools/ruview-mcp/src/tools/presence-now.ts
+++ b/tools/ruview-mcp/src/tools/presence-now.ts
@@ -8,13 +8,12 @@ import { fetchVitals, resolveNodeId } from "./vitals-fetch.js";
 
 export const presenceNowSchema = z.object({
   node_id: z.string().min(1).optional().describe("Target node id."),
-  sensing_server_url: z.string().url().optional(),
 });
 export type PresenceNowInput = z.infer<typeof presenceNowSchema>;
 
 export async function presenceNow(input: PresenceNowInput, config: RuviewConfig): Promise<object> {
   const nodeId = resolveNodeId(input.node_id);
-  const baseUrl = input.sensing_server_url ?? config.sensingServerUrl;
+  const baseUrl = config.sensingServerUrl;
   const r = await fetchVitals(nodeId, baseUrl, config.apiToken);
   if (!r.ok) return r;
   return {

--- a/tools/ruview-mcp/src/tools/registry-list.ts
+++ b/tools/ruview-mcp/src/tools/registry-list.ts
@@ -36,12 +36,6 @@ export const registryListSchema = z.object({
     .optional()
     .default(false)
     .describe("Bypass the 1-hour registry cache. Use sparingly."),
-  /** Override the sensing-server URL for this call only. */
-  sensing_server_url: z
-    .string()
-    .url()
-    .optional()
-    .describe("Override the sensing-server URL."),
 });
 
 export type RegistryListInput = z.infer<typeof registryListSchema>;
@@ -64,7 +58,7 @@ export async function registryList(
   input: RegistryListInput,
   config: RuviewConfig
 ): Promise<object> {
-  const baseUrl = input.sensing_server_url ?? config.sensingServerUrl;
+  const baseUrl = config.sensingServerUrl;
   const qs = input.refresh ? "?refresh=1" : "";
 
   const result = await sensingGet<UpstreamRegistryPayload>(

--- a/tools/ruview-mcp/src/tools/vitals-get-all.ts
+++ b/tools/ruview-mcp/src/tools/vitals-get-all.ts
@@ -8,7 +8,6 @@ import { fetchVitals, resolveNodeId } from "./vitals-fetch.js";
 
 export const vitalsGetAllSchema = z.object({
   node_id: z.string().min(1).optional().describe("Target node id."),
-  sensing_server_url: z.string().url().optional(),
 });
 export type VitalsGetAllInput = z.infer<typeof vitalsGetAllSchema>;
 
@@ -17,7 +16,7 @@ export async function vitalsGetAll(
   config: RuviewConfig
 ): Promise<object> {
   const nodeId = resolveNodeId(input.node_id);
-  const baseUrl = input.sensing_server_url ?? config.sensingServerUrl;
+  const baseUrl = config.sensingServerUrl;
   const r = await fetchVitals(nodeId, baseUrl, config.apiToken);
   if (!r.ok) return r;
   // Return the full EdgeVitalsMessage; `raw` field is never present in the

--- a/tools/ruview-mcp/src/tools/vitals-get-breathing.ts
+++ b/tools/ruview-mcp/src/tools/vitals-get-breathing.ts
@@ -9,7 +9,6 @@ import { fetchVitals, resolveNodeId } from "./vitals-fetch.js";
 export const vitalsGetBreathingSchema = z.object({
   node_id: z.string().min(1).optional().describe("Target node id."),
   window_s: z.number().positive().max(300).optional().describe("Averaging window (s, max 300)."),
-  sensing_server_url: z.string().url().optional(),
 });
 export type VitalsGetBreathingInput = z.infer<typeof vitalsGetBreathingSchema>;
 
@@ -18,7 +17,7 @@ export async function vitalsGetBreathing(
   config: RuviewConfig
 ): Promise<object> {
   const nodeId = resolveNodeId(input.node_id);
-  const baseUrl = input.sensing_server_url ?? config.sensingServerUrl;
+  const baseUrl = config.sensingServerUrl;
   const r = await fetchVitals(nodeId, baseUrl, config.apiToken);
   if (!r.ok) return r;
   return {

--- a/tools/ruview-mcp/src/tools/vitals-get-heart-rate.ts
+++ b/tools/ruview-mcp/src/tools/vitals-get-heart-rate.ts
@@ -9,7 +9,6 @@ import { fetchVitals, resolveNodeId } from "./vitals-fetch.js";
 export const vitalsGetHeartRateSchema = z.object({
   node_id: z.string().min(1).optional().describe("Target node id."),
   window_s: z.number().positive().max(300).optional().describe("Averaging window (s, max 300)."),
-  sensing_server_url: z.string().url().optional(),
 });
 export type VitalsGetHeartRateInput = z.infer<typeof vitalsGetHeartRateSchema>;
 
@@ -18,7 +17,7 @@ export async function vitalsGetHeartRate(
   config: RuviewConfig
 ): Promise<object> {
   const nodeId = resolveNodeId(input.node_id);
-  const baseUrl = input.sensing_server_url ?? config.sensingServerUrl;
+  const baseUrl = config.sensingServerUrl;
   const r = await fetchVitals(nodeId, baseUrl, config.apiToken);
   if (!r.ok) return r;
   return {

--- a/tools/ruview-mcp/tests/bfld-tools.test.ts
+++ b/tools/ruview-mcp/tests/bfld-tools.test.ts
@@ -80,12 +80,13 @@ describe("ruview.bfld.last_scan schema (BfldLastScanInputSchema)", () => {
     expect(() => BfldLastScanInputSchema.parse({ node_id: "" })).toThrow();
   });
 
-  it("accepts node_id + sensing_server_url", () => {
+  it("does not expose a per-call sensing-server override", () => {
     const r = BfldLastScanInputSchema.parse({
       node_id: "cognitum-seed-1",
       sensing_server_url: "http://localhost:3000",
     });
     expect(r.node_id).toBe("cognitum-seed-1");
+    expect(r).not.toHaveProperty("sensing_server_url");
   });
 });
 

--- a/tools/ruview-mcp/tests/http-client.test.ts
+++ b/tools/ruview-mcp/tests/http-client.test.ts
@@ -1,0 +1,41 @@
+import { createServer, type RequestListener } from "node:http";
+import { sensingGet } from "../src/http.js";
+
+async function withServer(
+  handler: RequestListener,
+  test: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  try {
+    await test(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+describe("sensingGet response bounds", () => {
+  it("accepts a small JSON response", async () => {
+    await withServer((_req, res) => {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: true }));
+    }, async (baseUrl) => {
+      const result = await sensingGet<{ ok: boolean }>(baseUrl, "/health", undefined);
+      expect(result).toEqual({ ok: true, data: { ok: true } });
+    });
+  });
+
+  it("rejects a chunked response larger than one MiB", async () => {
+    await withServer((_req, res) => {
+      res.setHeader("Content-Type", "application/json");
+      res.write(`{"data":"${"x".repeat(700_000)}`);
+      res.end(`${"x".repeat(700_000)}"}`);
+    }, async (baseUrl) => {
+      const result = await sensingGet(baseUrl, "/large", undefined);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("exceeds 1048576 bytes");
+    });
+  });
+});

--- a/tools/ruview-mcp/tests/http-transport.test.ts
+++ b/tools/ruview-mcp/tests/http-transport.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as http from "node:http";
-import { isOriginAllowed, buildHttpApp } from "../src/http-transport.js";
+import { isOriginAllowed, isLoopbackHost, buildHttpApp } from "../src/http-transport.js";
 import { Server as McpServer } from "@modelcontextprotocol/sdk/server/index.js";
 
 // ── helpers ────────────────────────────────────────────────────────────────
@@ -125,6 +125,19 @@ describe("isOriginAllowed()", () => {
 
   it("is case-sensitive for non-local allowlist entries per RFC 6454", () => {
     expect(isOriginAllowed("HTTPS://Partner.Example.com", ["https://partner.example.com"])).toBe(false);
+  });
+});
+
+describe("isLoopbackHost()", () => {
+  it("accepts loopback names and addresses", () => {
+    expect(isLoopbackHost("localhost")).toBe(true);
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+  });
+
+  it("rejects wildcard and network addresses", () => {
+    expect(isLoopbackHost("0.0.0.0")).toBe(false);
+    expect(isLoopbackHost("192.168.1.20")).toBe(false);
   });
 });
 

--- a/tools/ruview-mcp/tests/tools.test.ts
+++ b/tools/ruview-mcp/tests/tools.test.ts
@@ -41,10 +41,7 @@ describe("ruview_pose_infer", () => {
 
   it("result shape contains expected fields on success (stub)", async () => {
     // Point to a real binary that returns exit 0 on any argument (using 'node').
-    const result = await poseInfer(
-      { cog_binary: "node" },
-      { ...testConfig, poseCogBinary: "node" }
-    ) as Record<string, unknown>;
+    const result = await poseInfer({}, { ...testConfig, poseCogBinary: "node" }) as Record<string, unknown>;
     // node --help exits 0, so health passes, but output may be unexpected.
     // We just verify the response is shaped correctly.
     expect(typeof result["ok"]).toBe("boolean");

--- a/tools/ruview-mcp/tests/vitals-tools.test.ts
+++ b/tools/ruview-mcp/tests/vitals-tools.test.ts
@@ -6,8 +6,8 @@
  *   - Field projection correctness from a fixture EdgeVitalsMessage
  *   - Schema acceptance / rejection
  *
- * The fixture is injected via a custom sensing_server_url that points to a
- * port with nothing listening — identical to the BFLD tests pattern.
+ * The test config points to a port with nothing listening, identical to the
+ * BFLD tests pattern.
  */
 
 import os from "node:os";

--- a/v2/crates/wifi-densepose-desktop/src/commands/ota.rs
+++ b/v2/crates/wifi-densepose-desktop/src/commands/ota.rs
@@ -1,5 +1,7 @@
 use std::fs::File;
 use std::io::Read;
+use std::net::IpAddr;
+use std::path::Path;
 use std::time::Duration;
 
 use hmac::{Hmac, Mac};
@@ -16,8 +18,57 @@ const OTA_PATH: &str = "/ota/upload";
 
 /// Request timeout for OTA uploads.
 const OTA_TIMEOUT_SECS: u64 = 120;
+const MAX_FIRMWARE_BYTES: u64 = 32 * 1024 * 1024;
 
 type HmacSha256 = Hmac<Sha256>;
+
+fn validate_ota_target(node_ip: &str) -> Result<IpAddr, String> {
+    let ip: IpAddr = node_ip
+        .parse()
+        .map_err(|_| "Node address must be an IP address".to_string())?;
+    let allowed = match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local() || v4.is_loopback(),
+        IpAddr::V6(v6) => v6.is_unique_local() || v6.is_unicast_link_local() || v6.is_loopback(),
+    };
+    if !allowed {
+        return Err("OTA target must be a local or private network address".into());
+    }
+    Ok(ip)
+}
+
+fn read_firmware(path: &str) -> Result<Vec<u8>, String> {
+    let path = Path::new(path);
+    if path
+        .extension()
+        .and_then(|v| v.to_str())
+        .map(|v| v.eq_ignore_ascii_case("bin"))
+        != Some(true)
+    {
+        return Err("Firmware file must use the .bin extension".into());
+    }
+    let metadata = path
+        .symlink_metadata()
+        .map_err(|e| format!("Cannot inspect firmware: {}", e))?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Err("Firmware path must be a regular, non-symlink file".into());
+    }
+    if metadata.len() == 0 || metadata.len() > MAX_FIRMWARE_BYTES {
+        return Err(format!(
+            "Firmware size must be between 1 and {} bytes",
+            MAX_FIRMWARE_BYTES
+        ));
+    }
+    let mut data = Vec::with_capacity(metadata.len() as usize);
+    File::open(path)
+        .map_err(|e| format!("Cannot read firmware: {}", e))?
+        .take(MAX_FIRMWARE_BYTES + 1)
+        .read_to_end(&mut data)
+        .map_err(|e| format!("Failed to read firmware: {}", e))?;
+    if data.len() as u64 > MAX_FIRMWARE_BYTES || data.first() != Some(&0xE9) {
+        return Err("Invalid or oversized ESP firmware image".into());
+    }
+    Ok(data)
+}
 
 /// Push firmware to a single node via HTTP OTA (port 8032).
 ///
@@ -35,6 +86,7 @@ pub async fn ota_update(
     psk: Option<String>,
 ) -> Result<OtaResult, String> {
     let start_time = std::time::Instant::now();
+    let node_ip = validate_ota_target(&node_ip)?.to_string();
 
     // Emit progress
     let _ = app.emit(
@@ -48,12 +100,7 @@ pub async fn ota_update(
     );
 
     // Read firmware file
-    let mut file =
-        File::open(&firmware_path).map_err(|e| format!("Cannot read firmware: {}", e))?;
-
-    let mut firmware_data = Vec::new();
-    file.read_to_end(&mut firmware_data)
-        .map_err(|e| format!("Failed to read firmware: {}", e))?;
+    let firmware_data = read_firmware(&firmware_path)?;
 
     let firmware_size = firmware_data.len();
 

--- a/v2/crates/wifi-densepose-desktop/src/commands/wasm.rs
+++ b/v2/crates/wifi-densepose-desktop/src/commands/wasm.rs
@@ -11,6 +11,7 @@ const WASM_PORT: u16 = 8033;
 
 /// Request timeout for WASM operations.
 const WASM_TIMEOUT_SECS: u64 = 30;
+const MAX_WASM_BYTES: u64 = 16 * 1024 * 1024;
 
 /// List WASM modules loaded on a specific node.
 #[tauri::command]
@@ -55,11 +56,26 @@ pub async fn wasm_upload(
     auto_start: Option<bool>,
 ) -> Result<WasmUploadResult, String> {
     // Read WASM file
-    let mut file = File::open(&wasm_path).map_err(|e| format!("Cannot read WASM file: {}", e))?;
+    let metadata = std::fs::symlink_metadata(&wasm_path)
+        .map_err(|e| format!("Cannot inspect WASM file: {}", e))?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Err("WASM path must be a regular, non-symlink file".into());
+    }
+    if metadata.len() == 0 || metadata.len() > MAX_WASM_BYTES {
+        return Err(format!(
+            "WASM size must be between 1 and {} bytes",
+            MAX_WASM_BYTES
+        ));
+    }
+    let file = File::open(&wasm_path).map_err(|e| format!("Cannot read WASM file: {}", e))?;
 
     let mut wasm_data = Vec::new();
-    file.read_to_end(&mut wasm_data)
+    file.take(MAX_WASM_BYTES + 1)
+        .read_to_end(&mut wasm_data)
         .map_err(|e| format!("Failed to read WASM file: {}", e))?;
+    if wasm_data.len() as u64 > MAX_WASM_BYTES {
+        return Err(format!("WASM file exceeds {} bytes", MAX_WASM_BYTES));
+    }
 
     let wasm_size = wasm_data.len();
 

--- a/v2/crates/wifi-densepose-sensing-server/src/bearer_auth.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/bearer_auth.rs
@@ -46,6 +46,7 @@
 //! to `sensing:read` or `sensing:admin` — see its docs for the split and why it
 //! is drawn where it is.
 
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use axum::{
@@ -118,6 +119,11 @@ fn allowed_client_ids() -> Vec<String> {
 /// in tests, but it is NO LONGER the rule. The gate is [`is_anonymous`] —
 /// deny-by-default. See that function for why.
 pub const PROTECTED_PREFIX: &str = "/api/v1/";
+
+/// A routable bind must never silently downgrade to an unauthenticated API.
+pub fn auth_required_for_bind(bind_ip: IpAddr, auth_enabled: bool) -> bool {
+    !auth_enabled && !bind_ip.is_loopback()
+}
 
 /// Paths that stay reachable with no credential when auth is enabled.
 ///
@@ -889,6 +895,16 @@ mod tests {
             status(r, "GET", "/ui/index.html", None).await,
             StatusCode::OK
         );
+    }
+
+    #[test]
+    fn routable_bind_requires_configured_auth() {
+        let loopback: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let routable: std::net::IpAddr = "0.0.0.0".parse().unwrap();
+
+        assert!(!auth_required_for_bind(loopback, false));
+        assert!(auth_required_for_bind(routable, false));
+        assert!(!auth_required_for_bind(routable, true));
     }
 
     #[tokio::test]

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -5389,8 +5389,18 @@ async fn start_recording(
     // `GET /api/v1/recordings` (and the success response below) sees it.
     let watermark = s.source_state().export_watermark();
 
+    // Validate the caller-controlled id before it becomes a filesystem path.
+    let rec_path = match path_safety::recording_path(&id) {
+        Ok(path) => path,
+        Err(_) => {
+            return Json(serde_json::json!({
+                "error": "invalid recording id",
+                "success": false,
+            }));
+        }
+    };
+
     // Create the recording file
-    let rec_path = PathBuf::from("data/recordings").join(format!("{}.jsonl", id));
     let file = match std::fs::File::create(&rec_path) {
         Ok(f) => f,
         Err(e) => {
@@ -8671,6 +8681,15 @@ async fn main() {
                 std::process::exit(1);
             }
         };
+    if wifi_densepose_sensing_server::bearer_auth::auth_required_for_bind(
+        bind_ip,
+        bearer_auth_state.is_enabled(),
+    ) {
+        error!(
+            "API auth is required when --bind-addr is routable; set RUVIEW_API_TOKEN or RUVIEW_OAUTH_ISSUER"
+        );
+        std::process::exit(1);
+    }
     if bearer_auth_state.is_enabled() {
         if bearer_auth_state.oauth_enabled() {
             info!("API auth: ON for /api/v1/* — Cognitum OAuth (ADR-271){}",

--- a/v2/crates/wifi-densepose-sensing-server/src/path_safety.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/path_safety.rs
@@ -16,6 +16,7 @@
 //! `format!()` that builds a path under a fixed parent directory.
 
 use std::fmt;
+use std::path::PathBuf;
 
 /// Maximum length for a safe identifier. 64 is generous for human-typed
 /// session names while keeping the resulting filename well under
@@ -102,9 +103,16 @@ pub fn safe_id(input: &str) -> Result<&str, PathSafetyError> {
     Ok(input)
 }
 
+/// Build a recording filename only after validating its caller-controlled id.
+pub fn recording_path(input: &str) -> Result<PathBuf, PathSafetyError> {
+    let safe = safe_id(input)?;
+    Ok(PathBuf::from("data/recordings").join(format!("{safe}.jsonl")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn accepts_simple_alphanumeric() {
@@ -199,5 +207,15 @@ mod tests {
     fn boundary_max_len() {
         let at_max = "a".repeat(MAX_ID_LEN);
         assert!(safe_id(&at_max).is_ok());
+    }
+
+    #[test]
+    fn recording_path_is_confined_to_recordings_root() {
+        assert_eq!(
+            recording_path("capture_1").unwrap(),
+            PathBuf::from("data/recordings/capture_1.jsonl")
+        );
+        assert!(recording_path("../../etc/passwd").is_err());
+        assert!(recording_path("capture/escape").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- validate recording IDs before filesystem writes
- require API auth on routable binds
- protect all WASM handlers with OTA auth
- keep provisioning passwords out of argv, CSV fallbacks, and local state

## Verification
- `cargo test -p wifi-densepose-sensing-server --no-default-features --lib`: 531 passed, 1 ignored
- firmware unittest suite: 18 passed