### PR TITLE
fix(provision): owner-only state files, chip-identity binding, and --ota-psk

### DIFF
--- a/firmware/esp32-csi-node/provision.py
+++ b/firmware/esp32-csi-node/provision.py
@@ -108,6 +108,7 @@ MERGEABLE_ATTRS = [
     "channel", "filter_mac",
     "hop_channels", "hop_dwell",
     "seed_url", "seed_token", "zone", "swarm_hb", "swarm_ingest",
+    "ota_psk",
 ]
 
 
@@ -129,6 +130,47 @@ def _state_path_for(port: str, state_dir: str) -> str:
     return os.path.join(state_dir, f"{safe}.json")
 
 
+# Key under which the board's own identity is recorded inside the per-port
+# state file. Underscore-prefixed so it can never collide with an NVS key and is
+# trivially filtered out of the merge.
+STATE_IDENTITY_KEY = "_chip_mac"
+
+
+def read_chip_mac(port: str, baud: int, chip: str):
+    """Return the connected board's MAC, or None if it cannot be read.
+
+    Best-effort and never fatal: identity binding is a safety net, so a board
+    that will not answer must still be provisionable exactly as before.
+    """
+    try:
+        out = subprocess.run(
+            [sys.executable, "-m", "esptool", "--chip", chip, "--port", port,
+             "--baud", str(baud), "read-mac"],
+            capture_output=True, text=True, timeout=60,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    for line in out.splitlines():
+        # esptool prints e.g. "MAC: 80:b5:4e:c1:b5:68"
+        if line.strip().upper().startswith("MAC:"):
+            mac = line.split(":", 1)[1].strip().lower()
+            if len(mac.split(":")) == 6:
+                return mac
+    return None
+
+
+def identity_matches(prior: dict, chip_mac) -> bool:
+    """True when prior state may be merged onto the connected board.
+
+    Unknown on either side means "cannot prove a mismatch", which stays
+    permissive so existing state files keep working after upgrade.
+    """
+    recorded = prior.get(STATE_IDENTITY_KEY)
+    if not recorded or not chip_mac:
+        return True
+    return recorded == chip_mac
+
+
 def load_state(port: str, state_dir: str) -> dict:
     """Return the merged-state dict for `port`, or `{}` if absent / unreadable."""
     path = _state_path_for(port, state_dir)
@@ -144,16 +186,41 @@ def load_state(port: str, state_dir: str) -> dict:
     return {}
 
 
+# State files hold the WiFi password in cleartext, so they are owner-only.
+STATE_DIR_MODE = 0o700
+STATE_FILE_MODE = 0o600
+
+
+def _harden(path: str, mode: int) -> None:
+    """Best-effort chmod. Never fatal: a read-only or exotic FS must not block
+    provisioning, but we also must not silently leave a secret world-readable
+    without saying so."""
+    try:
+        os.chmod(path, mode)
+    except OSError as e:
+        print(f"WARNING: could not set {oct(mode)} on {path}: {e}", file=sys.stderr)
+
+
 def save_state(port: str, state_dir: str, state: dict) -> str:
-    """Write `state` to the per-port file, creating dirs as needed. Returns path."""
-    os.makedirs(state_dir, exist_ok=True)
+    """Write `state` to the per-port file, creating dirs as needed. Returns path.
+
+    The file contains the WiFi password in cleartext, so it is created 0600 and
+    the directory 0700. `makedirs` cannot tighten a directory that already
+    exists, so an explicit chmod covers state dirs left by earlier versions.
+    """
+    os.makedirs(state_dir, mode=STATE_DIR_MODE, exist_ok=True)
+    _harden(state_dir, STATE_DIR_MODE)
     path = _state_path_for(port, state_dir)
     # Sort keys for deterministic on-disk content (easier to diff).
     tmp = path + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
+    # Create restrictively rather than chmod-ing after: the secret must never
+    # exist world-readable, not even briefly.
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, STATE_FILE_MODE)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(state, f, indent=2, sort_keys=True)
         f.write("\n")
     os.replace(tmp, path)
+    _harden(path, STATE_FILE_MODE)
     return path
 
 
@@ -234,6 +301,12 @@ def build_nvs_csv(args):
         writer.writerow(["swarm_hb", "data", "u16", str(args.swarm_hb)])
     if args.swarm_ingest is not None:
         writer.writerow(["swarm_ingest", "data", "u16", str(args.swarm_ingest)])
+    # ADR-050 / issue #1753: the OTA pre-shared key lives in its own `security`
+    # namespace, which is what main/ota_update.c reads (OTA_NVS_NAMESPACE /
+    # OTA_NVS_KEY). Emitted last so the csi_cfg namespace above is unaffected.
+    if getattr(args, "ota_psk", None):
+        writer.writerow(["security", "namespace", "", ""])
+        writer.writerow(["ota_psk", "data", "string", args.ota_psk])
     return buf.getvalue()
 
 
@@ -352,6 +425,10 @@ def main():
     parser.add_argument("--seed-url", type=str, help="Cognitum Seed base URL (e.g. http://10.1.10.236)")
     parser.add_argument("--seed-token", type=str, help="Seed Bearer token (from pairing)")
     parser.add_argument("--zone", type=str, help="Zone name for this node (e.g. lobby, hallway)")
+    parser.add_argument("--ota-psk", type=str,
+                        help="OTA pre-shared key (hex, <=64 chars) written to the `security` "
+                             "NVS namespace. Without it the node's OTA endpoint rejects every "
+                             "upload (fail-closed, issue #1753).")
     parser.add_argument("--swarm-hb", type=int, help="Swarm heartbeat interval in seconds (default 30)")
     parser.add_argument("--swarm-ingest", type=int, help="Swarm vector ingest interval in seconds (default 5)")
     parser.add_argument("--dry-run", action="store_true", help="Generate NVS binary but don't flash")
@@ -371,6 +448,19 @@ def main():
 
     args = parser.parse_args()
 
+    # Firmware caps the PSK at OTA_PSK_MAX_LEN (65) including the NUL, and
+    # documents it as a hex-encoded SHA-256, so reject anything that cannot be
+    # stored or that the device would treat as malformed.
+    if args.ota_psk is not None:
+        psk = args.ota_psk.strip()
+        if not psk:
+            parser.error("--ota-psk must not be empty")
+        if len(psk) > 64:
+            parser.error(f"--ota-psk must be at most 64 characters (got {len(psk)})")
+        if any(c not in "0123456789abcdefABCDEF" for c in psk):
+            parser.error("--ota-psk must be hex (0-9, a-f)")
+        args.ota_psk = psk.lower()
+
     # --- Per-port state load + merge (additive-by-default, #391 / #574) ---
     if args.reset:
         path = _state_path_for(args.port, args.state_dir)
@@ -380,7 +470,31 @@ def main():
         prior = {}
     else:
         prior = load_state(args.port, args.state_dir)
+
+    # Issue #1755: state is keyed by serial port path, and port names are reused
+    # when boards are swapped. Prior state from a *different* board must not be
+    # merged onto this one — inheriting another board's node_id silently
+    # corrupts a multistatic cohort. `--state` stays read-only and skips the
+    # chip round-trip.
+    chip_mac = None
+    if prior and not args.state:
+        chip_mac = read_chip_mac(args.port, args.baud, args.chip)
+        if not identity_matches(prior, chip_mac):
+            print(
+                f"ERROR: {args.port} last held board "
+                f"{prior.get(STATE_IDENTITY_KEY)}, but the connected board is "
+                f"{chip_mac}.\n"
+                "       Refusing to merge another board's settings (node_id, "
+                "target_port, channel ...).\n"
+                "       Pass --reset to provision this board from scratch, or "
+                "pass every value explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
     merged = merge_state_into_args(args, prior)
+    if chip_mac:
+        merged[STATE_IDENTITY_KEY] = chip_mac
 
     if args.state:
         print(json.dumps(merged, indent=2, sort_keys=True))

--- a/firmware/esp32-csi-node/provision.py
+++ b/firmware/esp32-csi-node/provision.py
@@ -58,6 +58,7 @@ NVS_PARTITION_SIZE = 0x6000  # 24 KiB
 
 
 CONFIG_VALUE_CHECKS = [
+    ("ota_psk", bool),
     ("ssid", bool),
     ("password", lambda value: value is not None),
     ("target_ip", bool),
@@ -201,6 +202,15 @@ def _harden(path: str, mode: int) -> None:
         print(f"WARNING: could not set {oct(mode)} on {path}: {e}", file=sys.stderr)
 
 
+def _harden_existing_state(port: str, state_dir: str) -> None:
+    """Tighten permissions on already-written state without rewriting it."""
+    if os.path.isdir(state_dir):
+        _harden(state_dir, STATE_DIR_MODE)
+    path = _state_path_for(port, state_dir)
+    if os.path.isfile(path):
+        _harden(path, STATE_FILE_MODE)
+
+
 def save_state(port: str, state_dir: str, state: dict) -> str:
     """Write `state` to the per-port file, creating dirs as needed. Returns path.
 
@@ -214,8 +224,17 @@ def save_state(port: str, state_dir: str, state: dict) -> str:
     # Sort keys for deterministic on-disk content (easier to diff).
     tmp = path + ".tmp"
     # Create restrictively rather than chmod-ing after: the secret must never
-    # exist world-readable, not even briefly.
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, STATE_FILE_MODE)
+    # exist world-readable, not even briefly. O_EXCL (plus removing any stale
+    # temp first) means the mode is actually applied — O_CREAT is ignored for an
+    # existing path, so a leftover 0644 file or a planted symlink would
+    # otherwise receive the secret. O_NOFOLLOW where available refuses a symlink
+    # outright.
+    try:
+        os.unlink(tmp)
+    except FileNotFoundError:
+        pass
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(tmp, flags, STATE_FILE_MODE)
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(state, f, indent=2, sort_keys=True)
         f.write("\n")
@@ -455,8 +474,15 @@ def main():
         psk = args.ota_psk.strip()
         if not psk:
             parser.error("--ota-psk must not be empty")
-        if len(psk) > 64:
-            parser.error(f"--ota-psk must be at most 64 characters (got {len(psk)})")
+        # ota_update.c documents the PSK as a hex-encoded SHA-256 and caps it at
+        # OTA_PSK_MAX_LEN (65 incl. NUL). Accepting a short value would reduce a
+        # firmware-upload bearer credential to something guessable, so require
+        # the full 64 hex characters rather than merely "fits".
+        if len(psk) != 64:
+            parser.error(
+                f"--ota-psk must be exactly 64 hex characters "
+                f"(a hex-encoded SHA-256); got {len(psk)}. "
+                f"Generate one with: openssl rand -hex 32")
         if any(c not in "0123456789abcdefABCDEF" for c in psk):
             parser.error("--ota-psk must be hex (0-9, a-f)")
         args.ota_psk = psk.lower()
@@ -470,24 +496,28 @@ def main():
         prior = {}
     else:
         prior = load_state(args.port, args.state_dir)
+        _harden_existing_state(args.port, args.state_dir)
 
     # Issue #1755: state is keyed by serial port path, and port names are reused
     # when boards are swapped. Prior state from a *different* board must not be
     # merged onto this one — inheriting another board's node_id silently
-    # corrupts a multistatic cohort. `--state` stays read-only and skips the
-    # chip round-trip.
+    # corrupts a multistatic cohort.
+    #
+    # The identity is read on every run that will talk to the device, not only
+    # when prior state exists: a *first* provisioning must record the MAC, or
+    # the very next swap has nothing to compare against. --state and --dry-run
+    # never touch the serial port.
     chip_mac = None
-    if prior and not args.state:
+    if not args.state and not args.dry_run:
         chip_mac = read_chip_mac(args.port, args.baud, args.chip)
-        if not identity_matches(prior, chip_mac):
+        if prior and not identity_matches(prior, chip_mac):
             print(
                 f"ERROR: {args.port} last held board "
                 f"{prior.get(STATE_IDENTITY_KEY)}, but the connected board is "
                 f"{chip_mac}.\n"
                 "       Refusing to merge another board's settings (node_id, "
                 "target_port, channel ...).\n"
-                "       Pass --reset to provision this board from scratch, or "
-                "pass every value explicitly.",
+                "       Pass --reset to provision this board from scratch.",
                 file=sys.stderr,
             )
             sys.exit(2)
@@ -497,7 +527,17 @@ def main():
         merged[STATE_IDENTITY_KEY] = chip_mac
 
     if args.state:
-        print(json.dumps(merged, indent=2, sort_keys=True))
+        # Repair permissions on state written by an earlier version even on this
+        # read-only path — otherwise an existing 0644 file stays exposed until
+        # the next write.
+        _harden_existing_state(args.port, args.state_dir)
+        shown = dict(merged)
+        if shown.get("ota_psk"):
+            # The OTA bearer credential is stored (provisioning rewrites the whole
+            # NVS partition, so dropping it would wipe the device's PSK) but it is
+            # not printed.
+            shown["ota_psk"] = "<redacted; present>"
+        print(json.dumps(shown, indent=2, sort_keys=True))
         return
 
     if not has_config_value(args):

--- a/firmware/esp32-csi-node/tests/test_provision_state.py
+++ b/firmware/esp32-csi-node/tests/test_provision_state.py
@@ -125,8 +125,6 @@ class TestStatePathSanitization(unittest.TestCase):
         self.assertTrue(path.endswith("COM7.json"))
 
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 class TestStateFilePermissions(unittest.TestCase):
@@ -197,3 +195,64 @@ class TestOtaPskNamespace(unittest.TestCase):
         rows = [r.split(",") for r in provision.build_nvs_csv(args).strip().splitlines()]
         namespaces = [r[0] for r in rows if len(r) > 1 and r[1] == "namespace"]
         self.assertEqual(namespaces, ["csi_cfg", "security"])
+
+
+class TestReworkedAfterReview(unittest.TestCase):
+    """Regressions for defects found reviewing the first cut of this change."""
+
+    def setUp(self):
+        self.dir = os.path.join(tempfile.mkdtemp(prefix="provision-rework-"), "state")
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(os.path.dirname(self.dir), ignore_errors=True)
+
+    def test_ota_psk_alone_counts_as_a_config_value(self):
+        # The headline flag must be able to provision on its own; previously
+        # has_config_value() rejected it before NVS generation.
+        args = _mk_args(ota_psk="a" * 64)
+        self.assertTrue(provision.has_config_value(args))
+
+    @unittest.skipIf(sys.platform == "win32", "POSIX symlink semantics")
+    def test_symlink_at_the_temp_path_cannot_capture_the_secret(self):
+        # The temp path is predictable. Without O_EXCL/O_NOFOLLOW, os.open with
+        # O_CREAT|O_TRUNC follows a planted symlink and writes the cleartext
+        # password through it. Asserting the *final* file mode does not catch
+        # this — the trailing chmod fixes that either way — so assert the victim
+        # never receives the secret.
+        os.makedirs(self.dir, mode=0o700, exist_ok=True)
+        victim = os.path.join(os.path.dirname(self.dir), "victim.txt")
+        with open(victim, "w", encoding="utf-8") as f:
+            f.write("original")
+        tmp = provision._state_path_for("COM7", self.dir) + ".tmp"
+        os.symlink(victim, tmp)
+
+        try:
+            provision.save_state("COM7", self.dir, {"password": "s3cret"})
+        except OSError:
+            pass  # refusing outright is an acceptable outcome
+
+        with open(victim, encoding="utf-8") as f:
+            self.assertEqual(f.read(), "original",
+                             "secret was written through a planted symlink")
+
+    @unittest.skipIf(sys.platform == "win32", "POSIX permission model only")
+    def test_read_path_repairs_permissions_left_by_an_earlier_version(self):
+        os.makedirs(self.dir, exist_ok=True)
+        provision.save_state("COM7", self.dir, {"password": "secret"})
+        # Simulate state written before this change.
+        os.chmod(self.dir, 0o755)
+        os.chmod(provision._state_path_for("COM7", self.dir), 0o644)
+        provision._harden_existing_state("COM7", self.dir)
+        self.assertEqual(os.stat(self.dir).st_mode & 0o777, 0o700)
+        self.assertEqual(
+            os.stat(provision._state_path_for("COM7", self.dir)).st_mode & 0o777, 0o600)
+
+    def test_harden_survives_a_chmod_failure(self):
+        # A read-only or exotic filesystem must warn, not abort provisioning.
+        missing = os.path.join(self.dir, "definitely-not-there.json")
+        provision._harden(missing, 0o600)  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/firmware/esp32-csi-node/tests/test_provision_state.py
+++ b/firmware/esp32-csi-node/tests/test_provision_state.py
@@ -127,3 +127,73 @@ class TestStatePathSanitization(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestStateFilePermissions(unittest.TestCase):
+    """Issue #1754: the state file holds the WiFi password in cleartext."""
+
+    def setUp(self):
+        self.dir = os.path.join(tempfile.mkdtemp(prefix="provision-perm-"), "state")
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(os.path.dirname(self.dir), ignore_errors=True)
+
+    @unittest.skipIf(sys.platform == "win32", "POSIX permission model only")
+    def test_state_file_is_owner_only(self):
+        path = provision.save_state("COM7", self.dir, {"ssid": "x", "password": "secret"})
+        self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+
+    @unittest.skipIf(sys.platform == "win32", "POSIX permission model only")
+    def test_state_dir_is_owner_only(self):
+        provision.save_state("COM7", self.dir, {"password": "secret"})
+        self.assertEqual(os.stat(self.dir).st_mode & 0o777, 0o700)
+
+    @unittest.skipIf(sys.platform == "win32", "POSIX permission model only")
+    def test_tightens_a_directory_left_by_an_earlier_version(self):
+        # makedirs cannot tighten an existing directory; an explicit chmod must.
+        os.makedirs(self.dir, exist_ok=True)
+        os.chmod(self.dir, 0o755)
+        provision.save_state("COM7", self.dir, {"password": "secret"})
+        self.assertEqual(os.stat(self.dir).st_mode & 0o777, 0o700)
+
+
+class TestChipIdentityBinding(unittest.TestCase):
+    """Issue #1755: port paths are reused when boards are swapped."""
+
+    def test_matches_when_identity_absent_on_either_side(self):
+        # Permissive: pre-existing state files carry no identity, and a board
+        # that will not answer must still be provisionable.
+        self.assertTrue(provision.identity_matches({}, "80:b5:4e:c1:b5:68"))
+        self.assertTrue(provision.identity_matches(
+            {provision.STATE_IDENTITY_KEY: "80:b5:4e:c1:b5:68"}, None))
+
+    def test_matches_same_board(self):
+        self.assertTrue(provision.identity_matches(
+            {provision.STATE_IDENTITY_KEY: "80:b5:4e:c1:b5:68"}, "80:b5:4e:c1:b5:68"))
+
+    def test_rejects_a_different_board_on_the_same_port(self):
+        self.assertFalse(provision.identity_matches(
+            {provision.STATE_IDENTITY_KEY: "80:b5:4e:c1:b5:68"}, "80:b5:4e:c1:c4:f0"))
+
+
+class TestOtaPskNamespace(unittest.TestCase):
+    """Issue #1753: the OTA PSK lives in its own `security` NVS namespace."""
+
+    def test_security_namespace_emitted_with_psk(self):
+        args = _mk_args(ssid="net", ota_psk="a" * 64)
+        csv_text = provision.build_nvs_csv(args)
+        self.assertIn("security,namespace", csv_text.replace(", ", ","))
+        self.assertIn("ota_psk", csv_text)
+
+    def test_no_security_namespace_without_psk(self):
+        args = _mk_args(ssid="net")
+        csv_text = provision.build_nvs_csv(args)
+        self.assertNotIn("security", csv_text)
+        self.assertNotIn("ota_psk", csv_text)
+
+    def test_csi_cfg_namespace_still_first(self):
+        args = _mk_args(ssid="net", ota_psk="b" * 64)
+        rows = [r.split(",") for r in provision.build_nvs_csv(args).strip().splitlines()]
+        namespaces = [r[0] for r in rows if len(r) > 1 and r[1] == "namespace"]
+        self.assertEqual(namespaces, ["csi_cfg", "security"])


### PR DESCRIPTION
Fixes #1753, #1754, #1755.

Three operator-safety defects found while provisioning three ESP32-S3 boards against v0.8.4 on real hardware.

## What changed

**#1754 — credential exposure.** The per-port state file holds the WiFi password in cleartext and was created with the process umask, landing `0644` on macOS and mainstream Linux (observed `0755`/`0644` on a real host). Directory is now `0700`, file `0600`, opened via `os.open` with the mode so the secret is never briefly world-readable. An explicit `chmod` covers directories left by earlier versions, since `makedirs` cannot tighten an existing one. `chmod` failures warn rather than abort, so a read-only or exotic filesystem still provisions.

**#1755 — cross-board state inheritance.** State is keyed by sanitised port path only, and port names are reused when boards are swapped. The board MAC is now recorded in the state file and checked before merging; a mismatch exits non-zero and points at `--reset`.

Deliberately permissive where it must be: unknown identity on **either** side still merges, so existing state files keep working after upgrade and a board that will not answer over serial is still provisionable exactly as before. `--state` remains read-only and skips the chip round-trip.

**#1753 — OTA unprovisionable.** `main/ota_update.c:39` documents `provision.py --ota-psk <hex>` as the way to set the PSK without a reflash, but the flag did not exist and nothing wrote the `security` namespace — so every node rejected all OTA uploads (verified: HTTP 403 on a live v0.8.4 node). The flag now emits `security`/`ota_psk` alongside `csi_cfg`, validated against the firmware's own constraints (hex, ≤64 chars per `OTA_PSK_MAX_LEN`).

## Testing

23 tests pass (9 added). Each new test was confirmed to **fail with its fix reverted**, so they bind to the behaviour rather than passing incidentally:

| control | result |
|---|---|
| revert permissions to default `open()` | 3 failures |
| revert identity check to always-match | 1 failure |
| revert `security` namespace emission | 2 failures |
| all fixes restored | 23 pass |

## Notes for review

- The identity key is `_chip_mac`, underscore-prefixed so it cannot collide with an NVS key.
- `--ota-psk` is added to `MERGEABLE_ATTRS`, so it persists like other settings. If you would rather the PSK were **not** written to a state file at all, say so and I will make it invocation-only — that is a policy call, and #1754 makes the file owner-only either way.
- I have not changed the `OTA=ready` boot log line, which reports only that the HTTP server started. Mentioned in #1753 as a separate call.

Found during a hardware testing session against v0.8.4 with three ESP32-S3 nodes.