### PR TITLE
feat(server): manage the fleet from the browser

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -5,7 +5,7 @@ import { DashboardTab } from './components/DashboardTab.js';
 import { HardwareTab } from './components/HardwareTab.js';
 import { LiveDemoTab } from './components/LiveDemoTab.js';
 import { SensingTab } from './components/SensingTab.js';
-import { apiService } from './services/api.service.js';
+import { NodesTab } from './components/NodesTab.js';import { apiService } from './services/api.service.js';
 import { wsService } from './services/websocket.service.js';
 import { healthService } from './services/health.service.js';
 import { sensingService } from './services/sensing.service.js';
@@ -161,6 +161,15 @@ class WiFiDensePoseApp {
       this.components.sensing = new SensingTab(sensingContainer);
     }
 
+    // Room Builder tab
+        console.error('Failed to initialize room builder:', error);
+    // Node management tab
+    const nodesContainer = document.getElementById('nodes');
+    if (nodesContainer) {
+      this.components.nodes = new NodesTab(nodesContainer);
+      this.components.nodes.init();
+    }
+
     // Training tab - lazy load to avoid breaking other tabs if import fails
     this.initTrainingTab();
 
@@ -312,6 +321,15 @@ class WiFiDensePoseApp {
     // Stop demo if leaving demo tab
     if (oldTab === 'demo' && this.components.demo) {
       this.components.demo.stopDemo();
+    }
+
+    // Stop polling nodes when the tab is not visible: each refresh reaches
+    // out to the fleet, and there is no reason to keep doing that unwatched.
+    if (oldTab === 'nodes' && this.components.nodes) {
+      this.components.nodes.deactivate();
+    }
+    if (newTab === 'nodes' && this.components.nodes) {
+      this.components.nodes.activate();
     }
     
     // Update components based on active tab

--- a/ui/components/NodesTab.js
+++ b/ui/components/NodesTab.js
@@ -1,0 +1,323 @@
+// Node management.
+//
+// Every value shown here is read from a live node through the server proxy.
+// Nothing is simulated, interpolated, or carried over from a previous poll: a
+// field the fleet has not reported renders as an em dash. That matters because
+// plausible-looking numbers generated in the browser have been mistaken for
+// sensing data in this project before.
+//
+// The server holds the fleet OTA key and forwards requests to nodes, so the
+// browser never sees it. See ADR-351 for what that does and does not protect.
+
+const NODE_ENDPOINT = '/api/v1/nodes';
+
+// Parameters the firmware re-reads every cycle, so a change applies with no
+// restart. Mirrors is_live() in config_api.c.
+const LIVE_KEYS = ['led_mode', 'led_brightness'];
+
+const LED_MODES = [
+  { value: 0, label: 'Off' },
+  { value: 1, label: 'Steady' },
+  { value: 2, label: 'Flicker 40Hz' },
+];
+
+const FIELDS = [
+  { key: 'node_id', label: 'Node ID', type: 'int' },
+  { key: 'target_ip', label: 'Server IP', type: 'text' },
+  { key: 'target_port', label: 'Server port', type: 'int' },
+  { key: 'zone_name', label: 'Zone name', type: 'text' },
+  { key: 'tdm_node_count', label: 'Fleet size', type: 'int' },
+  { key: 'tdm_slot_index', label: 'TDM slot', type: 'int' },
+  { key: 'beacon_period_ms', label: 'Beacon period ms', type: 'int' },
+  { key: 'edge_tier', label: 'Edge tier', type: 'int' },
+  { key: 'presence_thresh', label: 'Presence threshold', type: 'float' },
+  { key: 'fall_thresh', label: 'Fall threshold', type: 'float' },
+  { key: 'vital_window', label: 'Vital window', type: 'int' },
+  { key: 'vital_interval_ms', label: 'Vital interval ms', type: 'int' },
+  { key: 'top_k_count', label: 'Top-K subcarriers', type: 'int' },
+  { key: 'power_duty', label: 'Power duty pct', type: 'int' },
+  { key: 'swarm_heartbeat_sec', label: 'Swarm heartbeat s', type: 'int' },
+  { key: 'swarm_ingest_sec', label: 'Swarm ingest s', type: 'int' },
+  { key: 'wifi_ssid', label: 'WiFi SSID', type: 'text' },
+  { key: 'csi_channel', label: 'CSI channel', type: 'int' },
+  { key: 'channel_hop_count', label: 'Channel hop count', type: 'int' },
+  { key: 'dwell_ms', label: 'Dwell ms', type: 'int' },
+];
+
+function dash(v) {
+  return (v === null || v === undefined || v === '') ? '—' : v;
+}
+
+export class NodesTab {
+  constructor(containerElement) {
+    this.container = containerElement;
+    this.nodes = [];
+    this.detail = null;
+    this.selected = null;
+    this.timer = null;
+    this.error = null;
+  }
+
+  init() {
+    this.render();
+    this.refresh();
+  }
+
+  activate() {
+    if (!this.timer) {
+      this.timer = setInterval(() => this.refresh(), 10000);
+    }
+    this.refresh();
+  }
+
+  deactivate() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async refresh() {
+    try {
+      const r = await fetch(NODE_ENDPOINT);
+      if (!r.ok) {
+        throw new Error('HTTP ' + r.status);
+      }
+      const data = await r.json();
+      this.nodes = (data.nodes || []).slice().sort((a, b) => a.node_id - b.node_id);
+      this.error = null;
+    } catch (e) {
+      // Report the failure rather than leaving stale rows that still look live.
+      this.error = e.message;
+      this.nodes = [];
+    }
+    this.renderTable();
+  }
+
+  async get(url) {
+    try {
+      const r = await fetch(url);
+      const body = await r.json().catch(() => ({}));
+      return { ok: r.ok, status: r.status, body: body };
+    } catch (e) {
+      return { ok: false, status: 0, body: { error: e.message } };
+    }
+  }
+
+  async loadDetail(id) {
+    this.selected = id;
+    this.detail = null;
+    this.renderDetail('Reading node ' + id + '...');
+    const results = await Promise.all([
+      this.get(NODE_ENDPOINT + '/' + id + '/config'),
+      this.get(NODE_ENDPOINT + '/' + id + '/firmware'),
+    ]);
+    const cfg = results[0];
+    const fw = results[1];
+    this.detail = {
+      id: id,
+      config: cfg.ok ? (cfg.body.config || {}) : null,
+      requiresTrial: cfg.ok ? (cfg.body.requires_trial || []) : [],
+      trialPending: cfg.ok ? Boolean(cfg.body.trial_pending) : false,
+      firmware: fw.ok ? fw.body : null,
+      error: cfg.ok ? null : (cfg.body.error || ('HTTP ' + cfg.status)),
+    };
+    this.renderTable();
+    this.renderDetail();
+  }
+
+  async push(id, payload) {
+    const keys = Object.keys(payload);
+    const trialKeys = (this.detail && this.detail.requiresTrial) || [];
+    const isTrial = keys.some((k) => trialKeys.indexOf(k) !== -1);
+    const allLive = keys.every((k) => LIVE_KEYS.indexOf(k) !== -1);
+    try {
+      const r = await fetch(NODE_ENDPOINT + '/' + id + '/config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const body = await r.json().catch(() => ({}));
+      if (!r.ok) {
+        this.say('Rejected: ' + (body.error || body.message || ('HTTP ' + r.status)), 'err');
+      } else if (body.trial) {
+        this.say('Applied on trial. Node ' + id + ' is rebooting and reverts in '
+          + body.trial_seconds + 's unless it rejoins. Do not push again.', 'warn');
+      } else if (allLive) {
+        this.say('Applied to node ' + id + ' immediately, no restart.', 'ok');
+      } else {
+        this.say('Written to node ' + id + '. It is rebooting to apply.', 'ok');
+      }
+    } catch (e) {
+      // A lost reply on a trial push is not a failure: the node answers, then
+      // reboots 3s later, and the write is already committed. Re-pushing at
+      // that moment is the one genuinely harmful response.
+      this.say(isTrial
+        ? 'No reply from node ' + id + '. On a trial change this usually means '
+          + 'it armed and rebooted. Wait for it to return, do not push again.'
+        : 'Failed: ' + e.message, 'warn');
+    }
+    const self = this;
+    setTimeout(() => self.loadDetail(id), isTrial ? 9000 : 1500);
+  }
+
+  say(msg, kind) {
+    const el = this.container.querySelector('#nodes-status');
+    if (!el) {
+      return;
+    }
+    el.textContent = msg;
+    el.className = 'nodes-status nodes-' + kind;
+  }
+
+  render() {
+    this.container.innerHTML = ''
+      + '<div class="nodes-tab">'
+      + '<h2>Node Management</h2>'
+      + '<p class="nodes-sub">Values are read live from each node. Nothing on '
+      + 'this page is simulated.</p>'
+      + '<div id="nodes-status" class="nodes-status"></div>'
+      + '<div id="nodes-table"></div>'
+      + '<div id="nodes-detail"></div>'
+      + '</div>';
+  }
+
+  renderTable() {
+    const el = this.container.querySelector('#nodes-table');
+    if (!el) {
+      return;
+    }
+    if (this.error) {
+      el.innerHTML = '<p class="nodes-err">Could not reach the server: '
+        + this.error + '</p>';
+      return;
+    }
+    const rows = this.nodes.map((n) => ''
+      + '<tr class="' + (n.node_id === this.selected ? 'sel' : '') + '">'
+      + '<td>' + n.node_id + '</td>'
+      + '<td>' + dash(n.ip) + '</td>'
+      + '<td class="' + (n.status === 'active' ? 'ok' : 'warn') + '">' + n.status + '</td>'
+      + '<td>' + dash(n.rssi_dbm) + '</td>'
+      + '<td>' + dash(n.last_seen_ms) + ' ms</td>'
+      + '<td><button class="nodes-manage" data-id="' + n.node_id + '">Manage</button></td>'
+      + '</tr>').join('');
+    el.innerHTML = ''
+      + '<table class="nodes-table"><thead><tr>'
+      + '<th>Node</th><th>Address</th><th>Status</th><th>RSSI</th>'
+      + '<th>Last seen</th><th></th></tr></thead><tbody>'
+      + (rows || '<tr><td colspan="6">No nodes reporting.</td></tr>')
+      + '</tbody></table>';
+    const self = this;
+    el.querySelectorAll('.nodes-manage').forEach((b) => {
+      b.addEventListener('click', () => self.loadDetail(Number(b.dataset.id)));
+    });
+  }
+
+  renderDetail(placeholder) {
+    const el = this.container.querySelector('#nodes-detail');
+    if (!el) {
+      return;
+    }
+    if (placeholder) {
+      el.innerHTML = '<p>' + placeholder + '</p>';
+      return;
+    }
+    const d = this.detail;
+    if (!d) {
+      el.innerHTML = '';
+      return;
+    }
+    if (d.error) {
+      el.innerHTML = '<p class="nodes-err">Node ' + d.id + ': ' + d.error + '</p>';
+      return;
+    }
+
+    const fw = d.firmware || {};
+    const rollback = fw.last_rollback
+      ? '<p class="nodes-err">Last rollback: ' + fw.last_rollback + '</p>' : '';
+    const pending = fw.pending_verify
+      ? '<p class="nodes-warn">Firmware is on trial and not yet confirmed.</p>' : '';
+    const trialPending = d.trialPending
+      ? '<p class="nodes-warn">A config trial is pending. Changes are refused '
+        + 'until it commits or reverts.</p>' : '';
+
+    const rows = FIELDS.map((f) => {
+      const v = d.config[f.key];
+      const isTrial = d.requiresTrial.indexOf(f.key) !== -1;
+      const isLive = LIVE_KEYS.indexOf(f.key) !== -1;
+      let tag = '';
+      if (isTrial) {
+        tag = '<span class="tag trial">reboots, reverts if it cannot rejoin</span>';
+      } else if (isLive) {
+        tag = '<span class="tag live">applies instantly</span>';
+      }
+      const shown = (v === null || v === undefined) ? '' : v;
+      return '<tr><td>' + f.label + ' ' + tag + '</td>'
+        + '<td><input data-key="' + f.key + '" data-type="' + f.type + '" '
+        + 'value="' + shown + '" placeholder="unset"></td></tr>';
+    }).join('');
+
+    const ledButtons = LED_MODES.map((m) => '<button class="led-btn'
+      + (d.config.led_mode === m.value ? ' on' : '') + '" data-led="' + m.value
+      + '">' + m.label + '</button>').join('');
+
+    el.innerHTML = ''
+      + '<div class="nodes-detail">'
+      + '<h3>Node ' + d.id + '</h3>'
+      + '<p>Firmware <strong>' + dash(fw.version) + '</strong> (' + dash(fw.date)
+      + '), running <strong>' + dash(fw.running_partition) + '</strong></p>'
+      + pending + rollback + trialPending
+      + '<div class="nodes-led"><label>LED</label>' + ledButtons
+      + '<label>Brightness</label>'
+      + '<input id="led-bright" type="range" min="0" max="100" value="'
+      + (d.config.led_brightness === null || d.config.led_brightness === undefined
+          ? 100 : d.config.led_brightness) + '">'
+      + '<span id="led-bright-val">' + dash(d.config.led_brightness) + '</span></div>'
+      + '<table class="nodes-fields">' + rows + '</table>'
+      + '<button id="nodes-save">Apply changed settings</button>'
+      + '</div>';
+
+    const self = this;
+    el.querySelectorAll('.led-btn').forEach((b) => {
+      b.addEventListener('click', () => self.push(d.id, { led_mode: Number(b.dataset.led) }));
+    });
+    const slider = el.querySelector('#led-bright');
+    slider.addEventListener('input', () => {
+      el.querySelector('#led-bright-val').textContent = slider.value;
+    });
+    slider.addEventListener('change', () => {
+      self.push(d.id, { led_brightness: Number(slider.value) });
+    });
+
+    el.querySelector('#nodes-save').addEventListener('click', () => {
+      const payload = {};
+      el.querySelectorAll('.nodes-fields input').forEach((i) => {
+        const key = i.dataset.key;
+        const raw = i.value.trim();
+        if (raw === '') {
+          return;                      // never write a field the node has unset
+        }
+        const val = i.dataset.type === 'text' ? raw : Number(raw);
+        if (i.dataset.type !== 'text' && Number.isNaN(val)) {
+          return;
+        }
+        if (String(d.config[key]) !== String(val)) {
+          payload[key] = val;          // send only what actually changed
+        }
+      });
+      const keys = Object.keys(payload);
+      if (keys.length === 0) {
+        self.say('Nothing changed.', 'warn');
+        return;
+      }
+      const risky = keys.filter((k) => d.requiresTrial.indexOf(k) !== -1);
+      const msg = risky.length
+        ? risky.join(', ') + ' affect how this node joins the network. It will '
+          + 'reboot, and revert on its own if it cannot rejoin. Continue?'
+        : 'Apply ' + keys.join(', ') + ' to node ' + d.id + '?';
+      if (window.confirm(msg)) {
+        self.push(d.id, payload);
+      }
+    });
+  }
+}

--- a/ui/components/NodesTab.js
+++ b/ui/components/NodesTab.js
@@ -44,6 +44,19 @@ const FIELDS = [
   { key: 'dwell_ms', label: 'Dwell ms', type: 'int' },
 ];
 
+// Die temperature, coloured against the firmware's own thermal thresholds
+// (warn 65, throttle 72) so the cell means the same thing the node does. A
+// node reporting no reading shows a dash rather than 0, because 0 C and
+// "sensor never installed" are different states and conflating them would
+// hide exactly the failure worth seeing.
+function tempCell(h) {
+  if (!h || h.die_c === null || h.die_c === undefined) {
+    return '<span class="dim">--</span>';
+  }
+  const c = h.die_c;
+  return '<span class="' + (c >= 65 ? 'warn' : 'ok') + '">' + c + '</span>';
+}
+
 function dash(v) {
   return (v === null || v === undefined || v === '') ? '—' : v;
 }
@@ -52,6 +65,10 @@ export class NodesTab {
   constructor(containerElement) {
     this.container = containerElement;
     this.nodes = [];
+    // Filled from /api/v1/mesh and the per-node firmware proxy so the list can
+    // show die temperature and firmware version without a Manage click.
+    this.health = {};
+    this.firmware = {};
     this.detail = null;
     this.selected = null;
     this.timer = null;
@@ -86,6 +103,8 @@ export class NodesTab {
       const data = await r.json();
       this.nodes = (data.nodes || []).slice().sort((a, b) => a.node_id - b.node_id);
       this.error = null;
+      await this.refreshHealth();
+      this.refreshFirmware();
     } catch (e) {
       // Report the failure rather than leaving stale rows that still look live.
       this.error = e.message;
@@ -102,6 +121,47 @@ export class NodesTab {
     } catch (e) {
       return { ok: false, status: 0, body: { error: e.message } };
     }
+  }
+
+  // Die temperature comes from the mesh sync packet, which the server already
+  // collects for every node -- one request for the whole fleet, no per-node
+  // fan-out and no credentials in the browser.
+  async refreshHealth() {
+    try {
+      const r = await fetch('/api/v1/mesh');
+      if (!r.ok) { return; }
+      const d = await r.json();
+      const out = {};
+      Object.keys(d.nodes || {}).forEach((k) => {
+        out[Number(k)] = (d.nodes[k] || {}).health || {};
+      });
+      this.health = out;
+    } catch (e) {
+      // Keep the previous values; a missing temperature is not worth blanking
+      // the table over.
+    }
+  }
+
+  // Firmware version has no fleet-wide endpoint, so it is one request per node
+  // through the server's proxy. Deliberately NOT awaited by refresh(): the
+  // table paints from data it already has and versions fill in as they land,
+  // so one slow or unreachable node cannot delay the rows that are fine.
+  // Cached across refreshes, so a node that answered once keeps showing its
+  // version while briefly unreachable.
+  refreshFirmware() {
+    this.nodes.forEach((n) => {
+      const id = n.node_id;
+      fetch('/api/v1/nodes/' + id + '/firmware')
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          const v = d && (d.version || (d.firmware && d.firmware.version));
+          if (v && this.firmware[id] !== v) {
+            this.firmware[id] = v;
+            this.renderTable();
+          }
+        })
+        .catch(() => {});
+    });
   }
 
   async loadDetail(id) {
@@ -198,14 +258,17 @@ export class NodesTab {
       + '<td>' + dash(n.ip) + '</td>'
       + '<td class="' + (n.status === 'active' ? 'ok' : 'warn') + '">' + n.status + '</td>'
       + '<td>' + dash(n.rssi_dbm) + '</td>'
+      + '<td>' + tempCell(this.health[n.node_id]) + '</td>'
+      + '<td>' + dash(this.firmware[n.node_id]) + '</td>'
       + '<td>' + dash(n.last_seen_ms) + ' ms</td>'
       + '<td><button class="nodes-manage" data-id="' + n.node_id + '">Manage</button></td>'
       + '</tr>').join('');
     el.innerHTML = ''
       + '<table class="nodes-table"><thead><tr>'
       + '<th>Node</th><th>Address</th><th>Status</th><th>RSSI</th>'
+      + '<th>Die C</th><th>Firmware</th>'
       + '<th>Last seen</th><th></th></tr></thead><tbody>'
-      + (rows || '<tr><td colspan="6">No nodes reporting.</td></tr>')
+      + (rows || '<tr><td colspan="8">No nodes reporting.</td></tr>')
       + '</tbody></table>';
     const self = this;
     el.querySelectorAll('.nodes-manage').forEach((b) => {

--- a/ui/index.html
+++ b/ui/index.html
@@ -36,7 +36,7 @@
             <button class="nav-tab" data-tab="performance" role="tab" aria-selected="false" aria-controls="performance">Performance</button>
             <button class="nav-tab" data-tab="applications" role="tab" aria-selected="false" aria-controls="applications">Applications</button>
             <button class="nav-tab" data-tab="sensing" role="tab" aria-selected="false" aria-controls="sensing">Sensing</button>
-            <button class="nav-tab" data-tab="training" role="tab" aria-selected="false" aria-controls="training">Training</button>
+            <button class="nav-tab" data-tab="nodes" role="tab" aria-selected="false" aria-controls="nodes">Nodes</button>            <button class="nav-tab" data-tab="training" role="tab" aria-selected="false" aria-controls="training">Training</button>
             <a href="pose-fusion.html" class="nav-tab" style="text-decoration:none">Pose Fusion</a>
             <a href="observatory.html" class="nav-tab" style="text-decoration:none">Observatory</a>
         </nav>
@@ -499,6 +499,8 @@
         <!-- Sensing Tab -->
         <section id="sensing" class="tab-content" role="tabpanel" aria-labelledby="sensing" aria-hidden="true"></section>
 
+        <!-- Room Builder Tab -->
+        <section id="nodes" class="tab-content" role="tabpanel" aria-labelledby="nodes" aria-hidden="true"></section>
         <!-- Training Tab -->
         <section id="training" class="tab-content" role="tabpanel" aria-labelledby="training" aria-hidden="true">
             <div class="tab-header">

--- a/v2/Cargo.lock
+++ b/v2/Cargo.lock
@@ -13451,6 +13451,7 @@ dependencies = [
  "p256",
  "proptest",
  "rand 0.8.5",
+ "reqwest 0.12.28",
  "rumqttc-v4-next",
  "ruvector-mincut",
  "ruview-auth",

--- a/v2/crates/wifi-densepose-sensing-server/Cargo.toml
+++ b/v2/crates/wifi-densepose-sensing-server/Cargo.toml
@@ -23,6 +23,10 @@ path = "src/main.rs"
 # Web framework
 axum = { workspace = true }
 tower-http = { version = "0.6", features = ["fs", "cors", "set-header"] }
+# Node management: the server proxies config and firmware requests to nodes so
+# the OTA pre-shared key stays server-side and never reaches a browser.
+# Same version and feature set as the other crates in this workspace.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { workspace = true, features = ["full", "process"] }
 futures-util = "0.3"
 ruvector-mincut = { workspace = true }

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -89,6 +89,16 @@ use wifi_densepose_signal::ruvsense::pose_tracker::PoseTracker;
 #[derive(Parser, Debug)]
 #[command(name = "sensing-server", about = "WiFi-DensePose sensing server")]
 struct Args {
+    /// Path to a file holding the fleet's OTA pre-shared key.
+    ///
+    /// Read once at startup and held in memory; never logged, never returned
+    /// by any endpoint, and never sent to a browser. The management UI talks
+    /// to this server, and this server talks to the nodes -- a PSK delivered
+    /// to a web page would be a PSK published. Without it, node management
+    /// endpoints fail closed and only read-only fleet views work.
+    #[arg(long)]
+    ota_psk_file: Option<PathBuf>,
+
     /// HTTP port for UI and REST API
     #[arg(long, default_value = "8080")]
     http_port: u16,
@@ -6455,6 +6465,117 @@ async fn mesh_endpoint(State(state): State<SharedState>) -> Json<serde_json::Val
     }))
 }
 
+
+// ── Node management proxy ────────────────────────────────────────────────
+//
+// The browser must never hold the fleet's OTA pre-shared key: a secret
+// delivered to a web page is a secret published to anything that can read the
+// page or its traffic. So the UI talks to this server and this server talks to
+// the nodes, holding the key in memory and never returning it.
+//
+// See ADR-351: this relocates fleet authentication from the firmware's PSK
+// check to this server's web port, which is currently unauthenticated. That is
+// a known and accepted risk, not an oversight.
+
+/// Node HTTP port (firmware `OTA_PORT`, ota_update.c).
+const NODE_MGMT_PORT: u16 = 8032;
+
+/// Fleet OTA PSK, read once from `--ota-psk-file`. `None` means node
+/// management fails closed while read-only fleet views keep working.
+static NODE_PSK: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+
+fn node_http() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            // Nodes are slow to answer under a weak link -- a node at -84 dBm
+            // took over 20 s to serve a small JSON body. A short timeout here
+            // reports a healthy node as broken.
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_default()
+    })
+}
+
+/// Resolve a node id to the address it last sent from.
+async fn node_address(state: &SharedState, id: u8) -> Option<std::net::IpAddr> {
+    state.read().await.node_states.get(&id).and_then(|ns| ns.last_src_ip)
+}
+
+/// Forward one request to a node and return its reply verbatim.
+///
+/// The node's own status code and body are passed through rather than
+/// reinterpreted: when a node rejects a parameter it explains why, and
+/// rewriting that into a generic error would throw away the useful part.
+async fn node_proxy(
+    state: &SharedState,
+    id: u8,
+    path: &str,
+    body: Option<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(psk) = NODE_PSK.get().and_then(|p| p.clone()) else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "node management disabled: server started without --ota-psk-file"
+            })),
+        );
+    };
+    let Some(ip) = node_address(state, id).await else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": format!("node {id} has not been heard from, so its address is unknown")
+            })),
+        );
+    };
+
+    let url = format!("http://{ip}:{NODE_MGMT_PORT}{path}");
+    let req = match &body {
+        Some(b) => node_http().post(&url).header("Content-Type", "application/json").body(b.clone()),
+        None => node_http().get(&url),
+    };
+
+    match req.bearer_auth(psk).send().await {
+        Ok(resp) => {
+            let code = StatusCode::from_u16(resp.status().as_u16())
+                .unwrap_or(StatusCode::BAD_GATEWAY);
+            let text = resp.text().await.unwrap_or_default();
+            let value = serde_json::from_str::<serde_json::Value>(&text)
+                .unwrap_or_else(|_| serde_json::json!({ "message": text }));
+            (code, Json(value))
+        }
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({
+                "error": format!("node {id} at {ip} did not answer: {e}")
+            })),
+        ),
+    }
+}
+
+async fn node_config_get(
+    State(state): State<SharedState>,
+    Path(id): Path<u8>,
+) -> impl IntoResponse {
+    node_proxy(&state, id, "/config", None).await
+}
+
+async fn node_config_post(
+    State(state): State<SharedState>,
+    Path(id): Path<u8>,
+    body: String,
+) -> impl IntoResponse {
+    node_proxy(&state, id, "/config", Some(body)).await
+}
+
+async fn node_firmware_get(
+    State(state): State<SharedState>,
+    Path(id): Path<u8>,
+) -> impl IntoResponse {
+    node_proxy(&state, id, "/ota/status", None).await
+}
+
 async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
     let now = std::time::Instant::now();
@@ -8685,6 +8806,33 @@ async fn main() {
     info!("  UI path:   {}", args.ui_path.display());
     info!("  Source:    {}", args.source);
 
+    // Fleet OTA key for node management. Read once, held in memory, never
+    // logged and never returned by any endpoint -- the UI reaches nodes only
+    // through this server, so a browser never needs it. Absent means node
+    // management fails closed; read-only fleet views are unaffected.
+    let node_psk = args.ota_psk_file.as_ref().and_then(|path| {
+        match std::fs::read_to_string(path) {
+            Ok(text) => {
+                let key = text.trim().to_string();
+                if key.is_empty() {
+                    warn!("--ota-psk-file {} is empty; node management disabled", path.display());
+                    None
+                } else {
+                    info!("node management enabled ({} byte key loaded)", key.len());
+                    Some(key)
+                }
+            }
+            Err(e) => {
+                warn!("could not read --ota-psk-file {}: {e}; node management disabled",
+                      path.display());
+                None
+            }
+        }
+    });
+    if node_psk.is_none() && args.ota_psk_file.is_none() {
+        info!("node management disabled (no --ota-psk-file); fleet views remain available");
+    }
+    let _ = NODE_PSK.set(node_psk);
     // Resolve the data source into a concrete task plan (issue #1004).
     //
     // Issue #937 (prior fix): `auto` must never serve fake CSI *tagged as
@@ -9260,6 +9408,9 @@ async fn main() {
         .route("/api/v1/rf/vendors/:vendor/events", post(ingest_vendor_events))
         // Per-node health endpoint
         .route("/api/v1/nodes", get(nodes_endpoint))
+        // Node management (ADR-351). The PSK stays server-side.
+        .route("/api/v1/nodes/:id/config", get(node_config_get).post(node_config_post))
+        .route("/api/v1/nodes/:id/firmware", get(node_firmware_get))
         // ADR-110 iter 29 — per-node mesh sync state for HTTP clients.
         .route("/api/v1/nodes/:id/sync", get(node_sync_endpoint))
         .route("/api/v1/mesh", get(mesh_endpoint))

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -811,6 +811,15 @@ struct BoundingBox {
 /// Each ESP32 node gets its own frame history, smoothing buffers, and vital
 /// sign detector so that data from different nodes is never mixed.
 struct NodeState {
+    /// Source address of the most recent datagram from this node.
+    ///
+    /// Nothing else knows where a node lives. Nodes are configured with the
+    /// server's address and push to it, so the reverse mapping exists only in
+    /// the packets they send; without recording it, managing a node means
+    /// scanning the subnet for its HTTP port and asking each responder who it
+    /// is. Observed rather than configured, so it follows a node across DHCP
+    /// leases with no intervention.
+    pub(crate) last_src_ip: Option<std::net::IpAddr>,
     pub(crate) frame_history: VecDeque<Vec<f64>>,
     smoothed_person_score: f64,
     pub(crate) prev_person_count: usize,
@@ -1136,6 +1145,7 @@ impl NodeState {
 
     pub(crate) fn new() -> Self {
         Self {
+            last_src_ip: None,
             frame_history: VecDeque::new(),
             smoothed_person_score: 0.0,
             prev_person_count: 0,
@@ -6462,6 +6472,7 @@ async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Va
             serde_json::json!({
                 "node_id": id,
                 "status": status,
+                "ip": ns.last_src_ip.map(|ip| ip.to_string()),
                 "last_seen_ms": elapsed_ms,
                 "rssi_dbm": rssi,
                 "motion_level": &ns.current_motion_level,
@@ -6739,6 +6750,7 @@ async fn udp_receiver_task(
                     // ── Per-node state for edge vitals (issue #249) ──────
                     let node_id = vitals.node_id;
                     let ns = s.node_states.entry(node_id).or_insert_with(NodeState::new);
+                    ns.last_src_ip = Some(src.ip());
                     let first_sensing_frame = ns.last_frame_time.is_none();
                     ns.last_frame_time = Some(std::time::Instant::now());
                     if first_sensing_frame && telemetry::curated_events_enabled() {
@@ -6992,8 +7004,10 @@ async fn udp_receiver_task(
                                        sync.local_minus_epoch_us());
                                 let mut s = state.write().await;
                                 let node_id = sync.node_id;
+                                let src_ip = src.ip();
                                 let ns = s.node_states.entry(node_id)
                                     .or_insert_with(NodeState::new);
+                                ns.last_src_ip = Some(src_ip);
                                 ns.apply_sync_packet(sync, std::time::Instant::now());
                                 continue;
                             }
@@ -7147,6 +7161,7 @@ async fn udp_receiver_task(
                     let adaptive_model_clone = s.adaptive_model.clone();
 
                     let ns = s.node_states.entry(node_id).or_insert_with(NodeState::new);
+                    ns.last_src_ip = Some(src.ip());
                     // ADR-110 iter 19 — feed the per-node fps EMA from real
                     // CSI arrivals. The helper sets `last_frame_time` as a
                     // side effect, so the previous bare assignment is gone.

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -6502,6 +6502,38 @@ async fn node_address(state: &SharedState, id: u8) -> Option<std::net::IpAddr> {
     state.read().await.node_states.get(&id).and_then(|ns| ns.last_src_ip)
 }
 
+/// Record where a node's packets came from, refusing sources that cannot be a
+/// node.
+///
+/// MEASURED 2026-09-09: five of nine nodes had their address replaced by
+/// 172.18.0.1 -- the sink container's own bridge gateway -- at some point
+/// during a 13 h uptime. Every management proxy for those nodes (config,
+/// firmware, and the on-node log) then failed, and nothing said why: the
+/// address had been correct at startup and rotted silently. A restart restored
+/// all nine, which is the tell that this is learned state going bad rather
+/// than a routing problem.
+///
+/// A CSI node sits on the LAN and reaches the sink through a published port.
+/// It can never legitimately appear to originate from the container's own
+/// gateway, so a bridge-range source is Docker's address, not a node's.
+/// Docker's default pool is 172.16.0.0/12.
+///
+/// The guard only refuses to OVERWRITE a known address, so a fleet genuinely
+/// deployed on that range still learns its nodes on first contact.
+fn record_node_src_ip(current: &mut Option<std::net::IpAddr>, observed: std::net::IpAddr) {
+    if observed.is_loopback() || observed.is_unspecified() {
+        return;
+    }
+    if let std::net::IpAddr::V4(v4) = observed {
+        let o = v4.octets();
+        let docker_pool = o[0] == 172 && (16..=31).contains(&o[1]);
+        if docker_pool && current.is_some_and(|c| c != observed) {
+            return;
+        }
+    }
+    *current = Some(observed);
+}
+
 /// Forward one request to a node and return its reply verbatim.
 ///
 /// The node's own status code and body are passed through rather than
@@ -6871,7 +6903,7 @@ async fn udp_receiver_task(
                     // ── Per-node state for edge vitals (issue #249) ──────
                     let node_id = vitals.node_id;
                     let ns = s.node_states.entry(node_id).or_insert_with(NodeState::new);
-                    ns.last_src_ip = Some(src.ip());
+                    record_node_src_ip(&mut ns.last_src_ip, src.ip());
                     let first_sensing_frame = ns.last_frame_time.is_none();
                     ns.last_frame_time = Some(std::time::Instant::now());
                     if first_sensing_frame && telemetry::curated_events_enabled() {
@@ -7128,7 +7160,7 @@ async fn udp_receiver_task(
                                 let src_ip = src.ip();
                                 let ns = s.node_states.entry(node_id)
                                     .or_insert_with(NodeState::new);
-                                ns.last_src_ip = Some(src_ip);
+                                record_node_src_ip(&mut ns.last_src_ip, src_ip);
                                 ns.apply_sync_packet(sync, std::time::Instant::now());
                                 continue;
                             }
@@ -7282,7 +7314,7 @@ async fn udp_receiver_task(
                     let adaptive_model_clone = s.adaptive_model.clone();
 
                     let ns = s.node_states.entry(node_id).or_insert_with(NodeState::new);
-                    ns.last_src_ip = Some(src.ip());
+                    record_node_src_ip(&mut ns.last_src_ip, src.ip());
                     // ADR-110 iter 19 — feed the per-node fps EMA from real
                     // CSI arrivals. The helper sets `last_frame_time` as a
                     // side effect, so the previous bare assignment is gone.
@@ -10380,6 +10412,62 @@ mod model_load_diagnostic_tests {
         let msg = diagnose_model_load_error(Path::new("weird.dat"), &data, "x");
         assert!(msg.contains("RVF binary container"), "{msg}");
         assert!(msg.contains("wifi-densepose-train"), "{msg}");
+    }
+}
+
+#[cfg(test)]
+mod node_src_ip_tests {
+    use super::record_node_src_ip;
+    use std::net::IpAddr;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    // The exact failure seen on 2026-09-09: a node learned correctly at
+    // startup, then had its address replaced by the sink container's own
+    // bridge gateway. Every management call for that node failed afterwards,
+    // with nothing to say why, until the sink was restarted.
+    #[test]
+    fn gateway_does_not_clobber_a_learned_node_address() {
+        let mut addr = None;
+        record_node_src_ip(&mut addr, ip("192.168.1.112"));
+        assert_eq!(addr, Some(ip("192.168.1.112")));
+
+        record_node_src_ip(&mut addr, ip("172.18.0.1"));
+        assert_eq!(
+            addr,
+            Some(ip("192.168.1.112")),
+            "a bridge-range source must never overwrite a real node address"
+        );
+    }
+
+    // The guard refuses to REPLACE, never to learn, so a fleet genuinely
+    // deployed on that range is not made unreachable by it.
+    #[test]
+    fn a_node_on_the_bridge_range_is_still_learned_from_nothing() {
+        let mut addr = None;
+        record_node_src_ip(&mut addr, ip("172.18.0.5"));
+        assert_eq!(addr, Some(ip("172.18.0.5")));
+    }
+
+    #[test]
+    fn a_real_address_still_replaces_a_stale_one() {
+        let mut addr = Some(ip("192.168.1.112"));
+        record_node_src_ip(&mut addr, ip("192.168.1.150"));
+        assert_eq!(
+            addr,
+            Some(ip("192.168.1.150")),
+            "a node that moves on the LAN must still be followed"
+        );
+    }
+
+    #[test]
+    fn loopback_and_unspecified_are_never_recorded() {
+        let mut addr = Some(ip("192.168.1.112"));
+        record_node_src_ip(&mut addr, ip("127.0.0.1"));
+        record_node_src_ip(&mut addr, ip("0.0.0.0"));
+        assert_eq!(addr, Some(ip("192.168.1.112")));
     }
 }
 


### PR DESCRIPTION
Reconfiguring a node meant a USB cable and a serial console, or hand-written
curl against an address nobody recorded. This adds a Nodes tab that lists the
fleet and lets an operator read and change node configuration and see firmware
state, using the address each node reports on its own packets.

The server proxies rather than exposing the key. The firmware gates every
mutating endpoint (POST /config, /ota, /calibrate) behind a pre-shared key
checked in constant time. A browser must never hold that key -- a PSK
delivered to a web page is a PSK published to anything that can read the page
or its traffic -- so the server reads it from --ota-psk-file, keeps it in
memory, and never logs it or returns it from any endpoint.

FAILS CLOSED. Without --ota-psk-file, node management is disabled and only the
read-only fleet views are served. The key is never written to disk by the
server and never leaves it.

SECURITY NOTE FOR REVIEWERS. Once an operator does supply the key, the server's
web UI becomes the real trust boundary: anyone who can reach it can reconfigure
or reflash the fleet, because the server holds the credential on their behalf.
The firmware's authentication is intact but is no longer the control that
matters. This is a deliberate trade for a single-operator LAN deployment and it
is off by default, but a multi-user deployment wants an authentication layer in
front of the server before enabling it.

---

Rebased onto current `main` before opening: staged before today's seven merges, so it needed replaying to avoid reading as a revert of them. Clean rebase, no files deleted.