### PR TITLE
fix(training): report when a run falls back to the live buffer

### DIFF
--- a/ui/components/TrainingPanel.js
+++ b/ui/components/TrainingPanel.js
@@ -54,6 +54,7 @@ const TP_STYLES = `
 .tp-btn-rec:hover:not(:disabled){background:rgba(220,53,69,.3)}
 .tp-btn-muted{background:transparent;color:#6b7a8d;border-color:rgba(56,68,89,.4);font-size:11px;padding:3px 8px}
 .tp-btn-muted:hover:not(:disabled){color:#b0b8c8;border-color:rgba(56,68,89,.8)}
+.tp-warning{background:rgba(255,193,7,.15);color:#ffd166;border:1px solid rgba(255,193,7,.35);border-radius:4px;padding:8px 12px;margin:10px 12px 0;font-size:12px;font-weight:500}
 `;
 
 export default class TrainingPanel {
@@ -180,6 +181,11 @@ export default class TrainingPanel {
     const panel = this._el('div', 'tp-panel');
     panel.appendChild(this._renderHeader());
     if (this.state.error) panel.appendChild(this._el('div', 'tp-error', this.state.error));
+    const ds = this.state.trainingStatus && this.state.trainingStatus.data_source;
+    if (ds === 'live_buffer_fallback') {
+      panel.appendChild(this._el('div', 'tp-warning',
+        '⚠ The recordings you selected did not load. This run trained on the live sensing buffer instead — it does NOT reflect your selected recordings.'));
+    }
     panel.appendChild(this._renderRecordings());
     const ts = this.state.trainingStatus;
     const active = ts && ts.active;
@@ -333,6 +339,7 @@ export default class TrainingPanel {
     g.appendChild(mc('Patience', ts.patience_remaining != null ? String(ts.patience_remaining) : '--'));
     g.appendChild(mc('ETA', ts.eta_secs != null ? this._fmtEta(ts.eta_secs) : '--'));
     g.appendChild(mc('Phase', ts.phase || '--'));
+    g.appendChild(mc('Data Source', this._fmtDataSource(ts.data_source)));
     s.appendChild(g);
 
     const stop = this._btn('Stop Training', 'tp-btn tp-btn-danger', () => this._stopTraining());
@@ -351,6 +358,7 @@ export default class TrainingPanel {
     g.appendChild(mc('Best PCK', ts.best_pck != null ? (ts.best_pck * 100).toFixed(1) + '%' : '--'));
     g.appendChild(mc('Best Epoch', ts.best_epoch != null ? String(ts.best_epoch) : '--'));
     g.appendChild(mc('Total Epochs', String(losses.length)));
+    g.appendChild(mc('Data Source', this._fmtDataSource(ts.data_source)));
     s.appendChild(g);
     const acts = this._el('div', 'tp-train-actions');
     acts.appendChild(this._btn('New Training', 'tp-btn tp-btn-secondary', () => {
@@ -420,6 +428,14 @@ export default class TrainingPanel {
 
   _fmtB(b) { return b < 1024 ? b + ' B' : b < 1048576 ? (b / 1024).toFixed(1) + ' KB' : (b / 1048576).toFixed(1) + ' MB'; }
   _fmtEta(s) { return s < 60 ? Math.round(s) + 's' : s < 3600 ? Math.round(s / 60) + 'm' : (s / 3600).toFixed(1) + 'h'; }
+  _fmtDataSource(ds) {
+    switch (ds) {
+      case 'recordings': return 'Selected recordings';
+      case 'live_buffer': return 'Live buffer';
+      case 'live_buffer_fallback': return '⚠ Live buffer (fallback)';
+      default: return '--';
+    }
+  }
 
   _injectStyles() {
     if (document.getElementById('training-panel-styles')) return;

--- a/v2/crates/wifi-densepose-sensing-server/src/training_api.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/training_api.rs
@@ -230,6 +230,15 @@ pub struct TrainingStatus {
     pub patience_remaining: u32,
     pub eta_secs: Option<u64>,
     pub phase: String,
+    /// What data this run actually trained on: `"none"` (not yet determined),
+    /// `"recordings"` (the requested `dataset_ids` loaded successfully),
+    /// `"live_buffer"` (no `dataset_ids` were requested), or
+    /// `"live_buffer_fallback"` (recordings were requested but none loaded,
+    /// so the run silently substituted the live `frame_history` buffer).
+    /// The dashboard must surface `live_buffer_fallback` loudly — a run in
+    /// this state does NOT reflect the recordings the operator selected.
+    #[serde(default)]
+    pub data_source: String,
 }
 
 impl Default for TrainingStatus {
@@ -247,6 +256,7 @@ impl Default for TrainingStatus {
             patience_remaining: 0,
             eta_secs: None,
             phase: "idle".to_string(),
+            data_source: "none".to_string(),
         }
     }
 }
@@ -1041,9 +1051,29 @@ async fn run_training_job(
     }
 
     let mut frames = load_recording_frames(&dataset_ids).await;
-    if frames.is_empty() {
-        info!("No recordings found for dataset_ids; falling back to live frame_history");
+
+    // Determine what this run is actually training on, honestly. A run that
+    // requested specific recordings but silently trained on the live buffer
+    // instead (e.g. a stale/mistyped dataset_id, a deleted file) must not look
+    // identical to a real recordings-backed run in the status the dashboard reads.
+    let data_source = if !frames.is_empty() {
+        "recordings".to_string()
+    } else if !dataset_ids.is_empty() {
+        warn!(
+            "Requested {} recording(s) ({:?}) but none loaded; falling back to the live \
+             frame_history buffer. This run will NOT reflect the selected recordings.",
+            dataset_ids.len(),
+            dataset_ids
+        );
         frames = frames_from_history(&history_snapshot);
+        "live_buffer_fallback".to_string()
+    } else {
+        frames = frames_from_history(&history_snapshot);
+        "live_buffer".to_string()
+    };
+    {
+        let mut st = status.lock().unwrap();
+        st.data_source = data_source.clone();
     }
 
     if frames.len() < 10 {
@@ -1324,6 +1354,7 @@ async fn run_training_job(
                 patience_remaining,
                 eta_secs: Some(eta_secs),
                 phase: phase.to_string(),
+                data_source: data_source.clone(),
             };
         }
 
@@ -2394,6 +2425,80 @@ mod tests {
             frames.is_empty(),
             "path-traversal dataset_id must yield no frames"
         );
+    }
+
+    /// Regression guard: requesting recordings that don't resolve to any real
+    /// data must NOT look like a normal recordings-backed run. Before this fix,
+    /// `run_training_job` silently swapped in the live `frame_history` buffer
+    /// and the resulting status was indistinguishable from a real recordings
+    /// run — the operator had no way to tell their selection was ignored.
+    #[tokio::test]
+    async fn training_job_flags_live_buffer_fallback_when_recordings_missing() {
+        let history = synthetic_history(40, 56);
+        let (tx, _rx) = broadcast::channel::<String>(1024);
+        let status = Arc::new(Mutex::new(TrainingStatus::default()));
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let config = TrainingConfig {
+            epochs: 2,
+            batch_size: 8,
+            warmup_epochs: 1,
+            early_stopping_patience: 10,
+            ..Default::default()
+        };
+
+        // dataset_ids that resolve to nothing on disk — this must be reported,
+        // not silently substituted.
+        let rvf = run_training_job(
+            status.clone(),
+            cancel,
+            tx,
+            config,
+            vec!["nonexistent-recording-id".to_string()],
+            history,
+            "supervised",
+        )
+        .await;
+        let _ = std::fs::remove_file(rvf.expect("fallback run still trains and exports"));
+
+        assert_eq!(
+            status.lock().unwrap().data_source,
+            "live_buffer_fallback",
+            "a run that requested missing recordings must be flagged as a live-buffer fallback"
+        );
+    }
+
+    /// A run that never requested any recordings (e.g. a quick live-buffer
+    /// sanity check) is a different, honest case and must not be confused with
+    /// the fallback above.
+    #[tokio::test]
+    async fn training_job_reports_live_buffer_when_no_recordings_requested() {
+        let history = synthetic_history(40, 56);
+        let (tx, _rx) = broadcast::channel::<String>(1024);
+        let status = Arc::new(Mutex::new(TrainingStatus::default()));
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let config = TrainingConfig {
+            epochs: 2,
+            batch_size: 8,
+            warmup_epochs: 1,
+            early_stopping_patience: 10,
+            ..Default::default()
+        };
+
+        let rvf = run_training_job(
+            status.clone(),
+            cancel,
+            tx,
+            config,
+            Vec::new(),
+            history,
+            "supervised",
+        )
+        .await;
+        let _ = std::fs::remove_file(rvf.expect("run still trains and exports"));
+
+        assert_eq!(status.lock().unwrap().data_source, "live_buffer");
     }
 
     /// Exported model ids must be unique per call — a second-resolution


### PR DESCRIPTION
## Summary
- `run_training_job` silently substituted the live `frame_history` buffer whenever the requested `dataset_ids` failed to resolve to any recording files (stale id, deleted file, path-safety rejection) — the only signal was an `info!` log line, invisible to the dashboard.
- A run in that state was indistinguishable from a real recordings-backed run: same epochs, same loss/PCK panels, no indication the selected recordings were never used.

## Change
- Adds `TrainingStatus.data_source`: `"recordings"` / `"live_buffer"` (no recordings requested) / `"live_buffer_fallback"` (recordings requested but none loaded).
- Computed immediately after the load attempt, upgraded the log line to `warn!` naming the missing dataset ids, and threaded through the per-epoch status update so it survives the run.
- `TrainingPanel.js`: shows a warning banner on `live_buffer_fallback`, plus a "Data Source" metric in both the live-progress and completed-run views.
- Two new tests: fallback is flagged when requested recordings don't resolve; the no-recordings-requested case is reported as plain `live_buffer`, not conflated with the fallback.

## Test plan
- [x] `cargo test -p wifi-densepose-sensing-server --no-default-features training_` — 30/30 passing, including the two new regression tests
- [x] `npx @ruvnet/ruview claim-check` on this PR body — PASS, no untagged claims
- [ ] Maintainer smoke-test in the dashboard: select a recording, delete its file on disk, start training, confirm the warning banner appears