### PR TITLE
fix(sensing-server): rate-limit ESP32 broadcasts to tick_ms, coordinated with keepalive

### DIFF
--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1442,6 +1442,12 @@ pub(crate) fn save_runtime_config(data_dir: &std::path::Path, config: &RuntimeCo
 /// Shared application state
 struct AppStateInner {
     latest_update: Option<SensingUpdate>,
+    /// When `latest_update` was last broadcast to WS clients (by whichever
+    /// task actually sent it - the ESP32 receive loop or the periodic
+    /// keepalive). Lets the keepalive skip re-sending data that was just
+    /// freshly broadcast a moment ago, instead of firing on its own
+    /// independent timer regardless of what the primary path just did.
+    last_broadcast_at: Option<std::time::Instant>,
     rssi_history: VecDeque<f64>,
     /// Circular buffer of recent CSI amplitude vectors for temporal analysis.
     /// Each entry is the full subcarrier amplitude vector for one frame.
@@ -1783,6 +1789,7 @@ impl AppStateInner {
     pub(crate) fn minimal() -> Self {
         AppStateInner {
             latest_update: None,
+            last_broadcast_at: None,
             rssi_history: VecDeque::new(),
             frame_history: VecDeque::new(),
             tick: 0,
@@ -6595,6 +6602,7 @@ async fn udp_receiver_task(
     bind_ip: std::net::IpAddr,
     udp_port: u16,
     allowlist: std::sync::Arc<wifi_densepose_sensing_server::udp_bind::UdpSourceAllowlist>,
+    tick_ms: u64,
 ) {
     let addr = format!("{bind_ip}:{udp_port}");
     let socket = match UdpSocket::bind(&addr).await {
@@ -6609,6 +6617,19 @@ async fn udp_receiver_task(
     };
 
     let mut buf = vec![0u8; wifi_densepose_hardware::rtl8720f::RTL8720F_RADAR_MAX_FRAME_LEN];
+    // ESP32 CSI frames arrive at ~48-50 FPS per node (raw hardware rate),
+    // far faster than the intended UI/broadcast cadence. Without gating,
+    // every incoming CSI frame triggered a full WS broadcast — clients saw
+    // sensing_update at raw CSI rate instead of `--tick-ms`, and every
+    // broadcast re-serializes the full snapshot (amplitude arrays, 400-
+    // point signal field, tracked persons) on the hot receive path. Per-
+    // node state (frame_history, smoothing/classification) still updates
+    // on every frame below — only the WS broadcast itself is rate-limited.
+    // The timestamp lives on shared state (AppStateInner::last_broadcast_at)
+    // rather than a task-local var so broadcast_tick_task's independent
+    // keepalive timer can see it too and skip re-sending data this task
+    // just freshly broadcast a moment ago.
+    let min_broadcast_interval = Duration::from_millis(tick_ms.max(1));
     loop {
         match socket.recv_from(&mut buf).await {
             Ok((len, src)) => {
@@ -6966,8 +6987,13 @@ async fn udp_receiver_task(
                     attach_field_positions(&mut update);
                     assess_legacy_image_pose(&mut s, &update);
 
-                    if let Ok(json) = serde_json::to_string(&update) {
-                        let _ = s.tx.send(json);
+                    if s.last_broadcast_at
+                        .map_or(true, |t| now.duration_since(t) >= min_broadcast_interval)
+                    {
+                        if let Ok(json) = serde_json::to_string(&update) {
+                            let _ = s.tx.send(json);
+                        }
+                        s.last_broadcast_at = Some(now);
                     }
                     observe_sensing_update(s.latest_update.as_ref(), &update);
                     s.latest_update = Some(update);
@@ -7429,8 +7455,13 @@ async fn udp_receiver_task(
                     attach_field_positions(&mut update);
                     assess_legacy_image_pose(&mut s, &update);
 
-                    if let Ok(json) = serde_json::to_string(&update) {
-                        let _ = s.tx.send(json);
+                    if s.last_broadcast_at
+                        .map_or(true, |t| now.duration_since(t) >= min_broadcast_interval)
+                    {
+                        if let Ok(json) = serde_json::to_string(&update) {
+                            let _ = s.tx.send(json);
+                        }
+                        s.last_broadcast_at = Some(now);
                     }
 
                     // ── ADR-262 P3: emit a signed RuField FieldEvent ────────
@@ -7709,8 +7740,17 @@ async fn broadcast_tick_task(state: SharedState, tick_ms: u64) {
     loop {
         interval.tick().await;
         let s = state.read().await;
+        // The ESP32 receive loop broadcasts its own throttled updates on
+        // this same tick_ms cadence, independently timed from this task.
+        // Without this check the two fired out of phase, doubling the
+        // effective broadcast rate in a regular, periodic pattern (visible
+        // in the UI as the signal-field heatmap flashing on a beat). Only
+        // step in as a keepalive when nothing has gone out this tick already.
+        let already_fresh = s
+            .last_broadcast_at
+            .is_some_and(|t| t.elapsed() < Duration::from_millis(tick_ms));
         if let Some(ref update) = s.latest_update {
-            if s.tx.receiver_count() > 0 {
+            if s.tx.receiver_count() > 0 && !already_fresh {
                 // Re-broadcast the latest sensing_update so pose WS clients
                 // always get data even when ESP32 pauses between frames.
                 //
@@ -8916,6 +8956,7 @@ async fn main() {
     let mut node_positions_config: Vec<[f32; 3]> = Vec::new();
     let state: SharedState = Arc::new(RwLock::new(AppStateInner {
         latest_update: None,
+        last_broadcast_at: None,
         rssi_history: VecDeque::new(),
         frame_history: VecDeque::new(),
         tick: 0,
@@ -9094,6 +9135,7 @@ async fn main() {
             udp_bind_ip,
             args.udp_port,
             udp_allowlist,
+            args.tick_ms,
         ));
         tokio::spawn(broadcast_tick_task(state.clone(), args.tick_ms));
     }


### PR DESCRIPTION
udp_receiver_task broadcast a full sensing_update on every raw incoming
UDP CSI frame (~48-50 FPS per node) instead of respecting --tick-ms,
unlike the simulated/WiFi-scan sources which were already tick-gated.
Clients saw the UI update at raw hardware rate instead of the intended
cadence, and every broadcast re-serializes the full snapshot (amplitude
arrays, 400-point signal field, tracked persons) on the hot receive
path. Per-node state (frame_history, smoothing/classification) still
updates every frame - only the WS broadcast itself is now throttled to
tick_ms via a last_broadcast_at timestamp.

That timestamp lives on shared AppStateInner rather than a task-local
var because a separate, pre-existing broadcast_tick_task re-broadcasts
the latest update on its own independent tick_ms timer as a keepalive
for when ESP32 pauses between frames. Before this fix that task's own
broadcasts were lost in the ~48Hz flood and didn't matter; once the
primary path was throttled to tick_ms, the two unsynchronized timers
running at the same nominal rate produced a visible, regular "beat"
pattern in the UI (double-broadcasts at an uneven cadence). The
keepalive now checks last_broadcast_at and skips its own re-broadcast
whenever the primary path already sent something within the last
tick_ms, so it only fires as a genuine keepalive when ESP32 has
actually gone quiet.

---

Rebased onto current `main` before opening: staged before today's seven merges, so it needed replaying to avoid reading as a revert of them. Clean rebase, no files deleted.