### PR TITLE
C6: null-calibrated presence and recovery health diagnostics

### DIFF
--- a/firmware/esp32-csi-node/main/c6_lp_core.c
+++ b/firmware/esp32-csi-node/main/c6_lp_core.c
@@ -13,7 +13,7 @@
  *      `ulp_embed_binary(...)` in main/CMakeLists.txt from lp_core/main.c.
  *
  *   2. DISABLED — falls back to plain deep-sleep + GPIO wake-up
- *      (`esp_deep_sleep_enable_gpio_wakeup`). No debounce, no
+ *      (ESP-IDF deep-sleep GPIO wake API). No debounce, no
  *      sub-10 µA floor, but no LP toolchain dependency either.
  *      This is the path the v0.6.6 firmware shipped with.
  *
@@ -26,6 +26,7 @@
 #if defined(CONFIG_IDF_TARGET_ESP32C6) && defined(CONFIG_ULP_COPROC_TYPE_LP_CORE)
 
 #include "c6_lp_core.h"
+#include "esp_idf_version.h"
 #include "esp_log.h"
 #include "esp_sleep.h"
 #include "driver/rtc_io.h"
@@ -134,10 +135,17 @@ esp_err_t c6_lp_core_arm(int wake_gpio, bool active_high)
 #else
     /* --- Fallback path: plain deep-sleep GPIO wakeup (~10 µA floor) --- */
     uint64_t mask = 1ULL << wake_gpio;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    esp_sleep_gpio_wake_up_mode_t mode = active_high
+        ? ESP_GPIO_WAKEUP_GPIO_HIGH
+        : ESP_GPIO_WAKEUP_GPIO_LOW;
+    esp_err_t err = esp_sleep_enable_gpio_wakeup_on_hp_periph_powerdown(mask, mode);
+#else
     esp_deepsleep_gpio_wake_up_mode_t mode = active_high
         ? ESP_GPIO_WAKEUP_GPIO_HIGH
         : ESP_GPIO_WAKEUP_GPIO_LOW;
     esp_err_t err = esp_deep_sleep_enable_gpio_wakeup(mask, mode);
+#endif
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "enable_gpio_wakeup failed: %s", esp_err_to_name(err));
         return err;

--- a/firmware/esp32-csi-node/main/main.c
+++ b/firmware/esp32-csi-node/main/main.c
@@ -59,7 +59,7 @@ nvs_config_t g_nvs_config;
 
 static EventGroupHandle_t s_wifi_event_group;
 static int s_retry_num = 0;
-#define MAX_RETRY 10
+#define MAX_RETRY 90
 
 static void event_handler(void *arg, esp_event_base_t event_base,
                           int32_t event_id, void *event_data)
@@ -72,14 +72,17 @@ static void event_handler(void *arg, esp_event_base_t event_base,
         if (s_retry_num < MAX_RETRY) {
             esp_wifi_connect();
             s_retry_num++;
+            rv_radio_health_note_disconnect(disc->reason, disc->rssi, (uint16_t)s_retry_num);
             ESP_LOGI(TAG, "Retrying WiFi connection (%d/%d)", s_retry_num, MAX_RETRY);
         } else {
+            rv_radio_health_note_disconnect(disc->reason, disc->rssi, MAX_RETRY);
             xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
         }
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
         ESP_LOGI(TAG, "Got IP: " IPSTR, IP2STR(&event->ip_info.ip));
         s_retry_num = 0;
+        rv_radio_health_note_connected();
         xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
     }
 }

--- a/firmware/esp32-csi-node/main/rv_mesh.c
+++ b/firmware/esp32-csi-node/main/rv_mesh.c
@@ -218,6 +218,14 @@ esp_err_t rv_mesh_send_health(uint8_t role, uint32_t epoch,
             st.current_bw      = h.current_bw_mhz;
             st.noise_floor_dbm = h.noise_floor_dbm;
             st.pkt_yield       = h.pkt_yield_per_sec;
+            st.send_fail_count = h.send_fail_count;
+            st.wifi_retry_count = h.wifi_retry_count;
+            st.association_epoch = h.association_epoch;
+            st.free_heap_bytes = h.free_heap_bytes;
+            st.last_disconnect_reason = h.last_disconnect_reason;
+            st.reset_reason = h.reset_reason;
+            st.last_disconnect_rssi_dbm = h.last_disconnect_rssi_dbm;
+            memcpy(st.bssid, h.bssid, sizeof(st.bssid));
         }
     }
 

--- a/firmware/esp32-csi-node/main/rv_mesh.h
+++ b/firmware/esp32-csi-node/main/rv_mesh.h
@@ -100,10 +100,19 @@ typedef struct __attribute__((packed)) {
     uint16_t sync_error_us;   /**< Absolute drift vs. anchor. */
     uint16_t health_flags;
     uint16_t reserved;
+    uint16_t send_fail_count;
+    uint16_t wifi_retry_count;
+    uint32_t association_epoch;
+    uint32_t free_heap_bytes;
+    uint16_t last_disconnect_reason;
+    uint8_t  reset_reason;
+    int8_t   last_disconnect_rssi_dbm;
+    uint8_t  bssid[6];
+    uint16_t extended_reserved;
 } rv_node_status_t;
 
-_Static_assert(sizeof(rv_node_status_t) == 28,
-               "rv_node_status_t must be 28 bytes");
+_Static_assert(sizeof(rv_node_status_t) == 52,
+               "rv_node_status_t must be 52 bytes");
 
 /* ---- TIME_SYNC payload ---- */
 

--- a/firmware/esp32-csi-node/main/rv_radio_ops.h
+++ b/firmware/esp32-csi-node/main/rv_radio_ops.h
@@ -63,8 +63,18 @@ typedef struct {
     uint8_t  current_channel;     /**< Channel currently configured. */
     uint8_t  current_bw_mhz;      /**< Bandwidth currently configured. */
     uint8_t  current_profile;     /**< Active rv_capture_profile_t. */
-    uint8_t  reserved;
+    uint8_t  reset_reason;        /**< esp_reset_reason_t captured at boot. */
+    uint16_t wifi_retry_count;    /**< Current consecutive STA retry count. */
+    uint16_t last_disconnect_reason; /**< Latest wifi_err_reason_t, zero if none. */
+    int8_t   last_disconnect_rssi_dbm;
+    uint8_t  bssid[6];            /**< Current or last associated AP BSSID. */
+    uint32_t association_epoch;   /**< Increments after each acquired STA IP. */
+    uint32_t free_heap_bytes;     /**< Current free internal heap. */
 } rv_radio_health_t;
+
+/** Record station lifecycle telemetry from the application Wi-Fi handler. */
+void rv_radio_health_note_disconnect(uint16_t reason, int8_t rssi, uint16_t retry_count);
+void rv_radio_health_note_connected(void);
 
 /* ---- The vtable ---- */
 

--- a/firmware/esp32-csi-node/main/rv_radio_ops_esp32.c
+++ b/firmware/esp32-csi-node/main/rv_radio_ops_esp32.c
@@ -18,7 +18,9 @@
 #include <string.h>
 #include "esp_err.h"
 #include "esp_log.h"
+#include "esp_system.h"
 #include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
 
 static const char *TAG = "rv_radio_esp32";
 
@@ -43,6 +45,36 @@ static uint8_t  s_current_bw      = 20;
 static uint8_t  s_current_profile = RV_PROFILE_PASSIVE_LOW_RATE;
 static uint8_t  s_current_mode    = RV_RADIO_MODE_PASSIVE_RX;
 static bool     s_csi_enabled     = true;
+static uint16_t s_wifi_retry_count = 0;
+static uint16_t s_last_disconnect_reason = 0;
+static int8_t   s_last_disconnect_rssi_dbm = 0;
+static uint8_t  s_last_bssid[6] = {0};
+static uint32_t s_association_epoch = 0;
+static portMUX_TYPE s_health_lock = portMUX_INITIALIZER_UNLOCKED;
+
+void rv_radio_health_note_disconnect(uint16_t reason, int8_t rssi, uint16_t retry_count)
+{
+    portENTER_CRITICAL(&s_health_lock);
+    s_last_disconnect_reason = reason;
+    s_last_disconnect_rssi_dbm = rssi;
+    s_wifi_retry_count = retry_count;
+    portEXIT_CRITICAL(&s_health_lock);
+}
+
+void rv_radio_health_note_connected(void)
+{
+    wifi_ap_record_t ap = {0};
+    portENTER_CRITICAL(&s_health_lock);
+    s_wifi_retry_count = 0;
+    s_association_epoch++;
+    portEXIT_CRITICAL(&s_health_lock);
+    if (esp_wifi_sta_get_ap_info(&ap) == ESP_OK) {
+        portENTER_CRITICAL(&s_health_lock);
+        memcpy(s_last_bssid, ap.bssid, sizeof(s_last_bssid));
+        s_current_channel = ap.primary;
+        portEXIT_CRITICAL(&s_health_lock);
+    }
+}
 
 /* ---- Vtable implementations ---- */
 
@@ -147,10 +179,22 @@ static int esp32_get_health(rv_radio_health_t *out)
     out->current_channel   = s_current_channel;
     out->current_bw_mhz    = s_current_bw;
     out->current_profile   = s_current_profile;
+    out->reset_reason      = (uint8_t)esp_reset_reason();
+    out->free_heap_bytes   = esp_get_free_heap_size();
+
+    portENTER_CRITICAL(&s_health_lock);
+    out->wifi_retry_count = s_wifi_retry_count;
+    out->last_disconnect_reason = s_last_disconnect_reason;
+    out->last_disconnect_rssi_dbm = s_last_disconnect_rssi_dbm;
+    out->association_epoch = s_association_epoch;
+    memcpy(out->bssid, s_last_bssid, sizeof(out->bssid));
+    portEXIT_CRITICAL(&s_health_lock);
 
     wifi_ap_record_t ap = {0};
     if (esp_wifi_sta_get_ap_info(&ap) == ESP_OK) {
         out->rssi_median_dbm = ap.rssi;
+        out->current_channel = ap.primary;
+        memcpy(out->bssid, ap.bssid, sizeof(out->bssid));
     }
     return ESP_OK;
 }

--- a/firmware/esp32-csi-node/tests/hardware/test_wifi_recovery_harness.py
+++ b/firmware/esp32-csi-node/tests/hardware/test_wifi_recovery_harness.py
@@ -1,0 +1,80 @@
+import unittest
+
+from wifi_recovery_harness import evaluate_scenario
+
+
+def node(node_id, *, status="active", uptime_ms=100_000, association_epoch=1, channel=1):
+    return {
+        "node_id": node_id,
+        "status": status,
+        "health": {
+            "extended": True,
+            "uptime_ms": uptime_ms,
+            "association_epoch": association_epoch,
+            "channel": channel,
+        },
+    }
+
+
+def capture(at_ms, nodes, *, server_reachable=True, ap_uptime=None):
+    return {
+        "captured_at_unix_ms": at_ms,
+        "server_reachable": server_reachable,
+        "nodes": nodes,
+        "ap_uptime_seconds": ap_uptime,
+    }
+
+
+class WifiRecoveryEvidenceTests(unittest.TestCase):
+    def test_ap_outage_longer_than_initial_retry_window_recovers_without_node_reset(self):
+        evidence = {
+            "before": capture(0, [node(11), node(12), node(13)]),
+            "during": capture(100_000, [node(11, status="stale"), node(12, status="stale"), node(13, status="stale")]),
+            "after": capture(130_000, [
+                node(11, uptime_ms=230_000, association_epoch=2),
+                node(12, uptime_ms=230_000, association_epoch=2),
+                node(13, uptime_ms=230_000, association_epoch=2),
+            ]),
+        }
+        result = evaluate_scenario("ap-outage", evidence, expected_nodes={11, 12, 13}, minimum_outage_seconds=90)
+        self.assertTrue(result["passed"])
+
+    def test_ap_reboot_and_channel_change_requires_uptime_reset_and_new_channel(self):
+        evidence = {
+            "before": capture(0, [node(11), node(12), node(13)], ap_uptime=3_600),
+            "during": capture(20_000, [
+                node(11, status="stale"), node(12, status="stale"), node(13, status="stale"),
+            ], server_reachable=True, ap_uptime=None),
+            "after": capture(60_000, [
+                node(11, uptime_ms=160_000, association_epoch=2, channel=6),
+                node(12, uptime_ms=160_000, association_epoch=2, channel=6),
+                node(13, uptime_ms=160_000, association_epoch=2, channel=6),
+            ], ap_uptime=25),
+        }
+        result = evaluate_scenario("ap-reboot-channel", evidence, expected_nodes={11, 12, 13}, expected_channel=6)
+        self.assertTrue(result["passed"])
+
+    def test_helper_restart_or_closed_udp_keeps_association_epoch_and_node_uptime(self):
+        evidence = {
+            "before": capture(0, [node(11), node(12), node(13)]),
+            "during": capture(30_000, [], server_reachable=False),
+            "after": capture(45_000, [
+                node(11, uptime_ms=145_000), node(12, uptime_ms=145_000), node(13, uptime_ms=145_000),
+            ]),
+        }
+        result = evaluate_scenario("helper-restart", evidence, expected_nodes={11, 12, 13})
+        self.assertTrue(result["passed"])
+
+    def test_stale_to_active_rejects_a_usb_reset_disguised_as_recovery(self):
+        evidence = {
+            "before": capture(0, [node(11, uptime_ms=500_000)]),
+            "during": capture(15_000, [node(11, status="stale", uptime_ms=515_000)]),
+            "after": capture(30_000, [node(11, uptime_ms=5_000, association_epoch=1)]),
+        }
+        result = evaluate_scenario("stale-active", evidence, expected_nodes={11})
+        self.assertFalse(result["passed"])
+        self.assertIn("node 11 uptime moved backwards", result["failures"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/firmware/esp32-csi-node/tests/hardware/wifi_recovery_harness.py
+++ b/firmware/esp32-csi-node/tests/hardware/wifi_recovery_harness.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Evidence-gated ESP32 Wi-Fi recovery checks.
+
+This harness observes RuView and an optional AP status endpoint. It never
+changes AP, helper, USB, serial, or firmware state; the operator performs the
+named fault between phase captures. A passing recovery requires monotonic node
+uptime so a USB/power reset cannot masquerade as automatic recovery.
+"""
+
+import argparse
+import json
+import os
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+SCENARIOS = {"ap-outage", "ap-reboot-channel", "helper-restart", "stale-active"}
+PHASES = ("before", "during", "after")
+MAX_HTTP_BYTES = 512 * 1024
+MAX_SESSION_BYTES = 2 * 1024 * 1024
+
+
+def _nodes_by_id(capture):
+    return {
+        int(item["node_id"]): item
+        for item in capture.get("nodes", [])
+        if isinstance(item, dict) and isinstance(item.get("node_id"), int)
+    }
+
+
+def evaluate_scenario(scenario, evidence, *, expected_nodes, minimum_outage_seconds=90, expected_channel=None):
+    if scenario not in SCENARIOS:
+        raise ValueError(f"unsupported scenario: {scenario}")
+    failures = []
+    for phase in PHASES:
+        if phase not in evidence:
+            failures.append(f"missing {phase} capture")
+    if failures:
+        return {"passed": False, "scenario": scenario, "failures": failures}
+
+    before = evidence["before"]
+    during = evidence["during"]
+    after = evidence["after"]
+    before_nodes = _nodes_by_id(before)
+    during_nodes = _nodes_by_id(during)
+    after_nodes = _nodes_by_id(after)
+
+    for node_id in sorted(expected_nodes):
+        before_node = before_nodes.get(node_id)
+        after_node = after_nodes.get(node_id)
+        if not before_node or before_node.get("status") != "active":
+            failures.append(f"node {node_id} was not active before fault")
+            continue
+        if not after_node or after_node.get("status") != "active":
+            failures.append(f"node {node_id} did not recover active")
+            continue
+        before_health = before_node.get("health") or {}
+        after_health = after_node.get("health") or {}
+        if before_health.get("extended") is not True or after_health.get("extended") is not True:
+            failures.append(f"node {node_id} lacks extended HEALTH evidence")
+            continue
+        before_uptime = before_health.get("uptime_ms")
+        after_uptime = after_health.get("uptime_ms")
+        if not isinstance(before_uptime, int) or not isinstance(after_uptime, int):
+            failures.append(f"node {node_id} uptime is unavailable")
+        elif after_uptime < before_uptime:
+            failures.append(f"node {node_id} uptime moved backwards")
+
+        before_epoch = before_health.get("association_epoch")
+        after_epoch = after_health.get("association_epoch")
+        if scenario == "helper-restart" and after_epoch != before_epoch:
+            failures.append(f"node {node_id} association changed during helper restart")
+        if scenario in {"ap-outage", "ap-reboot-channel"} and (
+            not isinstance(before_epoch, int) or not isinstance(after_epoch, int) or after_epoch <= before_epoch
+        ):
+            failures.append(f"node {node_id} did not report a new association epoch")
+        if expected_channel is not None and after_health.get("channel") != expected_channel:
+            failures.append(f"node {node_id} did not recover on channel {expected_channel}")
+
+    if scenario != "helper-restart":
+        for node_id in sorted(expected_nodes):
+            if during_nodes.get(node_id, {}).get("status") != "stale":
+                failures.append(f"node {node_id} was not observed stale during fault")
+    elif during.get("server_reachable") is not False:
+        failures.append("helper was not observed unavailable during restart")
+
+    if scenario == "ap-outage":
+        elapsed_ms = during.get("captured_at_unix_ms", 0) - before.get("captured_at_unix_ms", 0)
+        if elapsed_ms < minimum_outage_seconds * 1_000:
+            failures.append(f"AP outage evidence is shorter than {minimum_outage_seconds} seconds")
+
+    if scenario == "ap-reboot-channel":
+        before_ap = before.get("ap_uptime_seconds")
+        after_ap = after.get("ap_uptime_seconds")
+        if not isinstance(before_ap, int) or not isinstance(after_ap, int) or after_ap >= before_ap:
+            failures.append("AP uptime did not prove a reboot")
+        if expected_channel is None:
+            failures.append("expected channel is required for AP reboot/channel test")
+
+    return {"passed": not failures, "scenario": scenario, "failures": failures}
+
+
+def _read_json_url(url):
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=3) as response:
+        content_length = response.headers.get("Content-Length")
+        if content_length and int(content_length) > MAX_HTTP_BYTES:
+            raise ValueError("HTTP response exceeds evidence cap")
+        data = response.read(MAX_HTTP_BYTES + 1)
+    if len(data) > MAX_HTTP_BYTES:
+        raise ValueError("HTTP response exceeds evidence cap")
+    return json.loads(data)
+
+
+def capture_phase(server_url, ap_info_url=None):
+    capture = {
+        "captured_at_unix_ms": int(time.time() * 1_000),
+        "server_reachable": False,
+        "nodes": [],
+        "ap_uptime_seconds": None,
+    }
+    try:
+        payload = _read_json_url(f"{server_url.rstrip('/')}/api/v1/nodes")
+        nodes = payload.get("nodes", [])
+        if not isinstance(nodes, list) or len(nodes) > 256:
+            raise ValueError("invalid node inventory")
+        capture["nodes"] = nodes
+        capture["server_reachable"] = True
+    except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError):
+        pass
+    if ap_info_url:
+        try:
+            payload = _read_json_url(ap_info_url)
+            uptime = payload.get("data", {}).get("uptime")
+            if isinstance(uptime, int) and uptime >= 0:
+                capture["ap_uptime_seconds"] = uptime
+        except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError):
+            pass
+    return capture
+
+
+def _load_session(session_path):
+    if not session_path.exists():
+        return {"schema": "ruview.hardware.wifi-recovery.v1", "captures": {}}
+    if session_path.stat().st_size > MAX_SESSION_BYTES:
+        raise ValueError("session evidence exceeds 2 MiB")
+    value = json.loads(session_path.read_text(encoding="utf-8"))
+    if value.get("schema") != "ruview.hardware.wifi-recovery.v1" or not isinstance(value.get("captures"), dict):
+        raise ValueError("invalid session evidence schema")
+    return value
+
+
+def _write_session(session_path, value):
+    data = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if len(data) > MAX_SESSION_BYTES:
+        raise ValueError("session evidence exceeds 2 MiB")
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=".wifi-recovery-", dir=str(session_path.parent))
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+        os.chmod(temporary_name, 0o600)
+        os.replace(temporary_name, session_path)
+    finally:
+        if os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    capture_parser = subparsers.add_parser("capture")
+    capture_parser.add_argument("--phase", choices=PHASES, required=True)
+    capture_parser.add_argument("--session", type=Path, required=True)
+    capture_parser.add_argument("--server-url", default="http://127.0.0.1:3000")
+    capture_parser.add_argument("--ap-info-url")
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("--scenario", choices=sorted(SCENARIOS), required=True)
+    verify_parser.add_argument("--session", type=Path, required=True)
+    verify_parser.add_argument("--nodes", required=True, help="comma-separated node IDs")
+    verify_parser.add_argument("--minimum-outage-seconds", type=int, default=90)
+    verify_parser.add_argument("--expected-channel", type=int)
+    arguments = parser.parse_args()
+
+    if arguments.command == "capture":
+        session = _load_session(arguments.session)
+        session["captures"][arguments.phase] = capture_phase(arguments.server_url, arguments.ap_info_url)
+        _write_session(arguments.session, session)
+        print(json.dumps(session["captures"][arguments.phase], sort_keys=True))
+        return
+
+    expected_nodes = {int(value) for value in arguments.nodes.split(",") if value.strip()}
+    if not expected_nodes or any(node_id < 1 or node_id > 255 for node_id in expected_nodes):
+        parser.error("--nodes must contain IDs in 1..255")
+    session = _load_session(arguments.session)
+    result = evaluate_scenario(
+        arguments.scenario,
+        session["captures"],
+        expected_nodes=expected_nodes,
+        minimum_outage_seconds=arguments.minimum_outage_seconds,
+        expected_channel=arguments.expected_channel,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    raise SystemExit(0 if result["passed"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/firmware/esp32-csi-node/tests/host/test_rv_mesh.c
+++ b/firmware/esp32-csi-node/tests/host/test_rv_mesh.c
@@ -38,6 +38,15 @@ static void test_encode_health_roundtrip(void) {
     st.noise_floor_dbm  = -93;
     st.pkt_yield        = 42;
     st.sync_error_us    = 12;
+    st.send_fail_count  = 3;
+    st.wifi_retry_count = 4;
+    st.association_epoch = 12;
+    st.free_heap_bytes  = 182640;
+    st.last_disconnect_reason = 200;
+    st.reset_reason     = 3;
+    st.last_disconnect_rssi_dbm = -81;
+    const uint8_t bssid[6] = {0xD4, 0xA0, 0xFB, 0x40, 0x01, 0x58};
+    memcpy(st.bssid, bssid, sizeof(bssid));
 
     uint8_t buf[RV_MESH_MAX_FRAME_BYTES];
     size_t n = rv_mesh_encode_health(RV_ROLE_OBSERVER, /*epoch*/ 100,

--- a/v2/crates/wifi-densepose-hardware/src/radio_ops.rs
+++ b/v2/crates/wifi-densepose-hardware/src/radio_ops.rs
@@ -138,6 +138,8 @@ impl RadioOps for MockRadio {
 
 /// `RV_MESH_MAGIC` from rv_mesh.h.
 pub const MESH_MAGIC: u32 = 0xC511_8100;
+/// Stable JSON schema exposed by the sensing server for decoded node health.
+pub const NODE_HEALTH_SCHEMA: &str = "ruview.node-health.v1";
 /// `RV_MESH_VERSION` from rv_mesh.h.
 pub const MESH_VERSION: u8 = 1;
 /// `RV_MESH_MAX_PAYLOAD` from rv_mesh.h.
@@ -218,7 +220,10 @@ pub struct MeshHeader {
     pub payload_len: u16,
 }
 
-/// `rv_node_status_t`, 28 bytes.
+/// `rv_node_status_t`, 52 bytes in the extended firmware contract.
+///
+/// The decoder also accepts the legacy 28-byte payload and marks
+/// `extended=false`, allowing hosts to ingest mixed-version fleets.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct NodeStatus {
     pub node_id: [u8; 8],
@@ -230,6 +235,16 @@ pub struct NodeStatus {
     pub pkt_yield: u16,
     pub sync_error_us: u16,
     pub health_flags: u16,
+    pub send_fail_count: u16,
+    pub wifi_retry_count: u16,
+    pub association_epoch: u32,
+    pub free_heap_bytes: u32,
+    pub last_disconnect_reason: u16,
+    pub reset_reason: u8,
+    pub last_disconnect_rssi_dbm: i8,
+    pub bssid: [u8; 6],
+    /// True when the extended telemetry fields were present on the wire.
+    pub extended: bool,
 }
 
 /// `rv_anomaly_alert_t`, 28 bytes.
@@ -351,18 +366,23 @@ pub fn decode_mesh(buf: &[u8]) -> Result<(MeshHeader, &[u8]), MeshError> {
     ))
 }
 
-/// Decode a `HEALTH` payload (28 bytes).
+/// Decode a legacy (28-byte) or extended (52-byte) `HEALTH` payload.
 pub fn decode_node_status(p: &[u8]) -> Result<NodeStatus, MeshError> {
-    if p.len() != 28 {
+    if p.len() != 28 && p.len() != 52 {
         return Err(MeshError::PayloadSizeMismatch {
             which: "HEALTH",
             got: p.len(),
-            want: 28,
+            want: 52,
         });
     }
     let mut node_id = [0u8; 8];
     node_id.copy_from_slice(&p[0..8]);
     let local_time_us = u64::from_le_bytes([p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]]);
+    let extended = p.len() == 52;
+    let mut bssid = [0u8; 6];
+    if extended {
+        bssid.copy_from_slice(&p[44..50]);
+    }
     Ok(NodeStatus {
         node_id,
         local_time_us,
@@ -373,6 +393,25 @@ pub fn decode_node_status(p: &[u8]) -> Result<NodeStatus, MeshError> {
         pkt_yield: u16::from_le_bytes([p[20], p[21]]),
         sync_error_us: u16::from_le_bytes([p[22], p[23]]),
         health_flags: u16::from_le_bytes([p[24], p[25]]),
+        send_fail_count: extended
+            .then(|| u16::from_le_bytes([p[28], p[29]]))
+            .unwrap_or(0),
+        wifi_retry_count: extended
+            .then(|| u16::from_le_bytes([p[30], p[31]]))
+            .unwrap_or(0),
+        association_epoch: extended
+            .then(|| u32::from_le_bytes([p[32], p[33], p[34], p[35]]))
+            .unwrap_or(0),
+        free_heap_bytes: extended
+            .then(|| u32::from_le_bytes([p[36], p[37], p[38], p[39]]))
+            .unwrap_or(0),
+        last_disconnect_reason: extended
+            .then(|| u16::from_le_bytes([p[40], p[41]]))
+            .unwrap_or(0),
+        reset_reason: if extended { p[42] } else { 0 },
+        last_disconnect_rssi_dbm: if extended { p[43] as i8 } else { 0 },
+        bssid,
+        extended,
     })
 }
 
@@ -400,10 +439,10 @@ pub fn decode_anomaly_alert(p: &[u8]) -> Result<AnomalyAlert, MeshError> {
     })
 }
 
-/// Encode a `HEALTH` payload. Produces the 16-byte header, 28-byte
+/// Encode an extended `HEALTH` payload. Produces the 16-byte header, 52-byte
 /// payload, and 4-byte CRC — bit-identical to what the firmware emits.
 pub fn encode_health(sender_role: MeshRole, epoch: u32, status: &NodeStatus) -> Vec<u8> {
-    let payload_len: u16 = 28;
+    let payload_len: u16 = 52;
     let mut buf = Vec::with_capacity(MESH_HEADER_SIZE + payload_len as usize + 4);
 
     // header
@@ -427,6 +466,15 @@ pub fn encode_health(sender_role: MeshRole, epoch: u32, status: &NodeStatus) -> 
     buf.extend_from_slice(&status.sync_error_us.to_le_bytes());
     buf.extend_from_slice(&status.health_flags.to_le_bytes());
     buf.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    buf.extend_from_slice(&status.send_fail_count.to_le_bytes());
+    buf.extend_from_slice(&status.wifi_retry_count.to_le_bytes());
+    buf.extend_from_slice(&status.association_epoch.to_le_bytes());
+    buf.extend_from_slice(&status.free_heap_bytes.to_le_bytes());
+    buf.extend_from_slice(&status.last_disconnect_reason.to_le_bytes());
+    buf.push(status.reset_reason);
+    buf.push(status.last_disconnect_rssi_dbm as u8);
+    buf.extend_from_slice(&status.bssid);
+    buf.extend_from_slice(&0u16.to_le_bytes()); // extended reserved
 
     let crc = crc32_ieee(&buf);
     buf.extend_from_slice(&crc.to_le_bytes());
@@ -480,20 +528,49 @@ mod tests {
             pkt_yield: 20,
             sync_error_us: 7,
             health_flags: 0x0001,
+            send_fail_count: 3,
+            wifi_retry_count: 4,
+            association_epoch: 12,
+            free_heap_bytes: 182_640,
+            last_disconnect_reason: 200,
+            reset_reason: 3,
+            last_disconnect_rssi_dbm: -81,
+            bssid: [0xD4, 0xA0, 0xFB, 0x40, 0x01, 0x58],
+            extended: true,
         };
 
         let wire = encode_health(MeshRole::Observer, 5, &st);
-        assert_eq!(wire.len(), MESH_HEADER_SIZE + 28 + 4);
-        assert_eq!(wire.len(), 48);
+        assert_eq!(wire.len(), MESH_HEADER_SIZE + 52 + 4);
+        assert_eq!(wire.len(), 72);
 
         let (hdr, payload) = decode_mesh(&wire).expect("decode");
         assert_eq!(hdr.msg_type, MeshMsgType::Health);
         assert_eq!(hdr.sender_role, MeshRole::Observer);
         assert_eq!(hdr.epoch, 5);
-        assert_eq!(hdr.payload_len, 28);
+        assert_eq!(hdr.payload_len, 52);
 
         let back = decode_node_status(payload).expect("payload decode");
         assert_eq!(back, st);
+    }
+
+    #[test]
+    fn legacy_health_payload_decodes_with_unavailable_extended_fields() {
+        let mut payload = vec![0u8; 28];
+        payload[0] = 11;
+        payload[8..16].copy_from_slice(&42_000_000u64.to_le_bytes());
+        payload[16] = MeshRole::Observer as u8;
+        payload[17] = 1;
+        payload[18] = 20;
+        payload[19] = (-94i8) as u8;
+        payload[20..22].copy_from_slice(&37u16.to_le_bytes());
+
+        let status = decode_node_status(&payload).expect("legacy health decode");
+        assert_eq!(status.node_id[0], 11);
+        assert_eq!(status.local_time_us, 42_000_000);
+        assert_eq!(status.pkt_yield, 37);
+        assert_eq!(status.send_fail_count, 0);
+        assert_eq!(status.bssid, [0; 6]);
+        assert!(!status.extended);
     }
 
     #[test]
@@ -508,6 +585,15 @@ mod tests {
             pkt_yield: 0,
             sync_error_us: 0,
             health_flags: 0,
+            send_fail_count: 0,
+            wifi_retry_count: 0,
+            association_epoch: 0,
+            free_heap_bytes: 0,
+            last_disconnect_reason: 0,
+            reset_reason: 0,
+            last_disconnect_rssi_dbm: 0,
+            bssid: [0; 6],
+            extended: true,
         };
         let mut wire = encode_health(MeshRole::Observer, 0, &st);
         let p0 = MESH_HEADER_SIZE; // first payload byte
@@ -548,6 +634,7 @@ mod tests {
     fn mesh_constants_match_firmware() {
         // These must match rv_mesh.h byte-for-byte.
         assert_eq!(MESH_MAGIC, 0xC511_8100);
+        assert_eq!(NODE_HEALTH_SCHEMA, "ruview.node-health.v1");
         assert_eq!(MESH_VERSION, 1);
         assert_eq!(MESH_HEADER_SIZE, 16);
         assert_eq!(MESH_MAX_PAYLOAD, 256);

--- a/v2/crates/wifi-densepose-sensing-server/src/calibration_session.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/calibration_session.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 pub const MAX_CALIBRATION_SOURCE_NODES: usize = 16;
 pub const CALIBRATED_PRESENCE_EVIDENCE_SCHEMA: &str =
-    "ruview.calibration.calibrated-presence-evidence.v1";
+    "ruview.calibration.calibrated-presence-evidence.v2";
 const SHA256_HEX_LEN: usize = 64;
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -68,7 +68,7 @@ pub struct CalibrationModelReceipt {
 /// A per-frame result that can be joined back to one exact immutable field
 /// model receipt. It is emitted only when the binary has produced a strict
 /// calibrated occupancy result; heuristic fallbacks never receive this shape.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CalibratedPresenceEvidence {
     pub schema: String,
     pub boot_epoch: String,
@@ -83,6 +83,31 @@ pub struct CalibratedPresenceEvidence {
     pub inference_method: String,
     pub presence: bool,
     pub person_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub residual_energy: Option<CalibratedResidualEnergyEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CalibratedNodeResidualEnergy {
+    pub node_id: u8,
+    pub energy: f64,
+    pub null_median: f64,
+    pub null_p95: f64,
+    pub null_p99: f64,
+    pub normalized_energy: f64,
+    pub decision_threshold: f64,
+    pub above_threshold: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CalibratedResidualEnergyEvidence {
+    pub nodes: Vec<CalibratedNodeResidualEnergy>,
+    pub aggregate_mean_energy: f64,
+    pub aggregate_mean_normalized_energy: f64,
+    pub nodes_above_threshold: usize,
+    pub node_quorum: usize,
+    pub hysteresis_present: bool,
+    pub hysteresis_candidate_frames: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -237,6 +262,25 @@ impl CalibrationSessionContract {
         person_count: usize,
         inference_method: &'static str,
     ) -> Option<CalibratedPresenceEvidence> {
+        self.calibrated_presence_evidence_with_residual(
+            inference_node_id,
+            source_tick,
+            observed_at_unix_ms,
+            person_count,
+            inference_method,
+            None,
+        )
+    }
+
+    pub fn calibrated_presence_evidence_with_residual(
+        &self,
+        inference_node_id: u8,
+        source_tick: u64,
+        observed_at_unix_ms: u64,
+        person_count: usize,
+        inference_method: &'static str,
+        residual_energy: Option<CalibratedResidualEnergyEvidence>,
+    ) -> Option<CalibratedPresenceEvidence> {
         let receipt = self.model_receipt.as_ref()?;
         if receipt
             .source_node_ids
@@ -246,7 +290,9 @@ impl CalibrationSessionContract {
             || person_count > 3
             || !matches!(
                 inference_method,
-                "field_model_eigenvalue_v1" | "field_model_perturbation_energy_v1"
+                "field_model_eigenvalue_v1"
+                    | "field_model_perturbation_energy_v1"
+                    | "field_model_null_normalized_v2"
             )
         {
             return None;
@@ -265,6 +311,7 @@ impl CalibrationSessionContract {
             inference_method: inference_method.to_string(),
             presence: person_count > 0,
             person_count,
+            residual_energy,
         })
     }
 
@@ -604,6 +651,37 @@ mod tests {
         assert_eq!(evidence.observed_at_unix_ms, 123_999);
         assert!(evidence.presence);
         assert_eq!(evidence.person_count, 1);
+        assert!(evidence.residual_energy.is_none());
+
+        let residual = CalibratedResidualEnergyEvidence {
+            nodes: vec![CalibratedNodeResidualEnergy {
+                node_id: 7,
+                energy: 2.0,
+                null_median: 0.5,
+                null_p95: 0.8,
+                null_p99: 1.0,
+                normalized_energy: 2.0,
+                decision_threshold: 1.0,
+                above_threshold: true,
+            }],
+            aggregate_mean_energy: 2.0,
+            aggregate_mean_normalized_energy: 2.0,
+            nodes_above_threshold: 1,
+            node_quorum: 1,
+            hysteresis_present: true,
+            hysteresis_candidate_frames: 0,
+        };
+        let diagnostic = contract
+            .calibrated_presence_evidence_with_residual(
+                7,
+                89,
+                124_000,
+                1,
+                "field_model_null_normalized_v2",
+                Some(residual.clone()),
+            )
+            .expect("null-normalized diagnostic evidence");
+        assert_eq!(diagnostic.residual_energy, Some(residual));
 
         assert!(contract
             .calibrated_presence_evidence(2, 89, 124_000, 0, "field_model_perturbation_energy_v1",)

--- a/v2/crates/wifi-densepose-sensing-server/src/csi.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/csi.rs
@@ -352,6 +352,9 @@ pub fn compute_subcarrier_variances(frame_history: &VecDeque<Vec<f64>>, n_sub: u
 
 pub fn extract_features_from_frame(
     frame: &Esp32Frame,
+    // Callers append `frame` before extraction so variance and breathing
+    // windows include the newest sample. Temporal motion must therefore use
+    // the entry immediately before the history tail, never the tail itself.
     frame_history: &VecDeque<Vec<f64>>,
     sample_rate_hz: f64,
 ) -> (FeatureInfo, ClassificationInfo, f64, Vec<f64>, f64) {
@@ -437,7 +440,7 @@ pub fn extract_features_from_frame(
         .filter(|w| (w[0] < threshold) != (w[1] < threshold))
         .count();
 
-    let temporal_motion_score = if let Some(prev_frame) = frame_history.back() {
+    let temporal_motion_score = if let Some(prev_frame) = frame_history.iter().rev().nth(1) {
         let n_cmp = n_sub.min(prev_frame.len());
         if n_cmp > 0 {
             let diff_energy: f64 = (0..n_cmp)

--- a/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
@@ -48,6 +48,7 @@ const MAX_SINGLE_LINK_OCCUPANCY: usize = 3;
 pub enum CalibratedOccupancyMethod {
     Eigenvalue,
     PerturbationEnergy,
+    NullNormalized,
 }
 
 impl CalibratedOccupancyMethod {
@@ -55,14 +56,114 @@ impl CalibratedOccupancyMethod {
         match self {
             Self::Eigenvalue => "field_model_eigenvalue_v1",
             Self::PerturbationEnergy => "field_model_perturbation_energy_v1",
+            Self::NullNormalized => "field_model_null_normalized_v2",
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CalibratedOccupancy {
     pub person_count: usize,
     pub method: CalibratedOccupancyMethod,
+    pub residual_evidence: Option<ResidualEnergyEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LinkResidualEnergyEvidence {
+    pub energy: f64,
+    pub null_median: f64,
+    pub null_p95: f64,
+    pub null_p99: f64,
+    pub normalized_energy: f64,
+    pub decision_threshold: f64,
+    pub above_threshold: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResidualEnergyEvidence {
+    pub links: Vec<LinkResidualEnergyEvidence>,
+    pub aggregate_mean_energy: f64,
+    pub aggregate_mean_normalized_energy: f64,
+    pub nodes_above_threshold: usize,
+    pub node_quorum: usize,
+    pub hysteresis_present: bool,
+    pub hysteresis_candidate_frames: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PresenceDetectorConfig {
+    pub node_quorum: usize,
+    pub enter_frames: usize,
+    pub exit_frames: usize,
+}
+
+impl Default for PresenceDetectorConfig {
+    fn default() -> Self {
+        Self {
+            node_quorum: 2,
+            enter_frames: 3,
+            exit_frames: 10,
+        }
+    }
+}
+
+impl PresenceDetectorConfig {
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        Self {
+            node_quorum: bounded_usize_env(
+                "WDP_CALIBRATED_PRESENCE_NODE_QUORUM",
+                defaults.node_quorum,
+                16,
+            ),
+            enter_frames: bounded_usize_env(
+                "WDP_CALIBRATED_PRESENCE_ENTER_FRAMES",
+                defaults.enter_frames,
+                10_000,
+            ),
+            exit_frames: bounded_usize_env(
+                "WDP_CALIBRATED_PRESENCE_EXIT_FRAMES",
+                defaults.exit_frames,
+                10_000,
+            ),
+        }
+    }
+}
+
+fn bounded_usize_env(name: &str, default: usize, maximum: usize) -> usize {
+    bounded_usize_value(std::env::var(name).ok().as_deref(), default, maximum)
+}
+
+fn bounded_usize_value(value: Option<&str>, default: usize, maximum: usize) -> usize {
+    value
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| (1..=maximum).contains(value))
+        .unwrap_or(default)
+}
+
+#[derive(Debug, Clone)]
+pub struct CalibratedPresenceDetector {
+    config: PresenceDetectorConfig,
+    present: bool,
+    candidate_frames: usize,
+}
+
+impl CalibratedPresenceDetector {
+    pub fn new(mut config: PresenceDetectorConfig) -> Self {
+        config.node_quorum = config.node_quorum.max(1);
+        config.enter_frames = config.enter_frames.max(1);
+        config.exit_frames = config.exit_frames.max(1);
+        Self {
+            config,
+            present: false,
+            candidate_frames: 0,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.present = false;
+        self.candidate_frames = 0;
+    }
 }
 
 /// Create a FieldModelConfig for single-link mode (one ESP32 node = one link).
@@ -71,6 +172,37 @@ pub fn single_link_config() -> FieldModelConfig {
     FieldModelConfig {
         n_links: 1,
         ..FieldModelConfig::default()
+    }
+}
+
+/// Create a field model whose stable link ordering is the bound calibration
+/// node ordering. A bound multi-node room must never be represented by a
+/// single-link model fed sequential samples from unrelated radios.
+pub fn multi_link_config(n_links: usize) -> FieldModelConfig {
+    FieldModelConfig {
+        n_links,
+        ..FieldModelConfig::default()
+    }
+}
+
+/// Feed one complete, already-canonicalized multi-link room observation.
+/// Returns true only when the field model accepted the cohort.
+pub fn maybe_feed_calibration_observation(
+    field: &mut FieldModel,
+    observations: &[Vec<f64>],
+) -> bool {
+    if !matches!(
+        field.status(),
+        CalibrationStatus::Uncalibrated | CalibrationStatus::Collecting
+    ) {
+        return false;
+    }
+    match field.feed_calibration(observations) {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::debug!("FieldModel calibration cohort feed: {error}");
+            false
+        }
     }
 }
 
@@ -161,6 +293,7 @@ pub fn calibrated_occupancy(
         return Some(CalibratedOccupancy {
             person_count: person_count.min(MAX_SINGLE_LINK_OCCUPANCY),
             method: CalibratedOccupancyMethod::Eigenvalue,
+            residual_evidence: None,
         });
     }
 
@@ -178,6 +311,86 @@ pub fn calibrated_occupancy(
     Some(CalibratedOccupancy {
         person_count,
         method: CalibratedOccupancyMethod::PerturbationEnergy,
+        residual_evidence: None,
+    })
+}
+
+/// Produce binary calibrated presence from a coherent multi-link observation.
+/// Person counting from a temporal single-link eigenvalue window is not valid
+/// for a spatial cohort, so this path deliberately reports only 0/1 from mean
+/// null-space residual energy.
+pub fn calibrated_multilink_occupancy(
+    field: &FieldModel,
+    observations: &[Vec<f64>],
+    observed_at_us: u64,
+    detector: &mut CalibratedPresenceDetector,
+    advance_hysteresis: bool,
+) -> Option<CalibratedOccupancy> {
+    if field.check_freshness(observed_at_us) != CalibrationStatus::Fresh || observations.is_empty()
+    {
+        return None;
+    }
+    let perturbation = field.extract_perturbation(observations).ok()?;
+    let learned = &field.modes()?.null_residual_energy;
+    if learned.len() != perturbation.energies.len()
+        || learned.iter().any(|item| item.sample_count == 0)
+    {
+        return None;
+    }
+    let quorum = detector.config.node_quorum.min(learned.len()).max(1);
+    let mut nodes_above_threshold = 0;
+    let links = perturbation
+        .energies
+        .iter()
+        .zip(learned.iter())
+        .map(|(&energy, null)| {
+            let threshold = if detector.present { null.p95 } else { null.p99 };
+            let threshold = threshold.max(1e-9);
+            let above_threshold = energy > threshold;
+            nodes_above_threshold += usize::from(above_threshold);
+            LinkResidualEnergyEvidence {
+                energy,
+                null_median: null.median,
+                null_p95: null.p95,
+                null_p99: null.p99,
+                normalized_energy: energy / null.p99.max(1e-9),
+                decision_threshold: threshold,
+                above_threshold,
+            }
+        })
+        .collect::<Vec<_>>();
+    let candidate_present = nodes_above_threshold >= quorum;
+    if advance_hysteresis {
+        if candidate_present == detector.present {
+            detector.candidate_frames = 0;
+        } else {
+            detector.candidate_frames += 1;
+            let required = if candidate_present {
+                detector.config.enter_frames
+            } else {
+                detector.config.exit_frames
+            };
+            if detector.candidate_frames >= required {
+                detector.present = candidate_present;
+                detector.candidate_frames = 0;
+            }
+        }
+    }
+    let mean_energy = perturbation.total_energy / observations.len() as f64;
+    let mean_normalized =
+        links.iter().map(|link| link.normalized_energy).sum::<f64>() / links.len() as f64;
+    Some(CalibratedOccupancy {
+        person_count: usize::from(detector.present),
+        method: CalibratedOccupancyMethod::NullNormalized,
+        residual_evidence: Some(ResidualEnergyEvidence {
+            links,
+            aggregate_mean_energy: mean_energy,
+            aggregate_mean_normalized_energy: mean_normalized,
+            nodes_above_threshold,
+            node_quorum: quorum,
+            hysteresis_present: detector.present,
+            hysteresis_candidate_frames: detector.candidate_frames,
+        }),
     })
 }
 
@@ -209,7 +422,6 @@ pub fn maybe_feed_calibration(field: &mut FieldModel, frame_history: &VecDeque<V
         }
     }
 }
-
 
 /// Parse node positions from a semicolon-delimited string.
 ///
@@ -304,6 +516,15 @@ mod tests {
         assert_eq!(positions[0], [3.0, 4.0, 5.0]);
     }
 
+    #[test]
+    fn detector_configuration_rejects_zero_invalid_and_excessive_values() {
+        assert_eq!(bounded_usize_value(Some("3"), 2, 16), 3);
+        assert_eq!(bounded_usize_value(Some("0"), 2, 16), 2);
+        assert_eq!(bounded_usize_value(Some("17"), 2, 16), 2);
+        assert_eq!(bounded_usize_value(Some("nope"), 2, 16), 2);
+        assert_eq!(bounded_usize_value(None, 2, 16), 2);
+    }
+
     /// Regression: a freshly-started (`Uncalibrated`) field model must begin
     /// collecting once frames arrive. Before the fix, `maybe_feed_calibration`
     /// only fed while already `Collecting`, but only `feed_calibration` sets
@@ -386,5 +607,115 @@ mod tests {
             calibrated_occupancy(&field, &VecDeque::new(), 1_500_000),
             None
         );
+    }
+
+    #[test]
+    fn multilink_calibration_consumes_one_spatial_cohort_per_frame() {
+        let mut field = FieldModel::new(multi_link_config(3)).expect("field model");
+        let cohort = vec![vec![0.5; 56], vec![0.6; 56], vec![0.7; 56]];
+
+        assert!(maybe_feed_calibration_observation(&mut field, &cohort));
+        assert_eq!(field.calibration_frame_count(), 1);
+        assert!(
+            !maybe_feed_calibration_observation(&mut field, &cohort[..1]),
+            "a partial node cohort must be rejected instead of contaminating the baseline"
+        );
+        assert_eq!(field.calibration_frame_count(), 1);
+    }
+
+    fn calibrated_multilink_test_model() -> (FieldModel, Vec<Vec<f64>>) {
+        let config = FieldModelConfig {
+            n_links: 3,
+            n_subcarriers: 8,
+            n_modes: 3,
+            min_calibration_frames: 32,
+            baseline_expiry_s: 10.0,
+        };
+        let mut field = FieldModel::new(config).unwrap();
+        let mut last = Vec::new();
+        for frame in 0..96 {
+            last = (0..3)
+                .map(|link| {
+                    (0..8)
+                        .map(|tone| {
+                            let phase = (frame * (link + 1) + tone * 7) as f64 * 0.071;
+                            2.0 + link as f64 * 0.4 + tone as f64 * 0.02 + phase.sin() * 0.08
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            field.feed_calibration(&last).unwrap();
+        }
+        field.finalize_calibration(1_000_000, 7).unwrap();
+        (field, last)
+    }
+
+    #[test]
+    fn null_normalized_detector_requires_quorum_and_hysteresis() {
+        let (field, null_like) = calibrated_multilink_test_model();
+        let mut detector = CalibratedPresenceDetector::new(PresenceDetectorConfig {
+            node_quorum: 2,
+            enter_frames: 2,
+            exit_frames: 3,
+        });
+
+        let empty =
+            calibrated_multilink_occupancy(&field, &null_like, 1_500_000, &mut detector, true)
+                .unwrap();
+        assert_eq!(empty.person_count, 0);
+        assert_eq!(empty.residual_evidence.as_ref().unwrap().links.len(), 3);
+        assert!(empty.residual_evidence.as_ref().unwrap().links[0]
+            .decision_threshold
+            .is_finite());
+
+        let mut one_noisy_link = null_like.clone();
+        for (tone, value) in one_noisy_link[0].iter_mut().enumerate() {
+            *value += if tone % 2 == 0 { 5.0 } else { -5.0 };
+        }
+        for _ in 0..3 {
+            let result = calibrated_multilink_occupancy(
+                &field,
+                &one_noisy_link,
+                1_500_000,
+                &mut detector,
+                true,
+            )
+            .unwrap();
+            assert_eq!(
+                result.person_count, 0,
+                "one noisy node must not satisfy quorum"
+            );
+        }
+
+        let mut two_changed_links = one_noisy_link;
+        for (tone, value) in two_changed_links[1].iter_mut().enumerate() {
+            *value += if tone % 2 == 0 { 5.0 } else { -5.0 };
+        }
+        let entering = calibrated_multilink_occupancy(
+            &field,
+            &two_changed_links,
+            1_500_000,
+            &mut detector,
+            true,
+        )
+        .unwrap();
+        assert_eq!(entering.person_count, 0);
+        let present = calibrated_multilink_occupancy(
+            &field,
+            &two_changed_links,
+            1_500_000,
+            &mut detector,
+            true,
+        )
+        .unwrap();
+        assert_eq!(present.person_count, 1);
+        assert_eq!(present.method.wire_name(), "field_model_null_normalized_v2");
+
+        for expected in [1, 1, 0] {
+            let result =
+                calibrated_multilink_occupancy(&field, &null_like, 1_500_000, &mut detector, true)
+                    .unwrap();
+            assert_eq!(result.person_count, expected);
+        }
     }
 }

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -35,9 +35,10 @@ pub mod types;
 mod vital_signs;
 
 use wifi_densepose_sensing_server::calibration_session::{
-    validate_start_request, CalibratedPresenceEvidence, CalibrationBoundRequest,
-    CalibrationModelReceipt, CalibrationResetRequest, CalibrationSessionContract,
-    CalibrationSessionError, CalibrationStartRequest,
+    validate_start_request, CalibratedNodeResidualEnergy, CalibratedPresenceEvidence,
+    CalibratedResidualEnergyEvidence, CalibrationBoundRequest, CalibrationModelReceipt,
+    CalibrationResetRequest, CalibrationSessionContract, CalibrationSessionError,
+    CalibrationStartRequest,
 };
 // Training pipeline modules (exposed via lib.rs)
 use wifi_densepose_sensing_server::{
@@ -408,6 +409,102 @@ struct NodeInfo {
     node_inference: Option<NodeInference>,
 }
 
+#[derive(Debug)]
+struct NodeHealthObservation {
+    node_id: u8,
+    mesh_epoch: u32,
+    status: wifi_densepose_hardware::NodeStatus,
+    observed_at: std::time::Instant,
+}
+
+fn decode_node_health_datagram(buf: &[u8]) -> Option<NodeHealthObservation> {
+    use wifi_densepose_hardware::{decode_mesh, decode_node_status, MeshMsgType};
+
+    let (header, payload) = decode_mesh(buf).ok()?;
+    if header.msg_type != MeshMsgType::Health {
+        return None;
+    }
+    let status = decode_node_status(payload).ok()?;
+    let node_id = status.node_id[0];
+    if node_id == 0 || status.node_id[1..].iter().any(|byte| *byte != 0) {
+        return None;
+    }
+    Some(NodeHealthObservation {
+        node_id,
+        mesh_epoch: header.epoch,
+        status,
+        observed_at: std::time::Instant::now(),
+    })
+}
+
+fn reset_reason_name(reason: u8) -> &'static str {
+    match reason {
+        1 => "power_on",
+        3 => "software",
+        4 => "panic",
+        5 => "interrupt_watchdog",
+        6 => "task_watchdog",
+        7 => "watchdog",
+        8 => "deep_sleep",
+        9 => "brownout",
+        10 => "sdio",
+        _ => "unknown",
+    }
+}
+
+fn disconnect_reason_name(reason: u16) -> &'static str {
+    match reason {
+        0 => "none_observed",
+        200 => "beacon_timeout",
+        201 => "no_ap_found",
+        202 => "authentication_failed",
+        203 => "association_failed",
+        204 => "handshake_timeout",
+        205 => "connection_failed",
+        _ => "other",
+    }
+}
+
+fn node_health_json(
+    observation: &NodeHealthObservation,
+    now: std::time::Instant,
+) -> serde_json::Value {
+    let status = observation.status;
+    let extended = status.extended;
+    let bssid = extended.then(|| {
+        status
+            .bssid
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<Vec<_>>()
+            .join(":")
+    });
+    serde_json::json!({
+        "schema": wifi_densepose_hardware::radio_ops::NODE_HEALTH_SCHEMA,
+        "extended": extended,
+        "last_health_ms": now.saturating_duration_since(observation.observed_at).as_millis() as u64,
+        "mesh_epoch": observation.mesh_epoch,
+        "uptime_ms": status.local_time_us / 1_000,
+        "role": status.role as u8,
+        "channel": status.current_channel,
+        "bandwidth_mhz": status.current_bw,
+        "noise_floor_dbm": status.noise_floor_dbm,
+        "packet_yield_per_sec": status.pkt_yield,
+        "sync_error_us": status.sync_error_us,
+        "health_flags": status.health_flags,
+        "udp_send_failures": extended.then_some(status.send_fail_count),
+        "wifi_retry_count": extended.then_some(status.wifi_retry_count),
+        "association_epoch": extended.then_some(status.association_epoch),
+        "free_heap_bytes": extended.then_some(status.free_heap_bytes),
+        "last_disconnect_reason": extended.then_some(status.last_disconnect_reason),
+        "last_disconnect_reason_name": extended.then(|| disconnect_reason_name(status.last_disconnect_reason)),
+        "last_disconnect_rssi_dbm": extended.then_some(status.last_disconnect_rssi_dbm),
+        "reset_reason": extended.then_some(status.reset_reason),
+        "reset_reason_name": extended.then(|| reset_reason_name(status.reset_reason)),
+        "bssid": bssid,
+    })
+}
+
 /// ADR-110 iter 23 — per-node mesh-sync snapshot embedded in NodeInfo.
 /// Surfaces what was previously only visible in the debug log so UI clients
 /// can render leader / follower / offset / measured-fps live.
@@ -701,6 +798,7 @@ struct NodeState {
     latest_vitals: VitalSigns,
     pub(crate) last_frame_time: Option<std::time::Instant>,
     edge_vitals: Option<Esp32VitalsPacket>,
+    latest_health: Option<NodeHealthObservation>,
     /// ADR-110 §A0.12: Latest sync packet received from this node. When a
     /// CSI frame arrives with byte 19 bit 4 set (`adr018_flags.ieee802154_sync_valid`),
     /// the host can recover a mesh-aligned timestamp via
@@ -720,6 +818,12 @@ struct NodeState {
     csi_fps_ema: f64,
     /// Number of inter-frame deltas observed (need ≥5 before trusting EMA).
     csi_fps_samples: u32,
+    /// Cadence of frames actually admitted to feature history. Rejected grid
+    /// packets must not shift DSP frequency bins.
+    accepted_csi_rate_window_started_at: Option<std::time::Instant>,
+    accepted_csi_rate_window_frames: u32,
+    accepted_csi_rate_hz: f64,
+    accepted_csi_rate_windows: u32,
     /// Latest extracted features for cross-node fusion.
     latest_features: Option<FeatureInfo>,
     // ── RuVector Phase 2: Temporal smoothing & coherence gating ──
@@ -772,10 +876,67 @@ mod node_device_type_tests {
             detected_esp32_device_type(Some((56, PpduType::HtLegacy))),
             ("esp32_unverified", "observed_csi_wire_format")
         );
-        assert_eq!(
-            detected_esp32_device_type(None),
-            ("unknown", "unavailable")
-        );
+        assert_eq!(detected_esp32_device_type(None), ("unknown", "unavailable"));
+    }
+}
+
+#[cfg(test)]
+mod node_health_ingestion_tests {
+    use super::*;
+    use wifi_densepose_hardware::{encode_health, MeshRole, NodeStatus};
+
+    fn extended_status() -> NodeStatus {
+        NodeStatus {
+            node_id: [11, 0, 0, 0, 0, 0, 0, 0],
+            local_time_us: 91_234_000,
+            role: MeshRole::Observer,
+            current_channel: 1,
+            current_bw: 20,
+            noise_floor_dbm: -96,
+            pkt_yield: 37,
+            sync_error_us: 8,
+            health_flags: 2,
+            send_fail_count: 5,
+            wifi_retry_count: 7,
+            association_epoch: 3,
+            free_heap_bytes: 181_224,
+            last_disconnect_reason: 200,
+            reset_reason: 3,
+            last_disconnect_rssi_dbm: -82,
+            bssid: [0xD4, 0xA0, 0xFB, 0x40, 0x01, 0x58],
+            extended: true,
+        }
+    }
+
+    #[test]
+    fn extended_health_datagram_is_decoded_for_the_legacy_node_id() {
+        let wire = encode_health(MeshRole::Observer, 17, &extended_status());
+        let observation = decode_node_health_datagram(&wire).expect("health datagram");
+        assert_eq!(observation.node_id, 11);
+        assert_eq!(observation.mesh_epoch, 17);
+        assert_eq!(observation.status.association_epoch, 3);
+        assert_eq!(observation.status.send_fail_count, 5);
+    }
+
+    #[test]
+    fn node_health_json_exposes_diagnostics_without_promoting_health_to_csi_liveness() {
+        let observation = NodeHealthObservation {
+            node_id: 11,
+            mesh_epoch: 17,
+            status: extended_status(),
+            observed_at: std::time::Instant::now(),
+        };
+        let value = node_health_json(&observation, std::time::Instant::now());
+        assert_eq!(value["uptime_ms"], 91_234);
+        assert_eq!(value["reset_reason"], 3);
+        assert_eq!(value["association_epoch"], 3);
+        assert_eq!(value["channel"], 1);
+        assert_eq!(value["bssid"], "d4:a0:fb:40:01:58");
+        assert_eq!(value["last_disconnect_reason"], 200);
+        assert_eq!(value["wifi_retry_count"], 7);
+        assert_eq!(value["udp_send_failures"], 5);
+        assert_eq!(value["packet_yield_per_sec"], 37);
+        assert_eq!(value["free_heap_bytes"], 181_224);
     }
 }
 
@@ -833,9 +994,19 @@ pub(crate) fn update_csi_fps_ema(prev_fps: f64, dt_sec: f64) -> Option<f64> {
     Some(prev_fps + (instantaneous - prev_fps) / 8.0)
 }
 
+const DEFAULT_CSI_SAMPLE_RATE_HZ: f64 = 20.0;
+
+fn effective_csi_sample_rate_hz(measured_hz: f64, completed_windows: u32) -> f64 {
+    if completed_windows == 0 {
+        DEFAULT_CSI_SAMPLE_RATE_HZ
+    } else {
+        measured_hz
+    }
+}
+
 #[cfg(test)]
 mod fps_ema_tests {
-    use super::update_csi_fps_ema;
+    use super::{effective_csi_sample_rate_hz, update_csi_fps_ema};
 
     #[test]
     fn steady_10hz_converges_toward_10() {
@@ -897,9 +1068,70 @@ mod fps_ema_tests {
             "EMA should stay within ~1 Hz of the 40 fps ground truth, got {fps}"
         );
     }
+
+    #[test]
+    fn feature_sample_rate_uses_warmed_accepted_history_measurement() {
+        assert_eq!(effective_csi_sample_rate_hz(37.5, 1), 37.5);
+        assert_eq!(effective_csi_sample_rate_hz(5.0, 1), 5.0);
+        assert_eq!(effective_csi_sample_rate_hz(37.5, 0), 20.0);
+    }
+}
+
+#[cfg(test)]
+mod accepted_history_cadence_tests {
+    use super::NodeState;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn accepted_history_rate_counts_every_admitted_frame() {
+        let mut node = NodeState::new();
+        let start = Instant::now();
+        for index in 0..=40 {
+            node.observe_accepted_feature_frame(start + Duration::from_millis(index * 25));
+        }
+        assert_eq!(node.accepted_csi_rate_windows, 1);
+        assert!((node.accepted_csi_rate_hz - 40.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn stalled_window_restarts_without_publishing_a_rate() {
+        let mut node = NodeState::new();
+        let start = Instant::now();
+        node.observe_accepted_feature_frame(start);
+        node.observe_accepted_feature_frame(start + Duration::from_secs(4));
+        assert_eq!(node.accepted_csi_rate_windows, 0);
+        assert_eq!(node.feature_sample_rate_hz(), 20.0);
+    }
 }
 
 impl NodeState {
+    fn observe_accepted_feature_frame(&mut self, now: std::time::Instant) {
+        let Some(started_at) = self.accepted_csi_rate_window_started_at else {
+            self.accepted_csi_rate_window_started_at = Some(now);
+            self.accepted_csi_rate_window_frames = 1;
+            return;
+        };
+        let elapsed = now.saturating_duration_since(started_at);
+        if elapsed > std::time::Duration::from_secs(3) {
+            self.accepted_csi_rate_window_started_at = Some(now);
+            self.accepted_csi_rate_window_frames = 1;
+            return;
+        }
+        self.accepted_csi_rate_window_frames =
+            self.accepted_csi_rate_window_frames.saturating_add(1);
+        if elapsed >= std::time::Duration::from_secs(1) {
+            let intervals = self.accepted_csi_rate_window_frames.saturating_sub(1);
+            self.accepted_csi_rate_hz = intervals as f64 / elapsed.as_secs_f64();
+            self.accepted_csi_rate_windows = self.accepted_csi_rate_windows.saturating_add(1);
+            self.accepted_csi_rate_window_started_at = Some(now);
+            self.accepted_csi_rate_window_frames = 1;
+        }
+    }
+
+    fn feature_sample_rate_hz(&self) -> f64 {
+        effective_csi_sample_rate_hz(self.accepted_csi_rate_hz, self.accepted_csi_rate_windows)
+    }
+
     /// ADR-110 §A0.12 timestamp recovery: given a CSI frame's node-local
     /// `esp_timer_get_time()` snapshot, return the mesh-aligned epoch
     /// computed from this node's most recent sync packet — or `None`
@@ -1042,7 +1274,9 @@ impl NodeState {
     ) -> bool {
         self.latest_csi_sequence = Some(sequence);
         self.latest_csi_sync_valid = sync_valid;
-        self.observe_csi_frame_arrival(now)
+        let first_sensing_frame = self.observe_csi_frame_arrival(now);
+        self.observe_accepted_feature_frame(now);
+        first_sensing_frame
     }
 
     pub(crate) fn new() -> Self {
@@ -1067,12 +1301,17 @@ impl NodeState {
             latest_vitals: VitalSigns::default(),
             last_frame_time: None,
             edge_vitals: None,
+            latest_health: None,
             latest_sync: None,
             latest_sync_at: None,
             latest_csi_sequence: None,
             latest_csi_sync_valid: false,
             csi_fps_ema: 20.0,
             csi_fps_samples: 0,
+            accepted_csi_rate_window_started_at: None,
+            accepted_csi_rate_window_frames: 0,
+            accepted_csi_rate_hz: DEFAULT_CSI_SAMPLE_RATE_HZ,
+            accepted_csi_rate_windows: 0,
             latest_features: None,
             prev_keypoints: None,
             motion_energy_history: VecDeque::with_capacity(COHERENCE_WINDOW),
@@ -1111,6 +1350,10 @@ impl NodeState {
                 self.frame_history.clear();
                 self.baseline_motion = 0.0;
                 self.baseline_frames = 0;
+                self.accepted_csi_rate_window_started_at = None;
+                self.accepted_csi_rate_window_frames = 0;
+                self.accepted_csi_rate_hz = DEFAULT_CSI_SAMPLE_RATE_HZ;
+                self.accepted_csi_rate_windows = 0;
                 true
             }
             Some(_) => false,
@@ -1488,6 +1731,14 @@ struct AppStateInner {
     mat_api_state: wifi_densepose_mat::api::AppState,
     /// SVD-based room field model for eigenvalue person counting (None until calibration).
     field_model: Option<FieldModel>,
+    /// Latest all-node sequence signature admitted to bound calibration.
+    /// A new spatial observation is collected only after every bound node has
+    /// advanced, preventing fast nodes from being overrepresented.
+    last_calibration_sequences: Option<Vec<(u8, u32)>>,
+    /// State for null-normalized calibrated presence. It advances only when a
+    /// complete bound cohort has a new all-node sequence signature.
+    calibrated_presence_detector: field_bridge::CalibratedPresenceDetector,
+    last_calibrated_presence_sequences: Option<Vec<(u8, u32)>>,
     /// Boot-scoped identity and immutable receipt for the single active field
     /// model.  This prevents a completed model from being rebound to another
     /// room or source-node set by a later mobile request.
@@ -1594,6 +1845,99 @@ mod adr323_pose_physics_http_tests {
 /// If no ESP32 frame arrives within this duration, source reverts to offline.
 const ESP32_OFFLINE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Build one stable, source-bound spatial observation. The returned rows are
+/// ordered by the session's strictly ascending node IDs and are admitted only
+/// when the multistatic guard retained the complete bound set.
+fn coherent_bound_observation(
+    node_states: &HashMap<u8, NodeState>,
+    source_node_ids: &[u8],
+    guard_interval_us: u64,
+) -> Option<(Vec<Vec<f64>>, Vec<(u8, u32)>)> {
+    if source_node_ids.is_empty() {
+        return None;
+    }
+    let frames = multistatic_bridge::bound_node_frames_from_states_with_guard(
+        node_states,
+        guard_interval_us,
+        source_node_ids,
+    );
+    let frame_ids: Vec<u8> = frames.iter().map(|frame| frame.node_id).collect();
+    if frame_ids != source_node_ids {
+        return None;
+    }
+
+    let mut observations = Vec::with_capacity(frames.len());
+    let mut sequences = Vec::with_capacity(frames.len());
+    for frame in frames {
+        let amplitude = frame.channel_frames.first()?.amplitude.clone();
+        observations.push(amplitude.into_iter().map(f64::from).collect());
+        sequences.push((
+            frame.node_id,
+            node_states.get(&frame.node_id)?.latest_csi_sequence?,
+        ));
+    }
+    Some((observations, sequences))
+}
+
+/// Admit exactly one calibration frame after every bound node has advanced.
+fn maybe_feed_bound_calibration(state: &mut AppStateInner, arriving_node_id: u8) {
+    // Preserve the explicitly legacy, unbound single-node dashboard path.
+    if state.calibration_session.session().is_none() {
+        if let (Some(field), Some(history)) = (
+            state.field_model.as_mut(),
+            state
+                .node_states
+                .get(&arriving_node_id)
+                .map(|node| &node.frame_history),
+        ) {
+            field_bridge::maybe_feed_calibration(field, history);
+        }
+        return;
+    }
+    if !state
+        .calibration_session
+        .accepts_source_node(arriving_node_id)
+    {
+        return;
+    }
+    state
+        .calibration_session
+        .record_source_node(arriving_node_id);
+    let Some(source_node_ids) = state
+        .calibration_session
+        .session()
+        .map(|identity| identity.source_node_ids.clone())
+    else {
+        return;
+    };
+    let Some((observation, sequences)) = coherent_bound_observation(
+        &state.node_states,
+        &source_node_ids,
+        state.multistatic_fuser.guard_interval_us(),
+    ) else {
+        return;
+    };
+    if state
+        .last_calibration_sequences
+        .as_ref()
+        .is_some_and(|previous| {
+            previous
+                .iter()
+                .zip(&sequences)
+                .any(|(before, after)| before.0 != after.0 || before.1 == after.1)
+        })
+    {
+        return;
+    }
+    let accepted = state
+        .field_model
+        .as_mut()
+        .is_some_and(|field| field_bridge::maybe_feed_calibration_observation(field, &observation));
+    if accepted {
+        state.last_calibration_sequences = Some(sequences);
+    }
+}
+
 impl AppStateInner {
     /// Return the effective data source, accounting for ESP32 frame timeout.
     /// If the source is "esp32" but no frame has arrived in 5 seconds, returns
@@ -1628,25 +1972,75 @@ impl AppStateInner {
     }
 
     fn calibrated_presence_evidence(
-        &self,
+        &mut self,
         inference_node_id: u8,
         source_tick: u64,
         observed_at_unix_ms: u64,
     ) -> Option<CalibratedPresenceEvidence> {
-        let field_model = self.field_model.as_ref()?;
-        let history = &self.node_states.get(&inference_node_id)?.frame_history;
-        let occupancy = field_bridge::calibrated_occupancy(
-            field_model,
-            history,
-            observed_at_unix_ms.saturating_mul(1_000),
-        )?;
-        self.calibration_session.calibrated_presence_evidence(
-            inference_node_id,
-            source_tick,
-            observed_at_unix_ms,
-            occupancy.person_count,
-            occupancy.method.wire_name(),
-        )
+        let source_ids = self.calibration_session.session()?.source_node_ids.clone();
+        let occupancy = if source_ids.len() == 1 {
+            let field_model = self.field_model.as_ref()?;
+            let history = &self.node_states.get(&inference_node_id)?.frame_history;
+            field_bridge::calibrated_occupancy(
+                field_model,
+                history,
+                observed_at_unix_ms.saturating_mul(1_000),
+            )?
+        } else {
+            let (observation, sequences) = coherent_bound_observation(
+                &self.node_states,
+                &source_ids,
+                self.multistatic_fuser.guard_interval_us(),
+            )?;
+            let advance_hysteresis =
+                self.last_calibrated_presence_sequences.as_ref() != Some(&sequences);
+            if advance_hysteresis {
+                self.last_calibrated_presence_sequences = Some(sequences);
+            }
+            field_bridge::calibrated_multilink_occupancy(
+                self.field_model.as_ref()?,
+                &observation,
+                observed_at_unix_ms.saturating_mul(1_000),
+                &mut self.calibrated_presence_detector,
+                advance_hysteresis,
+            )?
+        };
+        let residual_energy =
+            occupancy
+                .residual_evidence
+                .as_ref()
+                .map(|evidence| CalibratedResidualEnergyEvidence {
+                    nodes: source_ids
+                        .iter()
+                        .copied()
+                        .zip(evidence.links.iter())
+                        .map(|(node_id, link)| CalibratedNodeResidualEnergy {
+                            node_id,
+                            energy: link.energy,
+                            null_median: link.null_median,
+                            null_p95: link.null_p95,
+                            null_p99: link.null_p99,
+                            normalized_energy: link.normalized_energy,
+                            decision_threshold: link.decision_threshold,
+                            above_threshold: link.above_threshold,
+                        })
+                        .collect(),
+                    aggregate_mean_energy: evidence.aggregate_mean_energy,
+                    aggregate_mean_normalized_energy: evidence.aggregate_mean_normalized_energy,
+                    nodes_above_threshold: evidence.nodes_above_threshold,
+                    node_quorum: evidence.node_quorum,
+                    hysteresis_present: evidence.hysteresis_present,
+                    hysteresis_candidate_frames: evidence.hysteresis_candidate_frames,
+                });
+        self.calibration_session
+            .calibrated_presence_evidence_with_residual(
+                inference_node_id,
+                source_tick,
+                observed_at_unix_ms,
+                occupancy.person_count,
+                occupancy.method.wire_name(),
+                residual_energy,
+            )
     }
 
     fn effective_source(&self) -> String {
@@ -1776,6 +2170,11 @@ impl AppStateInner {
             ),
             mat_api_state: wifi_densepose_mat::api::AppState::new(),
             field_model: None,
+            last_calibration_sequences: None,
+            calibrated_presence_detector: field_bridge::CalibratedPresenceDetector::new(
+                field_bridge::PresenceDetectorConfig::default(),
+            ),
+            last_calibrated_presence_sequences: None,
             calibration_session: CalibrationSessionContract::new(),
             p95_variance: RollingP95::new(600, 60),
             p95_motion_band_power: RollingP95::new(600, 60),
@@ -2507,6 +2906,8 @@ fn compute_subcarrier_variances(frame_history: &VecDeque<Vec<f64>>, n_sub: usize
 /// Returns (features, raw_classification, breathing_rate_hz, sub_variances, raw_motion_score).
 fn extract_features_from_frame(
     frame: &Esp32Frame,
+    // Every caller appends `frame` first. The previous sample is immediately
+    // before the history tail, not `back()` (which is the current frame).
     frame_history: &VecDeque<Vec<f64>>,
     sample_rate_hz: f64,
 ) -> (FeatureInfo, ClassificationInfo, f64, Vec<f64>, f64) {
@@ -2610,7 +3011,7 @@ fn extract_features_from_frame(
     // ── Motion score: sliding-window temporal difference ──
     // Compare current frame against the most recent historical frame.
     // The difference is normalised by the mean amplitude to be scale-invariant.
-    let temporal_motion_score = if let Some(prev_frame) = frame_history.back() {
+    let temporal_motion_score = if let Some(prev_frame) = frame_history.iter().rev().nth(1) {
         let n_cmp = n_sub.min(prev_frame.len());
         if n_cmp > 0 {
             let diff_energy: f64 = (0..n_cmp)
@@ -2678,6 +3079,48 @@ fn extract_features_from_frame(
         sub_variances,
         motion_score,
     )
+}
+
+#[cfg(test)]
+mod feature_extraction_regression_tests {
+    use super::*;
+
+    fn test_frame(amplitudes: Vec<f64>) -> Esp32Frame {
+        let n_subcarriers = amplitudes.len() as u16;
+        Esp32Frame {
+            magic: 0xC511_0001,
+            node_id: 11,
+            n_antennas: 1,
+            n_subcarriers,
+            freq_mhz: 2437,
+            sequence: 2,
+            rssi: -45,
+            noise_floor: -90,
+            ppdu_type: wifi_densepose_hardware::PpduType::HtLegacy,
+            adr018_flags: wifi_densepose_hardware::Adr018Flags::default(),
+            amplitudes,
+            phases: vec![0.0; n_subcarriers as usize],
+        }
+    }
+
+    #[test]
+    fn temporal_motion_compares_with_frame_before_current_history_tail() {
+        let current = test_frame(vec![2.0; 4]);
+        let history = VecDeque::from([vec![1.0; 4], current.amplitudes.clone()]);
+        let (_, _, _, _, raw_motion) = extract_features_from_frame(&current, &history, 20.0);
+        assert!(
+            raw_motion >= 0.19,
+            "current tail was compared with itself: {raw_motion}"
+        );
+    }
+
+    #[test]
+    fn identical_consecutive_frames_remain_motionless() {
+        let current = test_frame(vec![2.0; 4]);
+        let history = VecDeque::from([current.amplitudes.clone(), current.amplitudes.clone()]);
+        let (_, _, _, _, raw_motion) = extract_features_from_frame(&current, &history, 20.0);
+        assert_eq!(raw_motion, 0.0);
+    }
 }
 
 /// Simple threshold classification (no smoothing) — used as the "raw" input.
@@ -3181,8 +3624,14 @@ mod vital_smoothing_response_tests {
         for _ in 0..80 {
             smooth_vitals_node(&mut node, &estimate(90.0));
         }
-        let output = node.latest_vitals.heart_rate_bpm.unwrap_or(node.smoothed_hr);
-        assert!(output > 84.0, "sustained 90 BPM evidence remained stuck at {output}");
+        let output = node
+            .latest_vitals
+            .heart_rate_bpm
+            .unwrap_or(node.smoothed_hr);
+        assert!(
+            output > 84.0,
+            "sustained 90 BPM evidence remained stuck at {output}"
+        );
         assert!(output <= 90.0);
     }
 }
@@ -6428,6 +6877,8 @@ async fn legacy_pose_calibration_start(
         Ok(fm) => {
             let status = format!("{:?}", fm.status()).to_lowercase();
             s.field_model = Some(fm);
+            s.calibrated_presence_detector.reset();
+            s.last_calibrated_presence_sequences = None;
             Json(serde_json::json!({
                 "success": true,
                 "message": "Legacy unbound calibration started — keep room empty while frames accumulate.",
@@ -6473,7 +6924,9 @@ async fn calibration_start(
             "frame_count": fm.calibration_frame_count(),
         }));
     }
-    match FieldModel::new(field_bridge::single_link_config()) {
+    match FieldModel::new(field_bridge::multi_link_config(
+        binding.source_node_ids().len(),
+    )) {
         Ok(fm) => {
             let status = format!("{:?}", fm.status()).to_lowercase();
             let identity = match s.calibration_session.begin(binding) {
@@ -6481,6 +6934,16 @@ async fn calibration_start(
                 Err(error) => return calibration_contract_error(error),
             };
             s.field_model = Some(fm);
+            s.calibrated_presence_detector.reset();
+            s.last_calibrated_presence_sequences = None;
+            // Snapshot any already-present cohort. Calibration evidence begins
+            // only after every source advances beyond this start boundary.
+            s.last_calibration_sequences = coherent_bound_observation(
+                &s.node_states,
+                &identity.source_node_ids,
+                s.multistatic_fuser.guard_interval_us(),
+            )
+            .map(|(_, sequences)| sequences);
             Json(serde_json::json!({
                 "success": true,
                 "message": "Calibration started — keep room empty while frames accumulate.",
@@ -6631,6 +7094,9 @@ async fn calibration_reset(
     // Reset is the only endpoint allowed to discard a Collecting, Fresh,
     // Stale, Expired, or legacy unbound global model.
     s.field_model = None;
+    s.calibrated_presence_detector.reset();
+    s.last_calibrated_presence_sequences = None;
+    s.last_calibration_sequences = None;
     Json(serde_json::json!({
         "success": true,
         "message": "Calibration model reset.",
@@ -6680,6 +7146,9 @@ async fn calibration_cancel(
         Err(error) => return calibration_contract_error(error),
     };
     s.field_model = None;
+    s.calibrated_presence_detector.reset();
+    s.last_calibrated_presence_sequences = None;
+    s.last_calibration_sequences = None;
     Json(serde_json::json!({
         "success": true,
         "message": "Unfinished empty-room capture cancelled.",
@@ -6776,8 +7245,7 @@ mod calibration_api_contract_tests {
         let Json(start) = calibration_start(State(state.clone()), Json(start_request())).await;
         let request = bound_request(&start);
 
-        let Json(cancelled) =
-            calibration_cancel(State(state.clone()), Json(request.clone())).await;
+        let Json(cancelled) = calibration_cancel(State(state.clone()), Json(request.clone())).await;
         assert_eq!(cancelled["success"], true);
         assert_eq!(cancelled["status"], "none");
         assert_eq!(cancelled["cancelled_session_id"], start["session_id"]);
@@ -6798,7 +7266,69 @@ mod calibration_api_contract_tests {
             calibration_cancel(State(state.clone()), Json(completed_request)).await;
         assert_eq!(rejected["success"], false);
         assert_eq!(rejected["error_code"], "calibration_not_collecting");
-        assert!(state.read().await.calibration_session.model_receipt().is_some());
+        assert!(state
+            .read()
+            .await
+            .calibration_session
+            .model_receipt()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn bound_multilink_calibration_waits_for_every_node_to_advance() {
+        let state = state();
+        let Json(start) = calibration_start(State(state.clone()), Json(start_request())).await;
+        assert_eq!(start["source_node_ids"], serde_json::json!([1, 7]));
+
+        let mut inner = state.write().await;
+        for node_id in [1_u8, 7_u8] {
+            let mut node = NodeState::new();
+            node.frame_history
+                .push_back(vec![0.5 + f64::from(node_id) * 0.01; 128]);
+            node.last_frame_time = Some(std::time::Instant::now());
+            node.latest_csi_sequence = Some(1);
+            inner.node_states.insert(node_id, node);
+        }
+        let mut unrelated = NodeState::new();
+        unrelated.frame_history.push_back(vec![0.9; 128]);
+        unrelated.last_frame_time = Some(std::time::Instant::now());
+        unrelated.latest_csi_sequence = Some(99);
+        inner.node_states.insert(99, unrelated);
+
+        maybe_feed_bound_calibration(&mut inner, 1);
+        assert_eq!(
+            inner
+                .field_model
+                .as_ref()
+                .expect("bound field model")
+                .calibration_frame_count(),
+            1,
+            "bound nodes must form one frame without contamination by an unrelated active node"
+        );
+
+        inner.node_states.get_mut(&1).unwrap().latest_csi_sequence = Some(2);
+        maybe_feed_bound_calibration(&mut inner, 1);
+        assert_eq!(
+            inner
+                .field_model
+                .as_ref()
+                .unwrap()
+                .calibration_frame_count(),
+            1,
+            "a fast node must not duplicate the unchanged peer in the baseline"
+        );
+
+        inner.node_states.get_mut(&7).unwrap().latest_csi_sequence = Some(2);
+        maybe_feed_bound_calibration(&mut inner, 7);
+        assert_eq!(
+            inner
+                .field_model
+                .as_ref()
+                .unwrap()
+                .calibration_frame_count(),
+            2,
+            "the next cohort is admitted after every bound node advances"
+        );
     }
 
     #[tokio::test]
@@ -6895,7 +7425,7 @@ mod calibration_api_contract_tests {
         let json = serde_json::to_value(&evidence).unwrap();
         assert_eq!(
             json["schema"],
-            "ruview.calibration.calibrated-presence-evidence.v1"
+            wifi_densepose_sensing_server::calibration_session::CALIBRATED_PRESENCE_EVIDENCE_SCHEMA
         );
         assert_eq!(json["binding_digest"], DIGEST_A);
         assert_eq!(json["source_node_ids"], serde_json::json!([1]));
@@ -7370,6 +7900,7 @@ async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Va
                 "person_count": ns.prev_person_count,
                 "detected_device_type": detected_device_type,
                 "device_type_evidence": device_type_evidence,
+                "health": ns.latest_health.as_ref().map(|health| node_health_json(health, now)),
             })
         })
         .collect();
@@ -7444,6 +7975,31 @@ async fn udp_receiver_task(
                         }
                         Ok(_) => warn!("Rejected non-synthetic canonical vendor event from {src}; live payloads must use the provider decoder HTTP route"),
                         Err(error) => warn!("Rejected ADR-270 vendor event from {src}: {error}"),
+                    }
+                    continue;
+                }
+                if len >= 4
+                    && u32::from_le_bytes(buf[..4].try_into().expect("four-byte slice"))
+                        == wifi_densepose_hardware::MESH_MAGIC
+                {
+                    match decode_node_health_datagram(&buf[..len]) {
+                        Some(observation) => {
+                            debug!(
+                                "ESP32 HEALTH from {src}: node={} epoch={} uptime_ms={} retries={} send_failures={}",
+                                observation.node_id,
+                                observation.mesh_epoch,
+                                observation.status.local_time_us / 1_000,
+                                observation.status.wifi_retry_count,
+                                observation.status.send_fail_count,
+                            );
+                            let mut s = state.write().await;
+                            let node = s
+                                .node_states
+                                .entry(observation.node_id)
+                                .or_insert_with(NodeState::new);
+                            node.latest_health = Some(observation);
+                        }
+                        None => warn!("Rejected ESP32 mesh HEALTH datagram from {src}"),
                     }
                     continue;
                 }
@@ -7644,20 +8200,7 @@ async fn udp_receiver_task(
 
                     // A bound session accepts only its snapshotted source-node
                     // set. Unrelated ESP32 traffic must not enter this model.
-                    if s.calibration_session.accepts_source_node(node_id) {
-                        if let Some(frame_history) = s
-                            .node_states
-                            .get(&node_id)
-                            .map(|ns| ns.frame_history.clone())
-                        {
-                            let contributes = s.calibration_session.record_source_node(node_id);
-                            if contributes {
-                                if let Some(ref mut fm) = s.field_model {
-                                    field_bridge::maybe_feed_calibration(fm, &frame_history);
-                                }
-                            }
-                        }
-                    }
+                    maybe_feed_bound_calibration(&mut s, node_id);
 
                     // Build nodes array with all active nodes.
                     let active_nodes: Vec<NodeInfo> = s
@@ -8003,7 +8546,7 @@ async fn udp_receiver_task(
                         ns.frame_history.pop_front();
                     }
 
-                    let sample_rate_hz = 1000.0 / 500.0_f64;
+                    let sample_rate_hz = ns.feature_sample_rate_hz();
                     let (
                         features,
                         mut classification,
@@ -8138,20 +8681,7 @@ async fn udp_receiver_task(
 
                     // A bound session accepts only its snapshotted source-node
                     // set. Unrelated ESP32 traffic must not enter this model.
-                    if s.calibration_session.accepts_source_node(node_id) {
-                        if let Some(frame_history) = s
-                            .node_states
-                            .get(&node_id)
-                            .map(|ns| ns.frame_history.clone())
-                        {
-                            let contributes = s.calibration_session.record_source_node(node_id);
-                            if contributes {
-                                if let Some(ref mut fm) = s.field_model {
-                                    field_bridge::maybe_feed_calibration(fm, &frame_history);
-                                }
-                            }
-                        }
-                    }
+                    maybe_feed_bound_calibration(&mut s, node_id);
 
                     // Build nodes array with all active nodes. ADR-141 output
                     // gating (review finding 1c): when the governed engine
@@ -9887,6 +10417,13 @@ async fn main() {
         } else {
             None
         },
+        last_calibration_sequences: None,
+        calibrated_presence_detector: {
+            let config = field_bridge::PresenceDetectorConfig::from_env();
+            info!(?config, "Calibrated presence detector configuration");
+            field_bridge::CalibratedPresenceDetector::new(config)
+        },
+        last_calibrated_presence_sequences: None,
         calibration_session: CalibrationSessionContract::new(),
         // ADR-044 §5.2: rolling-P95 over ~30 s at 20 Hz; warm-up after 60 samples.
         p95_variance: RollingP95::new(600, 60),

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -440,6 +440,7 @@ fn decode_node_health_datagram(buf: &[u8]) -> Option<NodeHealthObservation> {
 fn reset_reason_name(reason: u8) -> &'static str {
     match reason {
         1 => "power_on",
+        2 => "external_pin",
         3 => "software",
         4 => "panic",
         5 => "interrupt_watchdog",
@@ -448,6 +449,11 @@ fn reset_reason_name(reason: u8) -> &'static str {
         8 => "deep_sleep",
         9 => "brownout",
         10 => "sdio",
+        11 => "usb",
+        12 => "jtag",
+        13 => "efuse_error",
+        14 => "power_glitch",
+        15 => "cpu_lockup",
         _ => "unknown",
     }
 }
@@ -937,6 +943,17 @@ mod node_health_ingestion_tests {
         assert_eq!(value["udp_send_failures"], 5);
         assert_eq!(value["packet_yield_per_sec"], 37);
         assert_eq!(value["free_heap_bytes"], 181_224);
+    }
+
+    #[test]
+    fn reset_reason_names_cover_current_esp_idf_reasons() {
+        assert_eq!(reset_reason_name(2), "external_pin");
+        assert_eq!(reset_reason_name(11), "usb");
+        assert_eq!(reset_reason_name(12), "jtag");
+        assert_eq!(reset_reason_name(13), "efuse_error");
+        assert_eq!(reset_reason_name(14), "power_glitch");
+        assert_eq!(reset_reason_name(15), "cpu_lockup");
+        assert_eq!(reset_reason_name(255), "unknown");
     }
 }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/multistatic_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/multistatic_bridge.rs
@@ -119,10 +119,36 @@ pub fn node_frames_from_states_with_guard(
     node_states: &HashMap<u8, NodeState>,
     guard_interval_us: u64,
 ) -> Vec<MultiBandCsiFrame> {
+    node_frames_from_states_with_guard_for_nodes(node_states, guard_interval_us, None)
+}
+
+/// As [`node_frames_from_states_with_guard`], restricted to an immutable
+/// source-node set. Unrelated active radios cannot displace or invalidate a
+/// calibration cohort.
+pub fn bound_node_frames_from_states_with_guard(
+    node_states: &HashMap<u8, NodeState>,
+    guard_interval_us: u64,
+    source_node_ids: &[u8],
+) -> Vec<MultiBandCsiFrame> {
+    node_frames_from_states_with_guard_for_nodes(
+        node_states,
+        guard_interval_us,
+        Some(source_node_ids),
+    )
+}
+
+fn node_frames_from_states_with_guard_for_nodes(
+    node_states: &HashMap<u8, NodeState>,
+    guard_interval_us: u64,
+    source_node_ids: Option<&[u8]>,
+) -> Vec<MultiBandCsiFrame> {
     let now = Instant::now();
     let mut active: Vec<(u8, &NodeState)> = node_states
         .iter()
         .filter_map(|(&node_id, ns)| {
+            if source_node_ids.is_some_and(|ids| ids.binary_search(&node_id).is_err()) {
+                return None;
+            }
             let last_time = ns.last_frame_time.as_ref()?;
             (now.duration_since(*last_time) <= STALE_THRESHOLD).then_some((node_id, ns))
         })

--- a/v2/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
+++ b/v2/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
@@ -291,6 +291,21 @@ pub struct FieldNormalMode {
     /// per-window sample size. Defaults to 0.0 in the diagonal-fallback path.
     /// Issue #942.
     pub baseline_noise_var: f64,
+    /// Empirical empty-room residual-energy distribution for each link.
+    /// Runtime detectors use these learned quantiles instead of comparing
+    /// installation-dependent CSI amplitudes with an absolute threshold.
+    pub null_residual_energy: Vec<NullResidualEnergy>,
+}
+
+/// Robust, bounded summary of one link's residual energy while the room was
+/// explicitly empty. Quantiles are learned after removing the fitted normal
+/// modes, so they describe the detector's actual runtime feature.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NullResidualEnergy {
+    pub median: f64,
+    pub p95: f64,
+    pub p99: f64,
+    pub sample_count: usize,
 }
 
 /// Body perturbation extracted from a CSI observation.
@@ -345,6 +360,19 @@ pub struct FieldModel {
     covariance_sum: Option<Array2<f64>>,
     /// Number of frames accumulated into covariance_sum.
     covariance_count: u64,
+    /// Recent empty-room cohorts retained solely to learn post-projection
+    /// residual quantiles at finalize time. Bounded to avoid retaining an
+    /// unbounded CSI history.
+    null_residual_reservoir: Vec<Vec<Vec<f64>>>,
+}
+
+const NULL_RESIDUAL_RESERVOIR_CAPACITY: usize = 2_048;
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
 }
 
 /// Diagonal variance fallback for when full covariance SVD is unavailable.
@@ -400,6 +428,52 @@ fn diagonal_fallback(
     (mode_energies, environmental_modes, baseline_count)
 }
 
+fn residual_energy_after_projection(
+    observation: &[f64],
+    baseline: &[f64],
+    environmental_modes: &[Vec<f64>],
+) -> f64 {
+    let mut residual: Vec<f64> = observation
+        .iter()
+        .zip(baseline.iter())
+        .map(|(value, mean)| value - mean)
+        .collect();
+    for mode in environmental_modes {
+        let projection = residual
+            .iter()
+            .zip(mode.iter())
+            .map(|(value, coefficient)| value * coefficient)
+            .sum::<f64>();
+        for (value, coefficient) in residual.iter_mut().zip(mode.iter()) {
+            *value -= projection * coefficient;
+        }
+    }
+    residual
+        .iter()
+        .map(|value| value * value)
+        .sum::<f64>()
+        .sqrt()
+}
+
+fn summarize_null_residual_energy(mut samples: Vec<f64>) -> NullResidualEnergy {
+    samples.retain(|value| value.is_finite() && *value >= 0.0);
+    samples.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+    let sample_count = samples.len();
+    let quantile = |fraction: f64| {
+        if samples.is_empty() {
+            return 0.0;
+        }
+        let index = ((samples.len() - 1) as f64 * fraction).ceil() as usize;
+        samples[index.min(samples.len() - 1)]
+    };
+    NullResidualEnergy {
+        median: quantile(0.50),
+        p95: quantile(0.95),
+        p99: quantile(0.99),
+        sample_count,
+    }
+}
+
 impl FieldModel {
     /// Create a new field model for the given configuration.
     pub fn new(config: FieldModelConfig) -> Result<Self, FieldModelError> {
@@ -429,6 +503,7 @@ impl FieldModel {
             last_calibration_us: 0,
             covariance_sum: None,
             covariance_count: 0,
+            null_residual_reservoir: Vec::with_capacity(NULL_RESIDUAL_RESERVOIR_CAPACITY),
         })
     }
 
@@ -495,6 +570,20 @@ impl FieldModel {
         }
         // Count once per frame (not per link) for correct MP ratio
         self.covariance_count += 1;
+
+        if self.null_residual_reservoir.len() < NULL_RESIDUAL_RESERVOIR_CAPACITY {
+            self.null_residual_reservoir.push(observations.to_vec());
+        } else {
+            // Deterministic Algorithm-R reservoir sampling spreads the bounded
+            // sample across the entire empty-room interval instead of keeping
+            // only its final minute. The mixing function is not used for
+            // security; it merely avoids a periodic sampling bias.
+            let seen = self.covariance_count as usize;
+            let index = splitmix64(self.covariance_count) as usize % seen;
+            if index < NULL_RESIDUAL_RESERVOIR_CAPACITY {
+                self.null_residual_reservoir[index] = observations.to_vec();
+            }
+        }
 
         Ok(())
     }
@@ -616,8 +705,7 @@ impl FieldModel {
                         }
                         Err(_) => {
                             // Fallback to diagonal approximation on SVD failure
-                            let (e, m, b) =
-                                diagonal_fallback(&self.link_stats, n_sc, n_modes);
+                            let (e, m, b) = diagonal_fallback(&self.link_stats, n_sc, n_modes);
                             (e, m, b, 0.0_f64)
                         }
                     }
@@ -669,6 +757,21 @@ impl FieldModel {
             0.0
         };
 
+        let mut residual_samples = vec![Vec::new(); self.config.n_links];
+        for cohort in &self.null_residual_reservoir {
+            for (link_idx, observation) in cohort.iter().enumerate() {
+                residual_samples[link_idx].push(residual_energy_after_projection(
+                    observation,
+                    &baseline[link_idx],
+                    &environmental_modes,
+                ));
+            }
+        }
+        let null_residual_energy = residual_samples
+            .into_iter()
+            .map(summarize_null_residual_energy)
+            .collect();
+
         let field_mode = FieldNormalMode {
             baseline,
             environmental_modes,
@@ -678,6 +781,7 @@ impl FieldModel {
             geometry_hash,
             baseline_eigenvalue_count: baseline_eig_count,
             baseline_noise_var,
+            null_residual_energy,
         };
 
         self.modes = Some(field_mode);
@@ -935,6 +1039,33 @@ mod tests {
         assert!((w.mean - 5.0).abs() < 1e-10);
         assert!((w.variance() - 4.0).abs() < 1e-10);
         assert_eq!(w.count, 8);
+    }
+
+    #[test]
+    fn finalize_learns_per_link_null_residual_energy_distribution() {
+        let mut model = FieldModel::new(make_config(3, 8, 32)).unwrap();
+        for frame in 0..96 {
+            let observations = (0..3)
+                .map(|link| {
+                    (0..8)
+                        .map(|tone| {
+                            let phase = (frame * (link + 1) + tone * 7) as f64 * 0.071;
+                            2.0 + link as f64 * 0.4 + tone as f64 * 0.02 + phase.sin() * 0.08
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+            model.feed_calibration(&observations).unwrap();
+        }
+
+        let modes = model.finalize_calibration(1_000_000, 7).unwrap();
+        assert_eq!(modes.null_residual_energy.len(), 3);
+        for learned in &modes.null_residual_energy {
+            assert_eq!(learned.sample_count, 96);
+            assert!(learned.median.is_finite() && learned.median >= 0.0);
+            assert!(learned.p95 >= learned.median);
+            assert!(learned.p99 >= learned.p95);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Review scope

This is an exact-change review PR for the three C6 commits developed and physically exercised on nodes 11-13. It intentionally targets `codex/c6-recovery-review-base` (the original source parent) because current `main` does not contain `calibration_session.rs` and a PR directly to `main` would include thousands of unrelated NLOS/social-history files. **Do not merge this stacked review PR as-is.** Please review the detector, HEALTH wire contract, retry/recovery behavior, and test coverage; integration onto the selected upstream sensing baseline should follow after that decision.

## Changes

- expose per-node and aggregate residual-energy evidence
- normalize presence against learned empty-room residual distributions
- add hysteresis and configurable node quorum
- extend C6 HEALTH with association/channel/disconnect/retry/UDP/heap diagnostics
- raise Wi-Fi retry window to 90 attempts and preserve stale-to-active recovery
- add hardware recovery evidence harness and reset-reason decoding
- support the ESP-IDF 6 GPIO wake API

## Verification

- `python3 -m unittest -v test_wifi_recovery_harness.py`: 4 passed
- `make check LDLIBS=` on macOS: 60 assertions passed across adaptive controller, feature state, and mesh suites
- focused Rust run reached and passed the changed detector/HEALTH tests, including `null_normalized_detector_requires_quorum_and_hysteresis`, calibrated occupancy, and extended HEALTH decoding
- physical nodes 11-13: helper restart, stale-to-active, >90 s AP outage, and AP reboot/channel-change harness scenarios all passed

## Known gate outside this diff

The existing `auth_wiring::with_auth_off_both_listeners_stay_open` fails reproducibly before its assertions: the server refuses unauthenticated startup because calibration guidance requires RuView API authentication. The C6 commits do not modify that policy. This draft does not claim a globally green workspace.

## Review questions

1. Is the learned-null normalization faithful to the contrastive zero-first design?
2. Are quorum and hysteresis defaults appropriate for three-node C6 deployments?
3. Should malformed HEALTH rejection expose decoder reasons and counters?
4. Where should this be rebased now that current `main` lacks the original calibration-session baseline?