### PR TITLE
perf(firmware): stop the C6 sharing its radio with a stack that cannot receive

### DIFF
--- a/firmware/esp32-csi-node/sdkconfig.defaults.esp32c6
+++ b/firmware/esp32-csi-node/sdkconfig.defaults.esp32c6
@@ -77,3 +77,22 @@ CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=8192
 # ── Power: keep CPU at max 160 MHz (C6 ceiling) for DSP throughput ──
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_160=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=160
+
+# ADR-110 D1 / ruvnet/RuView#762: the 802.15.4 RX path never delivers a
+# protocol frame on IDF v5.4. Upstream tested five configurations -- channel
+# 15 and 26, OpenThread on and off, promiscuous on and off, PAN-matched and
+# broadcast -- and every one gave rx=0 with TX at 100% reliability. ESP-NOW
+# shipped as the workaround and is what this firmware actually syncs on
+# (measured 99.56% cross-board delivery, 104 us smoothed offset).
+#
+# The C6 has a single 2.4 GHz transceiver shared by WiFi, BLE and 802.15.4,
+# so leaving the 15.4 stack running costs coexistence time-slicing against
+# the CSI capture that is the entire point of the node -- beaconing every
+# 100 ms and listening on a radio that provably returns nothing. Disable it
+# and give the airtime back to WiFi, which matters most at nine nodes where
+# the 50 Hz receive gate is already the binding constraint.
+#
+# Safe to turn off: the ADR-018 byte 19 bit 4 "sync valid" flag is ORed from
+# both transports and the 15.4 branch is #ifdef-gated on this symbol, so the
+# working ESP-NOW path keeps setting it.
+CONFIG_C6_TIMESYNC_ENABLE=n


### PR DESCRIPTION
## What is wrong

The ESP32-C6 has a single 2.4 GHz radio shared between WiFi and 802.15.4 by
coexistence time-slicing. The 802.15.4 stack is started, but nothing in this
firmware receives on it — so every node pays coexistence overhead for a
capability it never uses.

That overhead comes directly out of CSI capture, which is the entire job of the
device.

## The fix

Disable the unused 802.15.4 stack in `sdkconfig.defaults.esp32c6`. Config only,
19 lines, no source change.

## Scope

C6-specific and confined to the C6 defaults file. S3 builds are untouched, since
they have no shared-radio coexistence to begin with.

## Testing

Built for esp32c6 with ESP-IDF v5.4 in the `espressif/idf:v5.4` container.