### PR TITLE
fix(ci): publish every firmware variant to the release, not just 8mb

### DIFF
--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -64,6 +64,8 @@ jobs:
             size_limit_kb: 1152
             artifact_app: esp32-csi-node-4mb.bin
             artifact_pt: partition-table-4mb.bin
+            artifact_bootloader: bootloader-4mb.bin
+            artifact_otadata: ota_data_initial-4mb.bin
           # ADR-110: ESP32-C6 research target (Wi-Fi 6 / 802.15.4 / TWT / LP-core)
           - variant: c6-4mb
             target: esp32c6
@@ -73,6 +75,8 @@ jobs:
             size_limit_kb: 1152
             artifact_app: esp32-csi-node-c6.bin
             artifact_pt: partition-table-c6.bin
+            artifact_bootloader: bootloader-c6.bin
+            artifact_otadata: ota_data_initial-c6.bin
 
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -162,10 +166,18 @@ jobs:
           mkdir -p release-staging
           cp build/esp32-csi-node.bin                      release-staging/${{ matrix.artifact_app }}
           cp build/partition_table/partition-table.bin     release-staging/${{ matrix.artifact_pt }}
+          # Every variant needs a bootloader and initial OTA data to flash a
+          # blank board; staging them only for 8mb left the C6 artifacts
+          # unflashable (RuView#1757). The 8mb names are unchanged so existing
+          # docs and scripts keep working.
           if [ "${{ matrix.variant }}" = "8mb" ]; then
             cp build/bootloader/bootloader.bin             release-staging/bootloader.bin
             cp build/ota_data_initial.bin                  release-staging/ota_data_initial.bin
+          else
+            cp build/bootloader/bootloader.bin             release-staging/${{ matrix.artifact_bootloader }}
+            cp build/ota_data_initial.bin                  release-staging/${{ matrix.artifact_otadata }}
           fi
+          ( cd release-staging && sha256sum -- * > SHA256SUMS-${{ matrix.variant }}.txt )
           ls -la release-staging/
 
       - name: Check QEMU ESP32-S3 support status
@@ -180,3 +192,32 @@ jobs:
           name: esp32-csi-node-firmware-${{ matrix.variant }}
           path: firmware/esp32-csi-node/release-staging/
           retention-days: 90
+
+  # RuView#1757: the build matrix produced C6 artifacts on every tag but nothing
+  # ever attached them to the release, so the newest published C6 firmware was
+  # v0.8.0 while S3 shipped v0.8.4. Release assets were being uploaded by hand,
+  # which is why one variant could be forgotten. Attach every variant the matrix
+  # built, from the artifacts it already uploads.
+  release:
+    name: Attach firmware artifacts to the release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-esp32')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download every variant's staged binaries
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          pattern: esp32-csi-node-firmware-*
+          path: artifacts
+
+      - name: List what will be attached
+        run: find artifacts -type f | sort
+
+      - name: Attach to release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: artifacts/**/*
+          fail_on_unmatched_files: true

--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -200,7 +200,10 @@ jobs:
   # built, from the artifacts it already uploads.
   release:
     name: Attach firmware artifacts to the release
-    needs: build
+    # Must need version-guard as well as build: they run in parallel, so
+    # depending on build alone would let a tag that FAILED the
+    # version.txt-matches-tag check still publish a release.
+    needs: [version-guard, build]
     if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-esp32')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Fixes #1757.

## The problem

The build matrix has produced ESP32-C6 artifacts on every firmware tag since v0.8.0 — and C6 is the only variant that *additionally* builds and runs the ADR-110 host tests — yet no C6 asset has been published since v0.8.0. The v0.8.4 notes say "ESP32-C6 all passed" while the release carries only the S3 8mb binary. A C6 operator's newest downloadable firmware is four minor versions behind, missing the v0.8.4 calibration fixes.

## Root cause

`firmware-ci.yml` never attached anything to a release. It uploads 90-day Actions artifacts only, so release assets were being attached **by hand** — `v0.8.4` assets show `uploader=ruvnet`. That is why one variant can be silently forgotten. `ci.yml` and `desktop-release.yml` already automate release uploads; firmware did not.

## Changes

**1. Stage a bootloader + initial OTA data for every variant.** Previously only `8mb` got them, so the C6 artifacts could not flash a blank board even if published. The `8mb` asset names are deliberately **unchanged** so existing docs and scripts keep working; other variants get suffixed names (`bootloader-c6.bin`, `ota_data_initial-c6.bin`). Each variant also emits `SHA256SUMS-<variant>.txt`, matching what the S3 release currently publishes by hand.

**2. Add a `release` job** gated on a `v*-esp32` tag that downloads every variant's staged binaries and attaches them, with `fail_on_unmatched_files: true` so a missing variant fails loudly instead of shipping a partial release. Uses the same pinned `softprops` action already used by `desktop-release.yml`, and a `download-artifact` SHA already pinned elsewhere in this repo.

## Verification

I built v0.8.4 for C6 locally using the exact CI toolchain and recipe (`espressif/idf:v5.4`, `idf.py set-target esp32c6`, `idf.py build`, no config changes — the `sdkconfig.defaults.esp32c6` overlay is auto-applied and pins `partitions_4mb.csv` itself):

| check | result |
|---|---|
| binary size (budget warn 1100 KB / fail 1152 KB) | 1,051,008 B = **1026 KB** |
| ADR-110 host unit tests | **21 passed, 0 failed** |
| app descriptor | version `0.8.4`, project `esp32-csi-node`, idf `v5.4` — identical to the published S3 image |

So the artifact this job would attach is known good.

`actionlint` clean on the change. The one remaining `SC2086` at line 88 is pre-existing and untouched.

## Note for review

`fail_on_unmatched_files: true` is deliberate — a release that silently ships fewer variants than it built is the bug being fixed. If you would rather it warn, that is a one-word change.