### PR TITLE
chore(forecast): bump ruforecast submodule to governance/spend enforcement fix

### DIFF
--- a/docs/adr/ADR-354-forecast-governance-enforcement-in-ruforecast-submodule.md
+++ b/docs/adr/ADR-354-forecast-governance-enforcement-in-ruforecast-submodule.md
@@ -1,0 +1,89 @@
+# ADR-354: fal.ai forecast governance and spend enforcement now real, in the vendored RuForecast submodule
+
+- **Status**: Accepted
+- **Date**: 2026-09-02
+- **Deciders**: ruv
+- **Owners**: RuView forecast training, security, and release maintainers
+- **Tags**: forecasting, training, fal, governance, submodule, cost-control
+- **Parent**: ADR-349
+- **Extends**: ADR-348, ADR-349
+- **Supersedes**: None
+
+## Decision
+
+ADR-349 specified two governance controls for RuView Forecast's fal.ai
+hosted path: operator-verified dataset/schema/policy/recipe authorization,
+and an explicit local spend-approval record bound to the request digest and
+maximum units. A 9-agent code review of the training stack merged as PR
+#1766 found that neither control was actually wired into the code path that
+builds a submittable, fal-destined training contract — `FalGovernanceVerifier`
+existed with zero callers outside its own tests, and no spend-approval type
+existed anywhere in the codebase.
+
+That code no longer lives directly in this repository. Between the review
+and this fix, `v2/crates/ruview-forecast-{core,model,train}` was extracted
+into its own repository, `github.com/ruvnet/RuForecast`, and is now vendored
+back into `v2/crates/ruforecast` as a git submodule (crates renamed to
+`ruforecast-{core,model,train}`). This ADR records two things at the RuView
+level:
+
+1. **The governance and spend-approval gaps are fixed**, in
+   `ruvnet/RuForecast` PR #2 (branch `fix/governance-and-spend-enforcement`).
+   The full technical decision record — what changed, why, and the
+   requirements/acceptance table — lives in that repository's own
+   [ADR-350](https://github.com/ruvnet/RuForecast/blob/main/docs/adr/ADR-350-fal-governance-and-spend-enforcement.md),
+   which this ADR defers to rather than duplicating. In summary: a
+   fal-destined `TrainSpec` can no longer be constructed without a real,
+   operator-signed, single-use-verified governance receipt; a hosted
+   reservation can no longer be built without a real, operator-signed spend
+   approval bound to the exact request digest and cost ceiling; and several
+   related correctness/resilience gaps on the same trust boundary
+   (unauthenticated Direct Server webhook, no execution timeout, mismatched
+   local/hosted artifact budgets, cancellation permanently wedging a job)
+   were fixed in the same pass.
+2. **The submodule pointer in this repository is bumped** to the commit
+   containing that fix, once `ruvnet/RuForecast`'s own CI is green on that
+   PR and it merges. This RuView-side change is deliberately small: a
+   pointer bump plus this ADR, not a re-implementation or re-review of code
+   that now lives, is tested, and is reviewed in its own repository.
+
+## Context
+
+RuView's own copies of ADR-348 and ADR-349 predate the extraction and still
+describe the crates as if they lived directly under `v2/crates/`. They are
+left as-is here (not corrected path-by-path) since the canonical, actively
+maintained copies of the forecast-specific ADRs now live in
+`ruvnet/RuForecast`'s own `docs/adr/`, which was seeded with copies of
+ADR-348/349 at extraction time and now also carries ADR-350. Consult that
+repository for the forecast subsystem's own decision history going forward;
+this repository's ADR series should record RuView-level integration
+decisions about the vendored submodule (like this one), not attempt to
+re-host the submodule's internal history.
+
+This repo's CLAUDE.md requires an ADR for load-bearing upstream changes.
+The governance-enforcement fix is load-bearing for RuView even though none
+of its source lines are: it changes what RuView's vendored forecast
+subsystem actually requires before it will reach real, billable fal.ai
+infrastructure on behalf of a RuView deployment.
+
+## Consequences
+
+Once the submodule pointer here is bumped, any RuView-side code, CLI
+wrapper, or documentation that assumes the old, unenforced fal.ai
+submission path (a bare `SourceState::synthetic` claim with no verified
+governance receipt or spend approval) will no longer compile or run against
+the vendored crate — `TrainSpec::new_fal_synthetic` and
+`ReservedSyntheticSubmission::reserve` both gained new required parameters.
+A repository-wide search found no such RuView-side caller today; this ADR
+records the change in case one is added later without checking the
+submodule's current API first.
+
+This pointer bump must not merge before `ruvnet/RuForecast` PR #2 merges and
+its CI is green — see that PR for status.
+
+## References
+
+- [ADR-349](./ADR-349-governed-local-and-fal-forecast-training.md) (this repository's copy; canonical copy is in `ruvnet/RuForecast`)
+- [ruvnet/RuForecast PR #2](https://github.com/ruvnet/RuForecast/pull/2)
+- [ruvnet/RuForecast ADR-350](https://github.com/ruvnet/RuForecast/blob/main/docs/adr/ADR-350-fal-governance-and-spend-enforcement.md)
+- [`v2/crates/ruforecast`](../../v2/crates/ruforecast) (submodule)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,6 +95,7 @@ Statuses: **Proposed** (under discussion), **Accepted** (approved and/or impleme
 | [ADR-348](ADR-348-independent-rust-multivariate-forecasting.md) | Independent Rust multivariate forecasting for RuView | Proposed |
 | [ADR-349](ADR-349-governed-local-and-fal-forecast-training.md) | Governed local and fal.ai forecast training | Proposed |
 | [ADR-350](ADR-350-ruvector-predictive-memory-and-ruvllm-boundary.md) | RuVector predictive memory and RuVLLM authority boundary | Proposed |
+| [ADR-354](ADR-354-forecast-governance-enforcement-in-ruforecast-submodule.md) | fal.ai forecast governance and spend enforcement now real, in the vendored RuForecast submodule | Accepted |
 
 ### Platform and UI
 


### PR DESCRIPTION
## Summary

- Bumps the `v2/crates/ruforecast` submodule pointer to `ruvnet/RuForecast@a802067f` — the tip of [ruvnet/RuForecast PR #2](https://github.com/ruvnet/RuForecast/pull/2), which closes 14 code-review findings against the forecast training stack merged as #1766.
- The most important of those: ADR-349 specified that the fal.ai hosted path requires operator-verified governance and an explicit spend-approval record before submission, but the code that shipped in #1766 never actually enforced either. It does now — see [RuForecast's ADR-350](https://github.com/ruvnet/RuForecast/blob/main/docs/adr/ADR-350-fal-governance-and-spend-enforcement.md) for the full record.
- Adds ADR-354 in this repo recording this as a RuView-level integration decision (the submodule is now the source of truth for the forecast subsystem's own decision history, not this repo).
- Confirmed no other RuView `v2/` crate calls the changed APIs (`TrainSpec::new_fal_synthetic`, `ReservedSyntheticSubmission::reserve`, `synthetic_train_spec`, `server::router`) — `ruforecast-autogenous-bridge` was the only other `v2/` crate referencing `ruforecast*` in its manifest, and it doesn't actually depend on `ruforecast-core`/`-train` (it's an unrelated, local-dev-only, unpublished-dependency bridge).

## Draft / dependency note

Opening as **draft**: this must not merge before `ruvnet/RuForecast#2` merges with green CI. That PR's CI was broken (silently never running) since the RuForecast extraction; also fixed as part of it. Will mark ready for review once RuForecast#2 is merged.

## Test plan

- [x] `git diff v2/crates/ruforecast` shows the expected pointer bump only
- [x] Confirmed no `v2/` workspace crate depends on the changed submodule APIs
- [ ] Blocked on ruvnet/RuForecast#2: merge that first, then re-verify this pointer still resolves to its merge commit (may need to update to the actual merge SHA if it differs from a802067f after squash/rebase merge)
