### PR TITLE
fix(csi): filter by MAC before the early rate gate

### DIFF
--- a/firmware/esp32-csi-node/main/csi_collector.c
+++ b/firmware/esp32-csi-node/main/csi_collector.c
@@ -250,6 +250,24 @@ static void wifi_csi_callback(void *ctx, wifi_csi_info_t *info)
 {
     (void)ctx;
 
+    /* ADR-060: MAC address filtering — MOVED ABOVE the rate gate.
+     *
+     * The gate below stamps s_last_process_us before this filter ran, so a
+     * frame from any foreign transmitter claimed the 20 ms window and was then
+     * discarded here — starving the filtered stream. Measured on an ESP32-C6
+     * locked to its associated AP: 1.7 CSI/s instead of ~20 Hz. Filtering
+     * first preserves the gate's crash protection (processing is still capped
+     * at 50 Hz) while letting the matched transmitter actually fill the slots.
+     * With no filter configured the behaviour is byte-for-byte unchanged.
+     *
+     * Uses defensively-copied s_filter_mac instead of g_nvs_config (which can
+     * be corrupted by wifi_init_sta — same root cause as the node_id clobber). */
+    if (s_filter_mac_set) {
+        if (memcmp(info->mac, s_filter_mac, 6) != 0) {
+            return;  /* Source MAC doesn't match filter — skip frame. */
+        }
+    }
+
     /* Early rate gate: drop excess callbacks to ~50 Hz to prevent
      * SPI flash cache crash in WiFi ISR (wDev_ProcessFiq). */
     int64_t now_us = esp_timer_get_time();
@@ -258,15 +276,6 @@ static void wifi_csi_callback(void *ctx, wifi_csi_info_t *info)
         return;
     }
     s_last_process_us = now_us;
-
-    /* ADR-060: MAC address filtering — drop frames from non-matching sources.
-     * Uses defensively-copied s_filter_mac instead of g_nvs_config (which can
-     * be corrupted by wifi_init_sta — same root cause as the node_id clobber). */
-    if (s_filter_mac_set) {
-        if (memcmp(info->mac, s_filter_mac, 6) != 0) {
-            return;  /* Source MAC doesn't match filter — skip frame. */
-        }
-    }
 
     s_cb_count++;
 


### PR DESCRIPTION
## Problem

`csi_collector.c` runs the ADR-060 MAC filter **after** the early rate gate. The gate stamps `s_last_process_us` before the filter has a chance to run, so a frame from *any* transmitter claims the 20 ms window and is then dropped by the filter. The matched transmitter's next frame arrives inside the window that the foreign frame just consumed, and gets gated away.

The net effect is that configuring `filter_mac` starves the very stream it is meant to isolate.

## Measurement

On an ESP32-C6 (v0.8.4, `sdkconfig.defaults.esp32c6`, node locked to its associated AP, `--filter-mac` set to that AP's BSSID):

| | CSI rate |
|---|---|
| before | **1.7 CSI/s** |
| after | **~20 Hz** (22 pps sustained) |

Same board, same room, same channel (2447 MHz), only the ordering changed.

## Fix

Move the `s_filter_mac_set` check above the rate gate.

- The gate's purpose — capping processing at 50 Hz to avoid the SPI flash cache crash in the WiFi ISR (`wDev_ProcessFiq`) — is preserved: every frame that reaches the gate is still gated.
- Filtering earlier only means the gate now sees *fewer* frames, never more, so the crash protection is not weakened.
- When no filter is configured (`s_filter_mac_set == false`) the code path is byte-for-byte unchanged.

The filter keeps using the defensively-copied `s_filter_mac` rather than `g_nvs_config`, for the same reason as before (the `wifi_init_sta` clobber).

## Testing

Built with ESP-IDF for `esp32c6` and flashed to real hardware; CSI rate verified over a live UDP stream (ADR-018 `0xC5110001` frames) for ~8 minutes of continuous capture. Vitals and sync frames are unaffected.