### PR TITLE
feat(room): storeys, walls and AP placement in the Room Builder

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -5,6 +5,7 @@ import { DashboardTab } from './components/DashboardTab.js';
 import { HardwareTab } from './components/HardwareTab.js';
 import { LiveDemoTab } from './components/LiveDemoTab.js';
 import { SensingTab } from './components/SensingTab.js';
+import { RoomBuilderTab } from './components/RoomBuilderTab.js';
 import { apiService } from './services/api.service.js';
 import { wsService } from './services/websocket.service.js';
 import { healthService } from './services/health.service.js';
@@ -159,6 +160,15 @@ class WiFiDensePoseApp {
     const sensingContainer = document.getElementById('sensing');
     if (sensingContainer) {
       this.components.sensing = new SensingTab(sensingContainer);
+    }
+
+    // Room Builder tab
+    const roomBuilderContainer = document.getElementById('roombuilder');
+    if (roomBuilderContainer) {
+      this.components.roomBuilder = new RoomBuilderTab(roomBuilderContainer);
+      this.components.roomBuilder.init().catch(error => {
+        console.error('Failed to initialize room builder:', error);
+      });
     }
 
     // Training tab - lazy load to avoid breaking other tabs if import fails
@@ -344,6 +354,14 @@ class WiFiDensePoseApp {
         }
         if (this.components.modelPanel && typeof this.components.modelPanel.refresh === 'function') {
           this.components.modelPanel.refresh();
+        }
+        break;
+
+      case 'roombuilder':
+        // Re-fetch the live config each time the tab is opened, in case it
+        // changed elsewhere (another browser tab's save, a server restart).
+        if (this.components.roomBuilder) {
+          this.components.roomBuilder._load();
         }
         break;
     }

--- a/ui/components/RoomBuilderTab.js
+++ b/ui/components/RoomBuilderTab.js
@@ -1,0 +1,468 @@
+/**
+ * RoomBuilderTab — define room geometry and sensor node positions
+ *
+ * A 2D top-down floor-plan editor: set room width/depth, add sensor nodes,
+ * drag them into place (or type exact coordinates), and save. Saving both
+ * applies the positions live (no restart needed) and persists them to
+ * <data_dir>/room_config.json, which is loaded automatically on the next
+ * server launch — replacing the --node-positions CLI-only workflow.
+ */
+
+import { apiService } from '../services/api.service.js';
+import { toastManager } from '../utils/toast.js';
+
+const ENDPOINT = '/api/v1/config/room';
+const CANVAS_W = 640;
+const CANVAS_H = 480;
+const MARGIN = 32;
+const NODE_RADIUS = 9;
+const METERS_PER_FOOT = 0.3048;
+const UNITS_STORAGE_KEY = 'roombuilder-units';
+
+export class RoomBuilderTab {
+  /** @param {HTMLElement} container - the #roombuilder section element */
+  constructor(container) {
+    this.container = container;
+    this.config = { width_m: 5, depth_m: 4, nodes: [] };
+    this._dragIndex = null;
+    this._loaded = false;
+    // Display-only - this.config always stays in meters (that's what the
+    // server/API/saved file use); only input values and labels convert.
+    this._units = 'metric';
+    try {
+      const saved = localStorage.getItem(UNITS_STORAGE_KEY);
+      if (saved === 'metric' || saved === 'imperial') this._units = saved;
+    } catch (e) { /* storage unavailable - default to metric */ }
+  }
+
+  /** Convert a length in meters to the currently-selected display unit. */
+  _toDisplay(meters) {
+    return this._units === 'imperial' ? meters / METERS_PER_FOOT : meters;
+  }
+
+  /** Convert a length from the currently-selected display unit back to meters. */
+  _fromDisplay(value) {
+    return this._units === 'imperial' ? value * METERS_PER_FOOT : value;
+  }
+
+  _unitLabel() {
+    return this._units === 'imperial' ? 'ft' : 'm';
+  }
+
+  async init() {
+    this._buildDOM();
+    this._wireEvents();
+    await this._load();
+  }
+
+  // ---- DOM ----------------------------------------------------------------
+
+  _buildDOM() {
+    this.container.innerHTML = `
+      <style>
+        .rb-layout { display: flex; gap: 20px; flex-wrap: wrap; }
+        .rb-canvas-wrap { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 8px; padding: 12px; }
+        .rb-canvas-wrap canvas { display: block; cursor: default; border-radius: 4px; }
+        .rb-panel { flex: 1; min-width: 280px; display: flex; flex-direction: column; gap: 16px; }
+        .rb-card { background: #12161f; border: 1px solid #2a2f3a; border-radius: 8px; padding: 14px; }
+        .rb-card-title { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: #8b93a7; margin-bottom: 10px; }
+        .rb-room-dims { display: flex; gap: 12px; }
+        .rb-room-dims label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: #8b93a7; }
+        .rb-room-dims input, .rb-node-row input { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 7px; font-size: 13px; box-sizing: border-box; }
+        .rb-room-dims input { width: 72px; }
+        .rb-room-dims select { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 7px; font-size: 13px; }
+        .rb-node-row { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 1fr 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
+        .rb-node-row input { width: 100%; }
+        .rb-node-row .rb-id { color: #32b8c6; font-weight: 600; font-size: 13px; }
+        /* Number inputs' native up/down spinner eats most of the width in
+           narrow columns (esp. the 42px ID field) - hide it. Nobody needs
+           spinner arrows to type a node ID or a coordinate. */
+        .rb-node-row input[type="number"]::-webkit-outer-spin-button,
+        .rb-node-row input[type="number"]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+        .rb-node-row input[type="number"] { -moz-appearance: textfield; appearance: textfield; }
+        .rb-remove-btn { background: none; border: none; color: #e05561; cursor: pointer; font-size: 15px; line-height: 1; }
+        .rb-btn { background: #32b8c6; color: #06222a; border: none; border-radius: 6px; padding: 8px 16px; font-weight: 600; cursor: pointer; font-size: 13px; }
+        .rb-btn.secondary { background: transparent; color: #32b8c6; border: 1px solid #32b8c6; }
+        .rb-actions { display: flex; gap: 10px; margin-top: 8px; }
+        .rb-hint { color: #6b7280; font-size: 12px; margin-top: 8px; line-height: 1.5; }
+        .rb-col-headers { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 1fr 24px; gap: 6px; font-size: 11px; color: #6b7280; margin-bottom: 6px; }
+      </style>
+      <h2>Room Builder</h2>
+      <p class="rb-hint" style="margin-bottom:16px;">
+        Define your room and place sensor nodes. Node <strong>ID</strong> must match
+        each board's provisioned <code>--node-id</code>. Saving applies immediately
+        (no restart) and is what future launches load automatically.
+      </p>
+      <div class="rb-layout">
+        <div class="rb-canvas-wrap">
+          <canvas id="rbCanvas" width="${CANVAS_W}" height="${CANVAS_H}"></canvas>
+        </div>
+        <div class="rb-panel">
+          <div class="rb-card">
+            <div class="rb-card-title">Room Dimensions</div>
+            <div class="rb-room-dims">
+              <label><span>Width (<span class="rb-unit-label">${this._unitLabel()}</span>)</span> <input type="number" id="rbWidth" min="0.1" step="0.1" value="${this._toDisplay(this.config.width_m).toFixed(2)}"></label>
+              <label><span>Depth (<span class="rb-unit-label">${this._unitLabel()}</span>)</span> <input type="number" id="rbDepth" min="0.1" step="0.1" value="${this._toDisplay(this.config.depth_m).toFixed(2)}"></label>
+              <label><span>Units</span>
+                <select id="rbUnits">
+                  <option value="metric" ${this._units === 'metric' ? 'selected' : ''}>Metric (m)</option>
+                  <option value="imperial" ${this._units === 'imperial' ? 'selected' : ''}>Imperial (ft)</option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div class="rb-card">
+            <div class="rb-card-title">Sensor Nodes</div>
+            <div class="rb-col-headers">
+              <span>ID</span><span>Label</span><span>X (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Y (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Z (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span></span><span></span>
+            </div>
+            <div id="rbNodeList"></div>
+            <div class="rb-actions">
+              <button class="rb-btn secondary" id="rbAddNode">+ Add Node</button>
+            </div>
+          </div>
+          <div class="rb-actions">
+            <button class="rb-btn" id="rbSave">Save</button>
+          </div>
+          <p class="rb-hint">
+            Drag a node on the canvas to reposition it (X/Y only — set height
+            with the Z field). Coordinates are in the same room-space meters
+            used by <code>--node-positions</code>.
+          </p>
+          <p class="rb-hint">
+            <strong>(0, 0)</strong> is the room's <strong>Northwest</strong> corner
+            (the <strong>N</strong> arrow on the canvas points that way) — X increases
+            going <strong>East</strong>, Y increases going <strong>South</strong>. Face
+            the room's actual north wall and match it up when you place nodes.
+          </p>
+        </div>
+      </div>
+    `;
+  }
+
+  _wireEvents() {
+    const widthEl = this.container.querySelector('#rbWidth');
+    const depthEl = this.container.querySelector('#rbDepth');
+    widthEl.addEventListener('input', () => {
+      this.config.width_m = Math.max(0.1, this._fromDisplay(parseFloat(widthEl.value) || 0));
+      this._render();
+    });
+    depthEl.addEventListener('input', () => {
+      this.config.depth_m = Math.max(0.1, this._fromDisplay(parseFloat(depthEl.value) || 0));
+      this._render();
+    });
+
+    this.container.querySelector('#rbUnits').addEventListener('change', (e) => {
+      this._units = e.target.value;
+      try { localStorage.setItem(UNITS_STORAGE_KEY, this._units); } catch (err) { /* ignore */ }
+      this._refreshUnitDisplay();
+    });
+
+    this.container.querySelector('#rbAddNode').addEventListener('click', () => {
+      this._addNode();
+    });
+    this.container.querySelector('#rbSave').addEventListener('click', () => {
+      this._save();
+    });
+
+    const canvas = this.container.querySelector('#rbCanvas');
+    canvas.addEventListener('mousedown', (e) => this._onCanvasDown(e));
+    canvas.addEventListener('mousemove', (e) => this._onCanvasMove(e));
+    window.addEventListener('mouseup', () => { this._dragIndex = null; });
+  }
+
+  // ---- Data -----------------------------------------------------------------
+
+  async _load() {
+    try {
+      const data = await apiService.get(ENDPOINT);
+      if (data && typeof data === 'object') {
+        this.config = {
+          width_m: data.width_m > 0 ? data.width_m : 5,
+          depth_m: data.depth_m > 0 ? data.depth_m : 4,
+          nodes: Array.isArray(data.nodes) ? data.nodes : [],
+        };
+      }
+    } catch (e) {
+      console.warn('[RoomBuilder] Failed to load room config, using defaults:', e.message);
+    }
+    this._loaded = true;
+    this._refreshUnitDisplay();
+  }
+
+  /** Re-render everything that shows a unit-dependent value, using the
+   * current `this._units` - called on load and whenever the unit toggle
+   * changes. `this.config` itself never changes here; only what's displayed. */
+  _refreshUnitDisplay() {
+    const label = this._unitLabel();
+    this.container.querySelectorAll('.rb-unit-label').forEach((el) => {
+      el.textContent = label;
+    });
+    this.container.querySelector('#rbWidth').value = this._toDisplay(this.config.width_m).toFixed(2);
+    this.container.querySelector('#rbDepth').value = this._toDisplay(this.config.depth_m).toFixed(2);
+    this._renderNodeList();
+    this._render();
+  }
+
+  async _save() {
+    // Pull the latest values out of the node-row inputs before sending -
+    // numeric fields don't write back into this.config until blur/save.
+    this._syncNodesFromInputs();
+    const ids = this.config.nodes.map((n) => n.id);
+    if (new Set(ids).size !== ids.length) {
+      toastManager.error('Cannot save: two or more nodes have the same ID. Give each a unique ID first.');
+      return;
+    }
+    try {
+      // The server validates width/depth/duplicate-ids and responds 200 OK
+      // with an {"error": ...} body rather than a non-2xx status, so a
+      // rejected save must be checked for explicitly - it won't throw.
+      const result = await apiService.post(ENDPOINT, this.config);
+      if (result && result.error) {
+        toastManager.error(`Save rejected: ${result.error}`);
+        return;
+      }
+      toastManager.success('Room config saved — applied immediately, and will load automatically on next launch.');
+    } catch (e) {
+      toastManager.error(`Failed to save room config: ${e.message}`);
+    }
+  }
+
+  _nextFreeId() {
+    const used = new Set(this.config.nodes.map((n) => n.id));
+    let id = 0;
+    while (used.has(id)) id++;
+    return id;
+  }
+
+  _addNode() {
+    this.config.nodes.push({
+      id: this._nextFreeId(),
+      x: this.config.width_m / 2,
+      y: this.config.depth_m / 2,
+      z: 0.4,
+      label: '',
+    });
+    this._renderNodeList();
+    this._render();
+  }
+
+  _removeNode(index) {
+    this.config.nodes.splice(index, 1);
+    this._renderNodeList();
+    this._render();
+  }
+
+  /** Pull edited values out of the node-row inputs back into this.config.nodes.
+   *
+   * Rows are matched to nodes by array index (`row.dataset.index`), NOT by
+   * `id` - id is one of the fields being edited, so using it as the lookup
+   * key meant renaming a node to an ID that collided with another node's ID
+   * broke the row<->node link: both rows' edits would then read/write
+   * whichever node .find() happened to return first, which looked like one
+   * node "jumping" onto or stacking with another. Array index never changes
+   * just because a field's value changes, so it can't have that problem. */
+  _syncNodesFromInputs() {
+    const rows = this.container.querySelectorAll('.rb-node-row');
+    rows.forEach((row) => {
+      const idx = parseInt(row.dataset.index, 10);
+      const node = this.config.nodes[idx];
+      if (!node) return;
+      const idInput = row.querySelector('.rb-id-input');
+      const newId = parseInt(idInput.value, 10);
+      if (!Number.isNaN(newId)) node.id = newId;
+      node.label = row.querySelector('.rb-label').value;
+      node.x = this._fromDisplay(parseFloat(row.querySelector('.rb-x').value) || 0);
+      node.y = this._fromDisplay(parseFloat(row.querySelector('.rb-y').value) || 0);
+      node.z = this._fromDisplay(parseFloat(row.querySelector('.rb-z').value) || 0);
+    });
+    this._warnOnDuplicateIds();
+  }
+
+  _warnOnDuplicateIds() {
+    const seen = new Set();
+    for (const node of this.config.nodes) {
+      if (seen.has(node.id)) {
+        toastManager.warning(`Duplicate node ID ${node.id} — IDs must be unique before saving.`);
+        return;
+      }
+      seen.add(node.id);
+    }
+  }
+
+  // ---- Node list (form rows) -------------------------------------------------
+
+  _renderNodeList() {
+    const list = this.container.querySelector('#rbNodeList');
+    list.innerHTML = '';
+    // A bad value here (non-finite x/y/z, or an id survey away turning up
+    // NaN) used to throw out of .toFixed() partway through the loop,
+    // silently aborting the render for every node after it - one bad node
+    // could make a later, perfectly fine node vanish from both the list and
+    // the canvas with no visible error. Coerce defensively instead.
+    const safe = (v, fallback = 0) => (Number.isFinite(v) ? v : fallback);
+    this.config.nodes.forEach((node, idx) => {
+      if (!Number.isFinite(node.x) || !Number.isFinite(node.y) || !Number.isFinite(node.z)) {
+        console.warn('[RoomBuilder] Node has non-finite coordinate(s), coercing to 0:', node);
+      }
+      const row = document.createElement('div');
+      row.className = 'rb-node-row';
+      row.dataset.index = idx;
+      row.innerHTML = `
+        <input class="rb-id-input" type="number" min="0" value="${safe(node.id)}" title="Node ID (must match --node-id)">
+        <input class="rb-label" type="text" value="${node.label || ''}" placeholder="e.g. front-right">
+        <input class="rb-x" type="number" step="0.05" value="${this._toDisplay(safe(node.x)).toFixed(2)}">
+        <input class="rb-y" type="number" step="0.05" value="${this._toDisplay(safe(node.y)).toFixed(2)}">
+        <input class="rb-z" type="number" step="0.05" value="${this._toDisplay(safe(node.z)).toFixed(2)}">
+        <span></span>
+        <button class="rb-remove-btn" title="Remove node">&times;</button>
+      `;
+      row.querySelectorAll('input').forEach((inp) => {
+        inp.addEventListener('input', () => {
+          this._syncNodesFromInputs();
+          this._render();
+        });
+      });
+      row.querySelector('.rb-remove-btn').addEventListener('click', () => this._removeNode(idx));
+      list.appendChild(row);
+    });
+  }
+
+  // ---- Canvas -----------------------------------------------------------------
+
+  /** Room-space (x,y) meters -> canvas pixel coordinates. */
+  _toPixel(x, y) {
+    const scale = Math.min(
+      (CANVAS_W - 2 * MARGIN) / this.config.width_m,
+      (CANVAS_H - 2 * MARGIN) / this.config.depth_m
+    );
+    return { px: MARGIN + x * scale, py: MARGIN + y * scale, scale };
+  }
+
+  /** Canvas pixel coordinates -> room-space (x,y) meters, clamped to the room. */
+  _toRoom(px, py) {
+    const scale = Math.min(
+      (CANVAS_W - 2 * MARGIN) / this.config.width_m,
+      (CANVAS_H - 2 * MARGIN) / this.config.depth_m
+    );
+    const x = Math.min(this.config.width_m, Math.max(0, (px - MARGIN) / scale));
+    const y = Math.min(this.config.depth_m, Math.max(0, (py - MARGIN) / scale));
+    return { x, y };
+  }
+
+  _canvasPos(e) {
+    const canvas = this.container.querySelector('#rbCanvas');
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: ((e.clientX - rect.left) / rect.width) * CANVAS_W,
+      y: ((e.clientY - rect.top) / rect.height) * CANVAS_H,
+    };
+  }
+
+  _onCanvasDown(e) {
+    const pos = this._canvasPos(e);
+    this.config.nodes.forEach((node, idx) => {
+      const { px, py } = this._toPixel(node.x, node.y);
+      if (this._dragIndex == null && Math.hypot(px - pos.x, py - pos.y) <= NODE_RADIUS + 4) {
+        this._dragIndex = idx;
+      }
+    });
+  }
+
+  _onCanvasMove(e) {
+    if (this._dragIndex == null) return;
+    const node = this.config.nodes[this._dragIndex];
+    if (!node) return;
+    const pos = this._canvasPos(e);
+    const room = this._toRoom(pos.x, pos.y);
+    node.x = Math.round(room.x * 100) / 100;
+    node.y = Math.round(room.y * 100) / 100;
+    this._renderNodeList();
+    this._render();
+  }
+
+  _render() {
+    const canvas = this.container.querySelector('#rbCanvas');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+
+    // Room rectangle.
+    const topLeft = this._toPixel(0, 0);
+    const bottomRight = this._toPixel(this.config.width_m, this.config.depth_m);
+    ctx.strokeStyle = '#32b8c6';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(topLeft.px, topLeft.py, bottomRight.px - topLeft.px, bottomRight.py - topLeft.py);
+
+    // Faint grid every meter, for scale reference.
+    ctx.strokeStyle = 'rgba(50,184,198,0.15)';
+    ctx.lineWidth = 1;
+    for (let gx = 1; gx < this.config.width_m; gx++) {
+      const { px } = this._toPixel(gx, 0);
+      ctx.beginPath();
+      ctx.moveTo(px, topLeft.py);
+      ctx.lineTo(px, bottomRight.py);
+      ctx.stroke();
+    }
+    for (let gy = 1; gy < this.config.depth_m; gy++) {
+      const { py } = this._toPixel(0, gy);
+      ctx.beginPath();
+      ctx.moveTo(topLeft.px, py);
+      ctx.lineTo(bottomRight.px, py);
+      ctx.stroke();
+    }
+
+    // Nodes.
+    this.config.nodes.forEach((node, idx) => {
+      const { px, py } = this._toPixel(node.x, node.y);
+      if (!Number.isFinite(px) || !Number.isFinite(py)) {
+        console.warn('[RoomBuilder] Skipping node with non-finite position:', node);
+        return;
+      }
+      ctx.beginPath();
+      ctx.arc(px, py, NODE_RADIUS, 0, Math.PI * 2);
+      ctx.fillStyle = idx === this._dragIndex ? '#ffd166' : '#e05561';
+      ctx.fill();
+      ctx.strokeStyle = '#0d1117';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+
+      ctx.fillStyle = '#e6e9ef';
+      ctx.font = '12px monospace';
+      ctx.textAlign = 'center';
+      const label = node.label ? `${node.id}:${node.label}` : `${node.id}`;
+      ctx.fillText(label, px, py - NODE_RADIUS - 6);
+    });
+
+    this._drawCompass(ctx);
+  }
+
+  /** (0,0,0) is the room's Northwest corner by convention - X increases
+   * going East, Y increases going South. That's already how _toPixel maps
+   * room space onto the canvas (x -> right, y -> down); this just draws a
+   * fixed compass badge in the corner so it reads as "North" instead of
+   * an arbitrary direction, so a person can orient the room to reality. */
+  _drawCompass(ctx) {
+    const cx = 20;
+    const cy = 20;
+    const len = 10;
+    ctx.save();
+    ctx.strokeStyle = '#e6e9ef';
+    ctx.fillStyle = '#e6e9ef';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy + len);
+    ctx.lineTo(cx, cy - len);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - len);
+    ctx.lineTo(cx - 4, cy - len + 6);
+    ctx.lineTo(cx + 4, cy - len + 6);
+    ctx.closePath();
+    ctx.fill();
+    ctx.font = 'bold 11px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText('N', cx, cy + len + 13);
+    ctx.restore();
+  }
+}

--- a/ui/components/RoomBuilderTab.js
+++ b/ui/components/RoomBuilderTab.js
@@ -123,6 +123,7 @@ export class RoomBuilderTab {
           </div>
           <div class="rb-actions">
             <button class="rb-btn" id="rbSave">Save</button>
+            <button class="rb-btn secondary" id="rbReload" title="Discard unsaved changes and reload the last saved config">Reload from Saved</button>
           </div>
           <p class="rb-hint">
             Drag a node on the canvas to reposition it (X/Y only — set height
@@ -163,6 +164,10 @@ export class RoomBuilderTab {
     });
     this.container.querySelector('#rbSave').addEventListener('click', () => {
       this._save();
+    });
+    this.container.querySelector('#rbReload').addEventListener('click', async () => {
+      await this._load();
+      toastManager.info('Reloaded from the last saved config — unsaved changes discarded.');
     });
 
     const canvas = this.container.querySelector('#rbCanvas');

--- a/ui/components/RoomBuilderTab.js
+++ b/ui/components/RoomBuilderTab.js
@@ -10,25 +10,62 @@
 
 import { apiService } from '../services/api.service.js';
 import { toastManager } from '../utils/toast.js';
+import { sensingService } from '../services/sensing.service.js';
 
 const ENDPOINT = '/api/v1/config/room';
 const CANVAS_W = 640;
 const CANVAS_H = 480;
 const MARGIN = 32;
 const NODE_RADIUS = 9;
+const AP_RADIUS = 8;
+const LIVE_DOT_RADIUS = 8;
 const METERS_PER_FOOT = 0.3048;
+const METERS_PER_INCH = 0.0254;
+// Typical residential defaults, used when a storey is first added.
+const DEFAULT_CEILING_IN = 96;    // 8 ft
+const DEFAULT_SUBFLOOR_IN = 16;   // joists + subfloor between storeys
 const UNITS_STORAGE_KEY = 'roombuilder-units';
+// Derived from the inch figures above so there is one source of truth for a
+// default storey; a second one in metres drifted from it the moment ceiling
+// height became an input rather than a constant.
+const DEFAULT_CEILING_M = DEFAULT_CEILING_IN * METERS_PER_INCH;
+const DEFAULT_SUBFLOOR_M = DEFAULT_SUBFLOOR_IN * METERS_PER_INCH;
+// Click within this many pixels of a wall endpoint to grab it.
+const WALL_HIT_PX = 7;
 
 export class RoomBuilderTab {
   /** @param {HTMLElement} container - the #roombuilder section element */
   constructor(container) {
     this.container = container;
-    this.config = { width_m: 5, depth_m: 4, nodes: [] };
+    this.config = { width_m: 5, depth_m: 4, nodes: [], ap_position: null };
     this._dragIndex = null;
+    this._draggingAp = false;
+    // Which storey the canvas is editing. Nodes and walls on other storeys
+    // are drawn faintly rather than hidden, so you can line up a second-floor
+    // node with the wall below it -- which is the whole point of stacking
+    // storeys on a shared origin.
+    this._activeFloor = 1;
+    // 'select' drags nodes and the AP; 'wall' draws segments.
+    this._mode = 'select';
+    this._wallStart = null;
+    this._wallPreview = null;
     this._loaded = false;
+    // Live tracked-position overlay, fed by sensingService (/ws/sensing).
+    // `_liveDot` is only ever set from a "bistatic_velocity", "doppler_centroid",
+    // or "motion_centroid" position_source (real room-space meters, same
+    // convention as this.config.nodes) — a "field_peak" fix lives in the Observatory's own
+    // grid-centered coordinate frame (unrelated to this room's actual
+    // width_m/depth_m), so plotting it here would be a fabricated-looking
+    // position. `_liveStatus` explains why no dot is showing when that's the
+    // case. `_liveDotSource` records which tier produced the current dot, so
+    // the canvas label can say which one is actually driving it.
+    this._liveDot = null;
+    this._liveDotSource = null;
+    this._liveStatus = 'Waiting for live sensing data…';
+    this._unsubSensingData = null;
     // Display-only - this.config always stays in meters (that's what the
     // server/API/saved file use); only input values and labels convert.
-    this._units = 'metric';
+    this._units = 'imperial';
     try {
       const saved = localStorage.getItem(UNITS_STORAGE_KEY);
       if (saved === 'metric' || saved === 'imperial') this._units = saved;
@@ -49,10 +86,133 @@ export class RoomBuilderTab {
     return this._units === 'imperial' ? 'ft' : 'm';
   }
 
+  /** Heights are entered in INCHES when imperial, not feet.
+   *
+   * A person siting a node measures "the outlet is 20 inches" and "the
+   * ceiling is 8 foot". Forcing one unit on both means every height becomes a
+   * conversion done by hand, and a conversion done nine times is one done
+   * wrong at least once. Plan distances stay in feet, where feet are natural.
+   */
+  _toHeight(meters) {
+    return this._units === 'imperial' ? meters / METERS_PER_INCH : meters;
+  }
+
+  _fromHeight(value) {
+    return this._units === 'imperial' ? value * METERS_PER_INCH : value;
+  }
+
+  _heightLabel() {
+    return this._units === 'imperial' ? 'in' : 'm';
+  }
+
+  /** Derived elevation of a storey's floor surface above the origin.
+   *
+   * Not measured, and not editable: nobody can put a tape on the height of a
+   * second floor above a first. It is the running sum of the ceiling height
+   * and subfloor thickness of every storey below, both of which a person can
+   * actually measure or look up.
+   */
+  _derivedElevation(level) {
+    const floors = this._floors();
+    let z = 0;
+    for (const f of floors) {
+      if (f.level >= level) break;
+      z += (f.ceiling_m || 0) + (f.subfloor_m || 0);
+    }
+    return Math.round(z * 10000) / 10000;
+  }
+
+  /** Recompute every storey's elevation from ceiling + subfloor, and carry
+   * anything standing on those storeys along with them.
+   *
+   * A node's stored z is absolute (height above the ground floor), but the
+   * height a person entered was relative to its own storey. If floor 1's
+   * ceiling changes, floor 2 moves, and a node 20 inches above floor 2 must
+   * stay 20 inches above floor 2 rather than staying at an absolute height
+   * that is now inside the ceiling below.
+   */
+  _reflowElevations() {
+    // Read every measured height BEFORE the elevations move, then write them
+    // back after. Preserving the measurement is the intent; shifting z by a
+    // delta was the mechanism, and it double-applied whenever another writer
+    // had already accounted for the same elevation.
+    const heights = this.config.nodes.map((n) => this._nodeHeight(n));
+    const apLevel = Number.isFinite(this.config.ap_floor) ? this.config.ap_floor : 1;
+    const apHeight = Array.isArray(this.config.ap_position)
+      ? this.config.ap_position[2] - this._elevationOf(apLevel)
+      : null;
+
+    const floors = this._floors();
+    floors.forEach((f) => { f.elevation_m = this._derivedElevation(f.level); });
+    this.config.floors = floors;
+
+    this.config.nodes.forEach((n, i) => this._setNodeHeight(n, heights[i]));
+    if (apHeight !== null) {
+      this.config.ap_position[2] =
+        Math.round((apHeight + this._elevationOf(apLevel)) * 10000) / 10000;
+    }
+  }
+
   async init() {
     this._buildDOM();
     this._wireEvents();
     await this._load();
+    // sensingService is a singleton started once globally (app.js); we just
+    // subscribe here, same pattern as DashboardTab's live-data subscription.
+    this._unsubSensingData = sensingService.onData((data) => this._onSensingData(data));
+  }
+
+  // ---- Live position overlay ---------------------------------------------
+
+  _onSensingData(data) {
+    const persons = Array.isArray(data.persons) ? data.persons : [];
+    if (persons.length === 0) {
+      this._liveDot = null;
+      this._liveDotSource = null;
+      this._liveStatus = 'No person currently detected.';
+      const idleStatusEl = this.container.querySelector('#rbLiveStatus');
+      if (idleStatusEl) idleStatusEl.textContent = this._liveStatus;
+      this._render();
+      return;
+    }
+
+    // With today's centroid methods, all persons share the one estimate
+    // (single-target only for now) — show just the first to avoid clutter
+    // from the tracker's occasional duplicate/ghost detections.
+    const p = persons[0];
+    const nodeCount = Array.isArray(data.nodes) ? data.nodes.length : 0;
+    const ROOM_SPACE_SOURCES = {
+      bistatic_velocity: 'Live bistatic-geometry estimate — real AP/node Doppler-ellipse math, '
+        + 'still an unvalidated first cut (see position_uncertainty_m).',
+      doppler_centroid: 'Live Doppler-weighted centroid — a heuristic estimate, not a calibrated fix.',
+      motion_centroid: 'Live motion-weighted centroid — a heuristic estimate, not a calibrated fix.',
+    };
+
+    if (ROOM_SPACE_SOURCES[p.position_source] && Array.isArray(p.position)) {
+      const [x, y] = p.position;
+      if (Number.isFinite(x) && Number.isFinite(y)) {
+        this._liveDot = { x, y };
+        this._liveDotSource = p.position_source;
+        this._liveStatus = ROOM_SPACE_SOURCES[p.position_source];
+      } else {
+        this._liveDot = null;
+        this._liveDotSource = null;
+        this._liveStatus = `${p.position_source} reported non-finite coordinates — not plotted.`;
+      }
+    } else {
+      // field_peak positions live in the Observatory's own grid-centered
+      // coordinate frame, not this room's meters/NW-origin frame — plotting
+      // them here would be misleading, so we explain instead of drawing.
+      this._liveDot = null;
+      this._liveDotSource = null;
+      this._liveStatus = `No room-space estimate yet — only ${nodeCount} node(s) reporting, `
+        + `or not enough measured motion right now (need >= 2 positioned nodes with real `
+        + `disturbance). Showing the Observatory's field-peak fallback instead, which isn't `
+        + `in this room's coordinates.`;
+    }
+    const statusEl = this.container.querySelector('#rbLiveStatus');
+    if (statusEl) statusEl.textContent = this._liveStatus;
+    this._render();
   }
 
   // ---- DOM ----------------------------------------------------------------
@@ -69,9 +229,13 @@ export class RoomBuilderTab {
         .rb-room-dims { display: flex; gap: 12px; }
         .rb-room-dims label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: #8b93a7; }
         .rb-room-dims input, .rb-node-row input { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 7px; font-size: 13px; box-sizing: border-box; }
+        .rb-wall-entry { display: grid; grid-template-columns: repeat(4, 1fr) auto; gap: 6px; align-items: end; margin-top: 8px; }
+        .rb-wall-entry label { display: flex; flex-direction: column; gap: 3px; font-size: 11px; color: #6b7280; }
+        .rb-wall-entry input { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 6px; font-size: 13px; width: 100%; box-sizing: border-box; }
+        .rb-node-row select { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 4px; font-size: 13px; width: 100%; box-sizing: border-box; }
         .rb-room-dims input { width: 72px; }
         .rb-room-dims select { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 7px; font-size: 13px; }
-        .rb-node-row { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 1fr 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
+        .rb-node-row { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 52px 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
         .rb-node-row input { width: 100%; }
         .rb-node-row .rb-id { color: #32b8c6; font-weight: 600; font-size: 13px; }
         /* Number inputs' native up/down spinner eats most of the width in
@@ -85,7 +249,7 @@ export class RoomBuilderTab {
         .rb-btn.secondary { background: transparent; color: #32b8c6; border: 1px solid #32b8c6; }
         .rb-actions { display: flex; gap: 10px; margin-top: 8px; }
         .rb-hint { color: #6b7280; font-size: 12px; margin-top: 8px; line-height: 1.5; }
-        .rb-col-headers { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 1fr 24px; gap: 6px; font-size: 11px; color: #6b7280; margin-bottom: 6px; }
+        .rb-col-headers { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 52px 24px; gap: 6px; font-size: 11px; color: #6b7280; margin-bottom: 6px; }
       </style>
       <h2>Room Builder</h2>
       <p class="rb-hint" style="margin-bottom:16px;">
@@ -96,6 +260,7 @@ export class RoomBuilderTab {
       <div class="rb-layout">
         <div class="rb-canvas-wrap">
           <canvas id="rbCanvas" width="${CANVAS_W}" height="${CANVAS_H}"></canvas>
+          <p class="rb-hint" id="rbLiveStatus" style="margin:8px 2px 0;">Waiting for live sensing data…</p>
         </div>
         <div class="rb-panel">
           <div class="rb-card">
@@ -112,9 +277,62 @@ export class RoomBuilderTab {
             </div>
           </div>
           <div class="rb-card">
+            <div class="rb-card-title">Storeys &amp; Walls</div>
+            <p class="rb-hint" style="margin-top:0;">
+              The origin (0,&nbsp;0,&nbsp;0) is the <strong>north-west corner of the
+              first floor</strong>, at floor level. Every storey shares it — the
+              second floor is not re-zeroed — so a node's X/Y means the same
+              thing on any storey and Z is height above the ground floor.
+            </p>
+            <div id="rbFloorControls"></div>
+            <div class="rb-actions" style="margin-top:10px;">
+              <button class="rb-btn secondary" id="rbAddFloor">+ Add Storey</button>
+              <button class="rb-btn secondary" id="rbRemoveFloor">Remove Top Storey</button>
+              <button class="rb-btn secondary" id="rbWallMode">Draw Walls</button>
+            </div>
+            <p class="rb-hint" id="rbWallHint" style="margin-bottom:6px;">
+              In wall mode, drag on the canvas to draw a segment on the selected
+              storey. Other storeys stay visible, faintly, so you can line one up
+              with the floor below.
+            </p>
+            <div class="rb-wall-entry">
+              <label><span>Start &middot; east &rarr;</span><input type="number" id="rbWallX1" step="0.25" value="0" title="Distance east from the north-west corner"></label>
+              <label><span>Start &middot; south &darr;</span><input type="number" id="rbWallY1" step="0.25" value="0" title="Distance south from the north-west corner"></label>
+              <label><span>End &middot; east &rarr;</span><input type="number" id="rbWallX2" step="0.25" placeholder="—" title="Distance east from the north-west corner"></label>
+              <label><span>End &middot; south &darr;</span><input type="number" id="rbWallY2" step="0.25" placeholder="—" title="Distance south from the north-west corner"></label>
+              <button class="rb-btn secondary" id="rbAddWall">Add</button>
+            </div>
+            <p class="rb-hint" id="rbWallEntryHint" style="margin:4px 2px 8px;">
+              Both points are measured from the <strong>north-west corner</strong>, in
+              <span class="rb-unit-label">${this._unitLabel()}</span> — east is right,
+              south is down, matching the <strong>N</strong> arrow on the canvas. A wall
+              along the north edge starting at the corner is
+              start&nbsp;0,&nbsp;0 → end&nbsp;12,&nbsp;0.
+            </p>
+            <div id="rbWallList"></div>
+          </div>
+          <div class="rb-card">
+            <div class="rb-card-title">Access Point</div>
+            <p class="rb-hint" style="margin-top:0;">
+              Optional — needed for Doppler-based position geometry. One AP,
+              same room-space meters as the nodes above (it's often outside
+              the room itself — a hallway, another floor — and that's fine).
+            </p>
+            <div class="rb-room-dims" id="rbApFields" style="${this.config.ap_position ? '' : 'display:none;'}">
+              <label><span>X (<span class="rb-unit-label">${this._unitLabel()}</span>)</span> <input type="number" id="rbApX" step="0.05" value="${this._toDisplay(this.config.ap_position?.[0] ?? 0).toFixed(2)}"></label>
+              <label><span>Y (<span class="rb-unit-label">${this._unitLabel()}</span>)</span> <input type="number" id="rbApY" step="0.05" value="${this._toDisplay(this.config.ap_position?.[1] ?? 0).toFixed(2)}"></label>
+              <label><span>Z (<span class="rb-hunit-label">${this._heightLabel()}</span>)</span> <input type="number" id="rbApZ" step="0.5" title="Height above the AP's own floor" value="${this._toHeight(this.config.ap_position?.[2] ?? 0).toFixed(1)}"></label>
+              <label><span>Floor</span> <select id="rbApFloor"></select></label>
+            </div>
+            <div class="rb-actions" style="margin-top:${this.config.ap_position ? '10px' : '0'};">
+              <button class="rb-btn secondary" id="rbAddAp" style="${this.config.ap_position ? 'display:none;' : ''}">+ Set AP Position</button>
+              <button class="rb-btn secondary" id="rbRemoveAp" style="${this.config.ap_position ? '' : 'display:none;'}">Remove AP</button>
+            </div>
+          </div>
+          <div class="rb-card">
             <div class="rb-card-title">Sensor Nodes</div>
             <div class="rb-col-headers">
-              <span>ID</span><span>Label</span><span>X (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Y (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Z (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span></span><span></span>
+              <span>ID</span><span>Label</span><span>X (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Y (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Z (<span class="rb-hunit-label">${this._heightLabel()}</span>)</span><span>Floor</span><span></span>
             </div>
             <div id="rbNodeList"></div>
             <div class="rb-actions">
@@ -122,19 +340,34 @@ export class RoomBuilderTab {
             </div>
           </div>
           <div class="rb-actions">
+            <button class="rb-btn secondary" id="rbCalibrate"
+                    title="Clear every node's ambient floor and re-learn it from the room as it is now">
+              Recalibrate All Nodes
+            </button>
+          </div>
+          <p class="rb-hint">
+            Use after moving boards or rearranging a room. Nodes adapt on their own,
+            but they climb back down to a lower floor slowly on purpose — so a person
+            standing still is never mistaken for the new normal. This skips the wait.
+            <strong>Leave the area first:</strong> each node re-learns from roughly the
+            next 30&nbsp;seconds, so whatever is moving then becomes its idea of quiet.
+          </p>
+          <div class="rb-actions">
             <button class="rb-btn" id="rbSave">Save</button>
             <button class="rb-btn secondary" id="rbReload" title="Discard unsaved changes and reload the last saved config">Reload from Saved</button>
           </div>
           <p class="rb-hint">
-            Drag a node on the canvas to reposition it (X/Y only — set height
-            with the Z field). Coordinates are in the same room-space meters
-            used by <code>--node-positions</code>.
+            Drag a node — or the AP marker (violet diamond), once set — on the
+            canvas to reposition it (X/Y only — set height with the Z field).
+            Coordinates are in the same room-space meters used by
+            <code>--node-positions</code>.
           </p>
           <p class="rb-hint">
             <strong>(0, 0)</strong> is the room's <strong>Northwest</strong> corner
             (the <strong>N</strong> arrow on the canvas points that way) — X increases
             going <strong>East</strong>, Y increases going <strong>South</strong>. Face
-            the room's actual north wall and match it up when you place nodes.
+            the room's actual north wall and match it up when you place nodes
+            and the access point.
           </p>
         </div>
       </div>
@@ -162,6 +395,145 @@ export class RoomBuilderTab {
     this.container.querySelector('#rbAddNode').addEventListener('click', () => {
       this._addNode();
     });
+    this.container.querySelector('#rbAddAp').addEventListener('click', () => {
+      // Default to head height on the storey currently being edited, rather
+      // than an absolute 2.5 m that would be inside the ceiling upstairs.
+      this.config.ap_floor = this._activeFloor;
+      this.config.ap_position = [
+        this.config.width_m / 2,
+        this.config.depth_m / 2,
+        Math.round((this._elevationOf(this._activeFloor) + 2.2) * 10000) / 10000,
+      ];
+      this._renderApFields();
+      this._render();
+    });
+    // Live preview: typing coordinates is only unclear until you can see what
+    // they produce. The dashed line uses the same path as a dragged wall.
+    const wallInputs = ['rbWallX1', 'rbWallY1', 'rbWallX2', 'rbWallY2'];
+    const previewWall = () => {
+      const raw = wallInputs.map((id) => this.container.querySelector(`#${id}`).value);
+      if (raw.some((v) => v === '' || v === null)) {
+        this._wallStart = null;
+        this._wallPreview = null;
+        this._updateWallEntryHint(null);
+        this._render();
+        return;
+      }
+      const [x1, y1, x2, y2] = raw.map((v) => this._fromDisplay(parseFloat(v) || 0));
+      this._wallStart = { x: x1, y: y1 };
+      const end = this._toPixel(x2, y2);
+      this._wallPreview = { x: end.px, y: end.py };
+      this._updateWallEntryHint(Math.hypot(x2 - x1, y2 - y1));
+      this._render();
+    };
+    wallInputs.forEach((id) => {
+      this.container.querySelector(`#${id}`).addEventListener('input', previewWall);
+    });
+
+    this.container.querySelector('#rbAddWall').addEventListener('click', () => {
+      const num = (id) => parseFloat(this.container.querySelector(`#${id}`).value);
+      // An empty end box used to fall through `|| 0` and draw a wall to the
+      // north-west corner, which is a real coordinate and so looked deliberate.
+      const missing = ['rbWallX2', 'rbWallY2'].some(
+        (id) => !Number.isFinite(num(id))
+      );
+      if (missing) {
+        toastManager.error('Fill in both end coordinates before adding the wall.');
+        return;
+      }
+      const x1 = this._fromDisplay(num('rbWallX1') || 0);
+      const y1 = this._fromDisplay(num('rbWallY1') || 0);
+      const x2 = this._fromDisplay(num('rbWallX2'));
+      const y2 = this._fromDisplay(num('rbWallY2'));
+      if (Math.hypot(x2 - x1, y2 - y1) < 0.1) {
+        toastManager.error('Start and end are the same point — a wall needs length.');
+        return;
+      }
+      if (!Array.isArray(this.config.walls)) this.config.walls = [];
+      const r = (v) => Math.round(v * 10000) / 10000;
+      this.config.walls.push({
+        level: this._activeFloor,
+        x1: r(x1), y1: r(y1), x2: r(x2), y2: r(y2),
+      });
+      // Chain from the end point -- walls in a room almost always meet -- but
+      // CLEAR the end. Copying both left all four boxes showing the same
+      // number and staged a zero-length wall, which looked broken.
+      this.container.querySelector('#rbWallX1').value = num('rbWallX2');
+      this.container.querySelector('#rbWallY1').value = num('rbWallY2');
+      this.container.querySelector('#rbWallX2').value = '';
+      this.container.querySelector('#rbWallY2').value = '';
+      this._wallStart = null;
+      this._wallPreview = null;
+      this._updateWallEntryHint(null);
+      this._renderWallList();
+      this._renderFloorControls();
+      this._render();
+    });
+    this.container.querySelector('#rbAddFloor').addEventListener('click', () => {
+      this._addFloor();
+    });
+    this.container.querySelector('#rbRemoveFloor').addEventListener('click', () => {
+      this._removeTopFloor();
+    });
+    this.container.querySelector('#rbWallMode').addEventListener('click', (e) => {
+      this._mode = this._mode === 'wall' ? 'select' : 'wall';
+      // Abandon a half-drawn segment rather than leaving it to commit on the
+      // next unrelated click.
+      this._wallStart = null;
+      this._wallPreview = null;
+      e.target.textContent = this._mode === 'wall' ? 'Done Drawing' : 'Draw Walls';
+      const canvas = this.container.querySelector('#rbCanvas');
+      if (canvas) canvas.style.cursor = this._mode === 'wall' ? 'crosshair' : 'default';
+      const hint = this.container.querySelector('#rbWallHint');
+      if (hint) {
+        hint.textContent = this._mode === 'wall'
+          ? 'Drag on the canvas to draw a wall on the selected storey. Dragging no longer moves nodes.'
+          : 'In wall mode, drag on the canvas to draw a segment on the selected storey. Other storeys stay visible, faintly, so you can line one up with the floor below.';
+      }
+      this._render();
+    });
+    this.container.querySelector('#rbRemoveAp').addEventListener('click', () => {
+      this.config.ap_position = null;
+      this._renderApFields();
+      this._render();
+    });
+    ['rbApX', 'rbApY', 'rbApZ'].forEach((id) => {
+      this.container.querySelector(`#${id}`).addEventListener('input', () => {
+        this._syncApFromInputs();
+        this._render();
+      });
+    });
+    this.container.querySelector('#rbCalibrate').addEventListener('click', async (e) => {
+      const btn = e.target;
+      btn.disabled = true;
+      const was = btn.textContent;
+      btn.textContent = 'Recalibrating…';
+      try {
+        const r = await apiService.post('/api/v1/calibrate', {});
+        if (r && r.error) {
+          toastManager.error(`Recalibrate failed: ${r.error}`);
+        } else {
+          const okList = (r && r.recalibrated) || [];
+          const bad = (r && r.failed) || [];
+          // Name the nodes that did not take it. "Partial success" with no
+          // list means walking the house to work out which board to look at.
+          if (bad.length) {
+            toastManager.error(
+              `Recalibrated ${okList.length}; failed on node(s) ${bad.map((f) => f.node).join(', ')}`
+            );
+          } else {
+            toastManager.success(
+              `Recalibrating ${okList.length} node(s) — they re-learn over about 30 seconds.`
+            );
+          }
+        }
+      } catch (err) {
+        toastManager.error(`Recalibrate failed: ${err.message}`);
+      } finally {
+        btn.disabled = false;
+        btn.textContent = was;
+      }
+    });
     this.container.querySelector('#rbSave').addEventListener('click', () => {
       this._save();
     });
@@ -173,19 +545,80 @@ export class RoomBuilderTab {
     const canvas = this.container.querySelector('#rbCanvas');
     canvas.addEventListener('mousedown', (e) => this._onCanvasDown(e));
     canvas.addEventListener('mousemove', (e) => this._onCanvasMove(e));
-    window.addEventListener('mouseup', () => { this._dragIndex = null; });
+    window.addEventListener('mouseup', (e) => {
+      if (this._mode === 'wall' && this._wallStart) {
+        this._commitWall(e);
+      }
+      this._dragIndex = null;
+      this._draggingAp = false;
+    });
   }
 
   // ---- Data -----------------------------------------------------------------
+
+  /** Storeys, ascending. An empty list means a single implicit ground floor,
+   * which is how every config written before storeys existed behaves. */
+  _floors() {
+    if (!Array.isArray(this.config.floors) || this.config.floors.length === 0) {
+      return [{ level: 1, name: 'First', elevation_m: 0, ceiling_m: DEFAULT_CEILING_M, subfloor_m: DEFAULT_SUBFLOOR_M }];
+    }
+    return [...this.config.floors].sort((a, b) => a.level - b.level);
+  }
+
+  _floorOf(node) {
+    return Number.isFinite(node.floor) ? node.floor : 1;
+  }
+
+  /** A node's height above its OWN storey — the number a person measured. */
+  _nodeHeight(node) {
+    return node.z - this._elevationOf(this._floorOf(node));
+  }
+
+  /** The ONLY place node.z is written.
+   *
+   * z is stored absolute (above the ground floor) because geometry needs one
+   * axis, but every height in this form is entered relative to its own storey.
+   * That conversion used to happen in three places — the input sync, the
+   * storey selector, and the elevation reflow — each adding the storey
+   * elevation independently. Any two firing for one edit added it twice, which
+   * is how nodes ended up at 122 and 246 inches above their own ceilings.
+   *
+   * Now there is one writer and one reader, and both go through the same
+   * elevation lookup, so the round trip is idempotent no matter how many times
+   * it runs. */
+  _setNodeHeight(node, relMeters) {
+    if (!Number.isFinite(relMeters)) return;
+    node.z = Math.round((relMeters + this._elevationOf(this._floorOf(node))) * 10000) / 10000;
+  }
+
+  _elevationOf(level) {
+    const f = this._floors().find((x) => x.level === level);
+    return f ? f.elevation_m : 0;
+  }
 
   async _load() {
     try {
       const data = await apiService.get(ENDPOINT);
       if (data && typeof data === 'object') {
+        // Spread first, then override only the fields that need defaulting.
+        //
+        // This was an explicit allowlist of four fields, which silently
+        // discarded everything the server sent that was not on it — floors,
+        // walls and ap_floor were all dropped on load. The visible symptom was
+        // storeys vanishing from the picker after a refresh, but the real
+        // danger was the next Save: config no longer held them, so it would
+        // POST an empty list and destroy the storeys on disk for real.
+        //
+        // Spreading means a field added to the server is carried through
+        // rather than quietly deleted by a UI that predates it.
         this.config = {
+          ...data,
           width_m: data.width_m > 0 ? data.width_m : 5,
           depth_m: data.depth_m > 0 ? data.depth_m : 4,
           nodes: Array.isArray(data.nodes) ? data.nodes : [],
+          ap_position: Array.isArray(data.ap_position) ? data.ap_position : null,
+          floors: Array.isArray(data.floors) ? data.floors : [],
+          walls: Array.isArray(data.walls) ? data.walls : [],
         };
       }
     } catch (e) {
@@ -198,21 +631,97 @@ export class RoomBuilderTab {
   /** Re-render everything that shows a unit-dependent value, using the
    * current `this._units` - called on load and whenever the unit toggle
    * changes. `this.config` itself never changes here; only what's displayed. */
+  /** Re-render every panel that depends on the loaded config. Called from the
+   * same places as _renderNodeList, so storeys and walls cannot drift out of
+   * sync with what was loaded or saved. */
+  _renderStoreyPanels() {
+    this._renderFloorControls();
+    this._renderWallList();
+  }
+
   _refreshUnitDisplay() {
     const label = this._unitLabel();
     this.container.querySelectorAll('.rb-unit-label').forEach((el) => {
       el.textContent = label;
     });
+    // Heights use their own unit (inches when imperial), so they have their
+    // own label class. Missing this leaves "ft" beside a field holding inches.
+    const hLabel = this._heightLabel();
+    this.container.querySelectorAll('.rb-hunit-label').forEach((el) => {
+      el.textContent = hLabel;
+    });
     this.container.querySelector('#rbWidth').value = this._toDisplay(this.config.width_m).toFixed(2);
     this.container.querySelector('#rbDepth').value = this._toDisplay(this.config.depth_m).toFixed(2);
     this._renderNodeList();
+    this._renderStoreyPanels();
+    this._renderApFields();
     this._render();
   }
 
+  /** Show/hide the AP X/Y/Z fields and Add/Remove buttons based on whether
+   * ap_position is set, and refresh the input values from this.config. */
+  _renderApFields() {
+    const fields = this.container.querySelector('#rbApFields');
+    const addBtn = this.container.querySelector('#rbAddAp');
+    const removeBtn = this.container.querySelector('#rbRemoveAp');
+    const has = Array.isArray(this.config.ap_position);
+    fields.style.display = has ? '' : 'none';
+    addBtn.style.display = has ? 'none' : '';
+    removeBtn.style.display = has ? '' : 'none';
+    if (has) {
+      const [x, y, z] = this.config.ap_position;
+      const lvl = Number.isFinite(this.config.ap_floor) ? this.config.ap_floor : 1;
+      this.container.querySelector('#rbApX').value = this._toDisplay(x).toFixed(2);
+      this.container.querySelector('#rbApY').value = this._toDisplay(y).toFixed(2);
+      // Shown as height above the AP's own storey, like every other height in
+      // this form. Storage stays absolute.
+      this.container.querySelector('#rbApZ').value =
+        this._toHeight(z - this._elevationOf(lvl)).toFixed(1);
+
+      const sel = this.container.querySelector('#rbApFloor');
+      if (sel) {
+        sel.innerHTML = this._floors()
+          .map((f) => `<option value="${f.level}" ${f.level === lvl ? 'selected' : ''}>${f.level}</option>`)
+          .join('');
+        if (!sel.dataset.wired) {
+          sel.dataset.wired = '1';
+          sel.addEventListener('change', () => {
+            // Keep the measured height: moving the AP upstairs moves its
+            // absolute z by the difference in storey elevations.
+            const prev = this._elevationOf(
+              Number.isFinite(this.config.ap_floor) ? this.config.ap_floor : 1
+            );
+            const next = this._elevationOf(Number(sel.value));
+            this.config.ap_floor = Number(sel.value);
+            if (Array.isArray(this.config.ap_position)) {
+              this.config.ap_position[2] =
+                Math.round((this.config.ap_position[2] - prev + next) * 10000) / 10000;
+            }
+            this._renderApFields();
+            this._render();
+          });
+        }
+      }
+    }
+  }
+
+  /** Pull edited values out of the AP X/Y/Z inputs back into
+   * this.config.ap_position, same pattern as _syncNodesFromInputs. */
+  _syncApFromInputs() {
+    if (!Array.isArray(this.config.ap_position)) return;
+    const x = this._fromDisplay(parseFloat(this.container.querySelector('#rbApX').value) || 0);
+    const y = this._fromDisplay(parseFloat(this.container.querySelector('#rbApY').value) || 0);
+    const lvl = Number.isFinite(this.config.ap_floor) ? this.config.ap_floor : 1;
+    const relZ = this._fromHeight(parseFloat(this.container.querySelector('#rbApZ').value) || 0);
+    const z = Math.round((relZ + this._elevationOf(lvl)) * 10000) / 10000;
+    this.config.ap_position = [x, y, z];
+  }
+
   async _save() {
-    // Pull the latest values out of the node-row inputs before sending -
+    // Pull the latest values out of the node-row/AP inputs before sending -
     // numeric fields don't write back into this.config until blur/save.
     this._syncNodesFromInputs();
+    this._syncApFromInputs();
     const ids = this.config.nodes.map((n) => n.id);
     if (new Set(ids).size !== ids.length) {
       toastManager.error('Cannot save: two or more nodes have the same ID. Give each a unique ID first.');
@@ -249,12 +758,14 @@ export class RoomBuilderTab {
       label: '',
     });
     this._renderNodeList();
+    this._renderStoreyPanels();
     this._render();
   }
 
   _removeNode(index) {
     this.config.nodes.splice(index, 1);
     this._renderNodeList();
+    this._renderStoreyPanels();
     this._render();
   }
 
@@ -279,7 +790,9 @@ export class RoomBuilderTab {
       node.label = row.querySelector('.rb-label').value;
       node.x = this._fromDisplay(parseFloat(row.querySelector('.rb-x').value) || 0);
       node.y = this._fromDisplay(parseFloat(row.querySelector('.rb-y').value) || 0);
-      node.z = this._fromDisplay(parseFloat(row.querySelector('.rb-z').value) || 0);
+      // The field holds height above this node's own storey; _setNodeHeight
+      // is the single place that turns that into absolute z.
+      this._setNodeHeight(node, this._fromHeight(parseFloat(row.querySelector('.rb-z').value) || 0));
     });
     this._warnOnDuplicateIds();
   }
@@ -318,10 +831,30 @@ export class RoomBuilderTab {
         <input class="rb-label" type="text" value="${node.label || ''}" placeholder="e.g. front-right">
         <input class="rb-x" type="number" step="0.05" value="${this._toDisplay(safe(node.x)).toFixed(2)}">
         <input class="rb-y" type="number" step="0.05" value="${this._toDisplay(safe(node.y)).toFixed(2)}">
-        <input class="rb-z" type="number" step="0.05" value="${this._toDisplay(safe(node.z)).toFixed(2)}">
-        <span></span>
+        <input class="rb-z" type="number" step="0.5" title="Height above this node's own floor"
+               value="${this._toHeight(safe(node.z) - this._elevationOf(this._floorOf(node))).toFixed(1)}">
+        <select class="rb-floor" title="Which storey this node is mounted on">
+          ${this._floors().map((f) => `<option value="${f.level}" ${this._floorOf(node) === f.level ? 'selected' : ''}>${f.level}</option>`).join('')}
+        </select>
         <button class="rb-remove-btn" title="Remove node">&times;</button>
       `;
+      const floorSel = row.querySelector('.rb-floor');
+      if (floorSel) {
+        floorSel.addEventListener('change', () => {
+          // Store the storey, and lift z onto it so the node does not stay at
+          // ground-floor height after being moved upstairs. z is measured from
+          // the FIRST floor, so moving between storeys has to move z too or the
+          // node silently ends up inside the ceiling below.
+          // Keep the height the person measured: read it against the OLD
+          // storey, change storey, write it back against the NEW one. The
+          // elevation is applied by _setNodeHeight and nowhere else.
+          const rel = this._nodeHeight(node);
+          node.floor = Number(floorSel.value);
+          this._setNodeHeight(node, rel);
+          this._renderNodeList();
+          this._render();
+        });
+      }
       row.querySelectorAll('input').forEach((inp) => {
         inp.addEventListener('input', () => {
           this._syncNodesFromInputs();
@@ -344,14 +877,20 @@ export class RoomBuilderTab {
     return { px: MARGIN + x * scale, py: MARGIN + y * scale, scale };
   }
 
-  /** Canvas pixel coordinates -> room-space (x,y) meters, clamped to the room. */
-  _toRoom(px, py) {
+  /** Canvas pixel coordinates -> room-space (x,y) meters. Clamped to the room
+   * by default (sensor nodes always live inside it); pass `clamp: false` for
+   * the AP marker, which is legitimately often outside the room. */
+  _toRoom(px, py, { clamp = true } = {}) {
     const scale = Math.min(
       (CANVAS_W - 2 * MARGIN) / this.config.width_m,
       (CANVAS_H - 2 * MARGIN) / this.config.depth_m
     );
-    const x = Math.min(this.config.width_m, Math.max(0, (px - MARGIN) / scale));
-    const y = Math.min(this.config.depth_m, Math.max(0, (py - MARGIN) / scale));
+    let x = (px - MARGIN) / scale;
+    let y = (py - MARGIN) / scale;
+    if (clamp) {
+      x = Math.min(this.config.width_m, Math.max(0, x));
+      y = Math.min(this.config.depth_m, Math.max(0, y));
+    }
     return { x, y };
   }
 
@@ -366,6 +905,23 @@ export class RoomBuilderTab {
 
   _onCanvasDown(e) {
     const pos = this._canvasPos(e);
+
+    if (this._mode === 'wall') {
+      // Walls are not clamped to the room rectangle. width_m/depth_m describe
+      // the sensed area, and an exterior wall is legitimately on or slightly
+      // outside that boundary.
+      const room = this._toRoom(pos.x, pos.y, { clamp: false });
+      this._wallStart = { x: room.x, y: room.y };
+      this._wallPreview = { x: pos.x, y: pos.y };
+      return;
+    }
+    if (Array.isArray(this.config.ap_position)) {
+      const { px, py } = this._toPixel(this.config.ap_position[0], this.config.ap_position[1]);
+      if (Math.hypot(px - pos.x, py - pos.y) <= AP_RADIUS + 4) {
+        this._draggingAp = true;
+        return;
+      }
+    }
     this.config.nodes.forEach((node, idx) => {
       const { px, py } = this._toPixel(node.x, node.y);
       if (this._dragIndex == null && Math.hypot(px - pos.x, py - pos.y) <= NODE_RADIUS + 4) {
@@ -375,6 +931,21 @@ export class RoomBuilderTab {
   }
 
   _onCanvasMove(e) {
+    if (this._mode === 'wall' && this._wallStart) {
+      const pos = this._canvasPos(e);
+      this._wallPreview = { x: pos.x, y: pos.y };
+      this._render();
+      return;
+    }
+    if (this._draggingAp) {
+      const pos = this._canvasPos(e);
+      const room = this._toRoom(pos.x, pos.y, { clamp: false });
+      this.config.ap_position[0] = Math.round(room.x * 100) / 100;
+      this.config.ap_position[1] = Math.round(room.y * 100) / 100;
+      this._renderApFields();
+      this._render();
+      return;
+    }
     if (this._dragIndex == null) return;
     const node = this.config.nodes[this._dragIndex];
     if (!node) return;
@@ -383,6 +954,231 @@ export class RoomBuilderTab {
     node.x = Math.round(room.x * 100) / 100;
     node.y = Math.round(room.y * 100) / 100;
     this._renderNodeList();
+    this._renderStoreyPanels();
+    this._render();
+  }
+
+  /** Storey selector, plus the two numbers a person can actually measure.
+   *
+   * Ceiling height and subfloor thickness are the inputs; elevation is
+   * derived from them and shown read-only. Nobody can put a tape measure on
+   * "height of the second floor above the first", but anyone can measure a
+   * ceiling and look up a joist depth -- and deriving it means every height
+   * elsewhere in this form is relative to the floor you are standing on.
+   */
+  _renderFloorControls() {
+    const host = this.container.querySelector('#rbFloorControls');
+    if (!host) return;
+    const floors = this._floors();
+    const active = floors.find((f) => f.level === this._activeFloor) || floors[0];
+    this._activeFloor = active.level;
+    const hu = this._heightLabel();
+
+    const opts = floors
+      .map((f) => {
+        const nodes = this.config.nodes.filter((n) => this._floorOf(n) === f.level).length;
+        const walls = (this.config.walls || []).filter((w) => w.level === f.level).length;
+        const sel = f.level === this._activeFloor ? 'selected' : '';
+        const nm = f.name || `Floor ${f.level}`;
+        return `<option value="${f.level}" ${sel}>${nm} — ${nodes} node(s), ${walls} wall(s)</option>`;
+      })
+      .join('');
+
+    const elev = this._derivedElevation(active.level);
+    host.innerHTML = `
+      <div class="rb-room-dims">
+        <label><span>Editing storey</span>
+          <select id="rbFloorSelect">${opts}</select>
+        </label>
+        <label><span>Floor to ceiling (<span class="rb-hunit-label">${hu}</span>)</span>
+          <input type="number" id="rbFloorCeil" min="1" step="0.5"
+                 value="${this._toHeight(active.ceiling_m).toFixed(1)}"
+                 title="Measured floor surface to ceiling on this storey"></label>
+        <label><span>Subfloor / joists (<span class="rb-hunit-label">${hu}</span>)</span>
+          <input type="number" id="rbFloorSub" min="0" step="0.5"
+                 value="${this._toHeight(active.subfloor_m || 0).toFixed(1)}"
+                 title="Structure between this ceiling and the floor above"></label>
+      </div>
+      <p class="rb-hint" style="margin:6px 2px 0;">
+        This storey's floor sits <strong>${this._toHeight(elev).toFixed(1)} ${hu}</strong>
+        above the ground floor${active.level === 1 ? ' (it defines the origin)' : ''}.
+        Heights you enter below are measured from <em>this</em> floor, so an outlet
+        20&nbsp;${hu} up is just 20.
+      </p>`;
+
+    const sel = host.querySelector('#rbFloorSelect');
+    if (sel) sel.addEventListener('change', () => {
+      this._activeFloor = Number(sel.value);
+      this._renderFloorControls();
+      this._renderNodeList();
+      this._renderWallList();
+      this._render();
+    });
+
+    const commit = () => {
+      const f = this._floors().find((x) => x.level === this._activeFloor);
+      if (!f) return;
+      const c = parseFloat(host.querySelector('#rbFloorCeil').value);
+      const sub = parseFloat(host.querySelector('#rbFloorSub').value);
+      if (Number.isFinite(c) && c > 0) f.ceiling_m = this._fromHeight(c);
+      if (Number.isFinite(sub) && sub >= 0) f.subfloor_m = this._fromHeight(sub);
+      this.config.floors = this._floors();
+      // Changing a ceiling moves every storey above it, and everything on them.
+      this._reflowElevations();
+      this._renderFloorControls();
+      this._renderNodeList();
+      this._renderApFields();
+      this._render();
+    };
+    ['#rbFloorCeil', '#rbFloorSub'].forEach((id) => {
+      const el = host.querySelector(id);
+      if (el) el.addEventListener('change', commit);
+    });
+  }
+
+  /** Show the length of the wall currently being typed, or the how-to text. */
+  _updateWallEntryHint(lengthMeters) {
+    const el = this.container.querySelector('#rbWallEntryHint');
+    if (!el) return;
+    if (lengthMeters == null) {
+      el.innerHTML = `Both points are measured from the <strong>north-west corner</strong>, in
+        <span class="rb-unit-label">${this._unitLabel()}</span> — east is right, south is
+        down, matching the <strong>N</strong> arrow on the canvas. A wall along the north
+        edge starting at the corner is start&nbsp;0,&nbsp;0 → end&nbsp;12,&nbsp;0.`;
+      return;
+    }
+    const u = this._unitLabel();
+    el.innerHTML = lengthMeters < 0.1
+      ? '<span style="color:#e05561;">Start and end are the same point.</span>'
+      : `This wall is <strong>${this._toDisplay(lengthMeters).toFixed(1)} ${u}</strong> long — shown dashed on the canvas.`;
+  }
+
+  /** Walls on the active storey, each removable. */
+  _renderWallList() {
+    const host = this.container.querySelector('#rbWallList');
+    if (!host) return;
+    const walls = this.config.walls || [];
+    const mine = walls
+      .map((w, i) => ({ w, i }))
+      .filter(({ w }) => w.level === this._activeFloor);
+
+    if (mine.length === 0) {
+      host.innerHTML = '<p class="rb-hint" style="margin:4px 2px;">No walls on this storey yet.</p>';
+      return;
+    }
+    const u = this._unitLabel();
+    host.innerHTML = mine
+      .map(({ w, i }) => {
+        const len = Math.hypot(w.x2 - w.x1, w.y2 - w.y1);
+        return `<div class="rb-hint" style="display:flex;align-items:center;gap:8px;margin:3px 2px;">
+          <span style="flex:1;font-family:monospace;">
+            (${this._toDisplay(w.x1).toFixed(1)}, ${this._toDisplay(w.y1).toFixed(1)})
+            → (${this._toDisplay(w.x2).toFixed(1)}, ${this._toDisplay(w.y2).toFixed(1)})
+            · ${this._toDisplay(len).toFixed(1)} ${u}
+          </span>
+          <button class="rb-btn secondary" data-wall="${i}" style="padding:2px 8px;">✕</button>
+        </div>`;
+      })
+      .join('');
+
+    host.querySelectorAll('button[data-wall]').forEach((b) => {
+      b.addEventListener('click', () => {
+        const idx = Number(b.getAttribute('data-wall'));
+        this.config.walls.splice(idx, 1);
+        this._renderWallList();
+        this._renderFloorControls();
+        this._render();
+      });
+    });
+  }
+
+  /** Finish the wall being dragged, if it is long enough to be a wall.
+   *
+   * The server rejects zero-length segments (they make any
+   * line-intersection test degenerate rather than merely wrong), so a stray
+   * click is dropped here rather than sent and bounced. 10 cm is below any
+   * real wall and above any accidental twitch.
+   */
+  _commitWall(e) {
+    const start = this._wallStart;
+    this._wallStart = null;
+    this._wallPreview = null;
+    if (!start) return;
+
+    const pos = this._canvasPos(e);
+    const end = this._toRoom(pos.x, pos.y, { clamp: false });
+    const len = Math.hypot(end.x - start.x, end.y - start.y);
+    if (!Number.isFinite(len) || len < 0.1) {
+      this._render();
+      return;
+    }
+
+    const round = (v) => Math.round(v * 100) / 100;
+    if (!Array.isArray(this.config.walls)) this.config.walls = [];
+    this.config.walls.push({
+      level: this._activeFloor,
+      x1: round(start.x), y1: round(start.y),
+      x2: round(end.x), y2: round(end.y),
+    });
+    this._renderWallList();
+    this._render();
+  }
+
+  /** Add a storey above the highest one. */
+  _addFloor() {
+    const floors = this._floors();
+    const top = floors[floors.length - 1];
+    const next = {
+      level: top.level + 1,
+      name: `Floor ${top.level + 1}`,
+      // Placeholder; _reflowElevations derives the real value from the
+      // ceiling and subfloor of every storey below.
+      elevation_m: 0,
+      ceiling_m: top.ceiling_m || DEFAULT_CEILING_M,
+      subfloor_m: DEFAULT_SUBFLOOR_M,
+    };
+    // Materialise the implicit ground floor too, otherwise saving a second
+    // storey would leave the first undeclared and the server would reject
+    // every node on it as living on an undefined floor.
+    // A storey below with no subfloor recorded would put the new floor
+    // exactly on the old ceiling, which is never true of a real building.
+    const below = floors[floors.length - 1];
+    if (!below.subfloor_m) below.subfloor_m = DEFAULT_SUBFLOOR_M;
+    this.config.floors = [...floors, next];
+    this._activeFloor = next.level;
+    this._reflowElevations();
+    this._renderFloorControls();
+    this._renderNodeList();
+    this._render();
+  }
+
+  /** Remove the top storey, and anything on it.
+   *
+   * Deleting a storey while nodes or walls still reference it would produce a
+   * config the server refuses to save, with an error naming a floor the user
+   * can no longer see. Better to say what will go, and go.
+   */
+  _removeTopFloor() {
+    const floors = this._floors();
+    if (floors.length <= 1) return;
+    const doomed = floors[floors.length - 1].level;
+    const nodes = this.config.nodes.filter((n) => this._floorOf(n) === doomed).length;
+    const walls = (this.config.walls || []).filter((w) => w.level === doomed).length;
+    if (nodes || walls) {
+      const ok = window.confirm(
+        `Remove floor ${doomed}? This also deletes ${nodes} node(s) and ${walls} wall(s) on it.`
+      );
+      if (!ok) return;
+    }
+    this.config.floors = floors.filter((f) => f.level !== doomed);
+    this.config.nodes = this.config.nodes.filter((n) => this._floorOf(n) !== doomed);
+    this.config.walls = (this.config.walls || []).filter((w) => w.level !== doomed);
+    if (this.config.floors.length <= 1) this.config.floors = [];
+    this._activeFloor = 1;
+    this._renderFloorControls();
+    this._renderNodeList();
+    this._renderStoreyPanels();
+    this._renderWallList();
     this._render();
   }
 
@@ -417,6 +1213,36 @@ export class RoomBuilderTab {
       ctx.stroke();
     }
 
+    // Walls. Drawn before nodes so a node marker is never hidden behind one.
+    // Other storeys show faintly: alignment between floors is exactly what a
+    // shared origin is for, and hiding them would make it guesswork.
+    (this.config.walls || []).forEach((w) => {
+      const a = this._toPixel(w.x1, w.y1);
+      const b = this._toPixel(w.x2, w.y2);
+      const active = w.level === this._activeFloor;
+      ctx.strokeStyle = active ? '#e6edf3' : 'rgba(230,237,243,0.18)';
+      ctx.lineWidth = active ? 4 : 2;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(a.px, a.py);
+      ctx.lineTo(b.px, b.py);
+      ctx.stroke();
+    });
+    ctx.lineCap = 'butt';
+
+    // Wall being dragged out right now.
+    if (this._wallStart && this._wallPreview) {
+      const a = this._toPixel(this._wallStart.x, this._wallStart.y);
+      ctx.strokeStyle = '#ffd166';
+      ctx.lineWidth = 4;
+      ctx.setLineDash([6, 4]);
+      ctx.beginPath();
+      ctx.moveTo(a.px, a.py);
+      ctx.lineTo(this._wallPreview.x, this._wallPreview.y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
     // Nodes.
     this.config.nodes.forEach((node, idx) => {
       const { px, py } = this._toPixel(node.x, node.y);
@@ -424,6 +1250,8 @@ export class RoomBuilderTab {
         console.warn('[RoomBuilder] Skipping node with non-finite position:', node);
         return;
       }
+      const onThisFloor = this._floorOf(node) === this._activeFloor;
+      ctx.globalAlpha = onThisFloor ? 1 : 0.28;
       ctx.beginPath();
       ctx.arc(px, py, NODE_RADIUS, 0, Math.PI * 2);
       ctx.fillStyle = idx === this._dragIndex ? '#ffd166' : '#e05561';
@@ -438,8 +1266,79 @@ export class RoomBuilderTab {
       const label = node.label ? `${node.id}:${node.label}` : `${node.id}`;
       ctx.fillText(label, px, py - NODE_RADIUS - 6);
     });
+    // Leaving globalAlpha faded would silently dim the AP, the live dot and
+    // the compass drawn below.
+    ctx.globalAlpha = 1;
 
+    this._drawAp(ctx);
+    this._drawLiveDot(ctx);
     this._drawCompass(ctx);
+  }
+
+  /** Draw the AP marker (a diamond, distinct from the round sensor nodes) —
+   * intentionally NOT clamped/warned about being outside the room rectangle,
+   * since a real AP very often is (see validate_room_config on the server). */
+  _drawAp(ctx) {
+    if (!Array.isArray(this.config.ap_position)) return;
+    const [x, y] = this.config.ap_position;
+    const { px, py } = this._toPixel(x, y);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return;
+
+    ctx.save();
+    ctx.translate(px, py);
+    ctx.rotate(Math.PI / 4);
+    const s = AP_RADIUS;
+    ctx.fillStyle = this._draggingAp ? '#ffd166' : '#a78bfa';
+    ctx.fillRect(-s, -s, s * 2, s * 2);
+    ctx.strokeStyle = '#0d1117';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(-s, -s, s * 2, s * 2);
+    ctx.restore();
+
+    ctx.fillStyle = '#e6e9ef';
+    ctx.font = '12px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText('AP', px, py - AP_RADIUS - 8);
+  }
+
+  /** Draw the live person-position estimate, when one exists. Pulses gently
+   * so it reads as "live" rather than a static marker like the sensor nodes.
+   * Label states which tier produced it (doppler vs motion) so it's never
+   * mistaken for a calibrated fix. */
+  _drawLiveDot(ctx) {
+    if (!this._liveDot) return;
+    const { px, py } = this._toPixel(this._liveDot.x, this._liveDot.y);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return;
+
+    const pulse = 1 + 0.15 * Math.sin(Date.now() / 300);
+    ctx.beginPath();
+    ctx.arc(px, py, LIVE_DOT_RADIUS * pulse, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(255, 209, 102, 0.9)';
+    ctx.fill();
+    ctx.strokeStyle = '#0d1117';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    ctx.fillStyle = '#ffd166';
+    ctx.font = 'bold 12px monospace';
+    ctx.textAlign = 'center';
+    const LIVE_DOT_LABELS = {
+      bistatic_velocity: 'live (bistatic)',
+      doppler_centroid: 'live (doppler)',
+      motion_centroid: 'live (motion)',
+    };
+    const label = LIVE_DOT_LABELS[this._liveDotSource] || 'live (motion)';
+    ctx.fillText(label, px, py - LIVE_DOT_RADIUS - 8);
+
+    // Keep animating the pulse while a fix is present.
+    if (!this._liveDotAnimHandle) {
+      const animate = () => {
+        if (!this._liveDot) { this._liveDotAnimHandle = null; return; }
+        this._render();
+        this._liveDotAnimHandle = requestAnimationFrame(animate);
+      };
+      this._liveDotAnimHandle = requestAnimationFrame(animate);
+    }
   }
 
   /** (0,0,0) is the room's Northwest corner by convention - X increases

--- a/ui/index.html
+++ b/ui/index.html
@@ -36,6 +36,7 @@
             <button class="nav-tab" data-tab="performance" role="tab" aria-selected="false" aria-controls="performance">Performance</button>
             <button class="nav-tab" data-tab="applications" role="tab" aria-selected="false" aria-controls="applications">Applications</button>
             <button class="nav-tab" data-tab="sensing" role="tab" aria-selected="false" aria-controls="sensing">Sensing</button>
+            <button class="nav-tab" data-tab="roombuilder" role="tab" aria-selected="false" aria-controls="roombuilder">Room Builder</button>
             <button class="nav-tab" data-tab="training" role="tab" aria-selected="false" aria-controls="training">Training</button>
             <a href="pose-fusion.html" class="nav-tab" style="text-decoration:none">Pose Fusion</a>
             <a href="observatory.html" class="nav-tab" style="text-decoration:none">Observatory</a>
@@ -498,6 +499,9 @@
 
         <!-- Sensing Tab -->
         <section id="sensing" class="tab-content" role="tabpanel" aria-labelledby="sensing" aria-hidden="true"></section>
+
+        <!-- Room Builder Tab -->
+        <section id="roombuilder" class="tab-content" role="tabpanel" aria-labelledby="roombuilder" aria-hidden="true"></section>
 
         <!-- Training Tab -->
         <section id="training" class="tab-content" role="tabpanel" aria-labelledby="training" aria-hidden="true">

--- a/ui/mesh3d.html
+++ b/ui/mesh3d.html
@@ -1,0 +1,546 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RF Distance Map</title>
+<!--
+  Orbitable 3D map of the mesh, laid out by RF distance rather than geometry.
+  No dependencies, so it works with the internet down — same as mark.html and
+  mesh.html.
+
+  Pipeline: RSSI -> distance (log-distance path loss) -> 3D positions
+  (gradient-descent MDS) -> projection you can orbit.
+
+  WHAT THIS IS NOT: architectural truth. Through walls and floors the signal
+  diffracts and bounces, so the path really is longer than the straight line
+  and every such link reads long. The reconstruction puffs up wherever
+  material intervenes.
+
+  WHAT IT IS: a map where distance means RF isolation. Two nodes in one room
+  sit close; two separated by a floor sit far apart *because the floor
+  attenuates*. Floors separate on their own without being told they exist,
+  and the gap between them measures what that floor costs. For sensing that
+  is the more useful quantity — RF coupling, not metres, is what decides
+  whether a link can see anything. It is also why the geometric link-line
+  model failed on this fleet: physical distance is not what matters.
+
+  The payoff is the comparison. Enter what you know to be physically true and
+  a link reading 80 ft across a 45 ft span is telling you something is in the
+  way — in feet, which is actionable, rather than dBm, which is not.
+
+  MDS by gradient descent rather than eigendecomposition: it needs no matrix
+  library, tolerates missing pairs (a link that cannot be heard is simply not
+  a constraint), and for N <= 16 converges in milliseconds.
+
+  At three nodes this is degenerate — three points always form a triangle, so
+  it fits perfectly and proves nothing. It starts testing itself at nine,
+  where 36 distances constrain 21 free parameters.
+-->
+<style>
+  :root{
+    --bg:#0d1117; --fg:#e6edf3; --dim:#8b949e; --line:#30363d; --card:#161b22;
+    --ok:#2ea043; --warn:#d29922; --bad:#f85149; --accent:#388bfd;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0; background:var(--bg); color:var(--fg);
+       font:13.5px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+       display:flex; flex-direction:column; height:100vh; overflow:hidden;}
+  header{padding:12px 16px 10px; border-bottom:1px solid var(--line); flex:0 0 auto;}
+  h1{font-size:15px; margin:0 0 2px;}
+  .sub{color:var(--dim); font-size:11.5px;}
+  .wrap{flex:1 1 auto; display:flex; min-height:0;}
+  #stage{flex:1 1 auto; position:relative; min-width:0;}
+  canvas{display:block; width:100%; height:100%; cursor:grab;}
+  canvas:active{cursor:grabbing;}
+  aside{flex:0 0 288px; border-left:1px solid var(--line); padding:14px;
+        overflow-y:auto; background:var(--card);}
+  @media (max-width:760px){ .wrap{flex-direction:column;} aside{flex:0 0 auto; border-left:none; border-top:1px solid var(--line);} }
+  h2{font-size:11px; letter-spacing:.1em; text-transform:uppercase;
+     color:var(--dim); margin:0 0 8px; font-weight:600;}
+  .grp{margin-bottom:18px;}
+  label{display:block; font-size:12px; color:var(--dim); margin:9px 0 3px;}
+  input[type=range]{width:100%;}
+  input[type=number]{width:100%; background:#0d1117; color:var(--fg);
+    border:1px solid var(--line); border-radius:5px; padding:5px 7px; font:inherit;}
+  .val{color:var(--fg); font-weight:600;}
+  table{width:100%; border-collapse:collapse; font-size:11.5px;}
+  td{padding:3px 4px; border-bottom:1px solid var(--line);}
+  td.n{text-align:right; font-variant-numeric:tabular-nums; white-space:nowrap;}
+  .hint{color:var(--dim); font-size:11px; margin-top:7px; line-height:1.45;}
+  button{font:inherit; font-size:12px; padding:6px 11px; border-radius:6px;
+    cursor:pointer; border:1px solid var(--line); background:#21262d; color:var(--fg);}
+  .err{color:var(--bad);}
+</style>
+</head>
+<body>
+
+<header>
+  <h1>RF Distance Map</h1>
+  <div class="sub">Laid out by signal isolation, not geometry. Drag to orbit, scroll to zoom.</div>
+  <div style="margin:8px 0 4px;">
+    <button id="vTop">Top &mdash; N up</button>
+    <button id="vNorth">Look north</button>
+    <button id="vWest">Look west</button>
+    <button id="vIso">Isometric</button>
+    <span class="sub" style="margin-left:10px;">presets match the floor plan: east is right, south is down</span>
+  </div>
+</header>
+
+<div class="wrap">
+  <div id="stage"><canvas id="cv"></canvas></div>
+  <aside>
+    <div class="grp">
+      <h2>Path loss</h2>
+      <label>reference power at 1 ft <span class="val" id="p0v"></span></label>
+      <input type="range" id="p0" min="-60" max="-20" step="1" value="-40">
+      <label>exponent <span class="val" id="nv"></span> <span class="sub">(2 = open air, 3&ndash;4 = walls)</span></label>
+      <input type="range" id="n" min="15" max="45" step="1" value="30">
+      <label>AP transmits harder by <span class="val" id="apv"></span></label>
+      <input type="range" id="apg" min="0" max="16" step="1" value="8">
+      <div class="hint">Calibrate: pick two nodes whose real separation you
+      know, then move the exponent until the map agrees. Everything else
+      follows.</div>
+    </div>
+
+    <div class="grp">
+      <h2>Known distance <span class="sub">(optional)</span></h2>
+      <label>between node <input type="number" id="ka" value="0" style="width:52px;display:inline-block"> and <input type="number" id="kb" value="1" style="width:52px;display:inline-block"></label>
+      <label>actually <input type="number" id="kd" placeholder="feet" style="width:80px;display:inline-block"> ft apart</label>
+      <button id="solve">Fit exponent to this</button>
+      <div class="hint" id="fitnote"></div>
+    </div>
+
+    <div class="grp">
+      <h2>Auto-calibrate</h2>
+      <button id="auto">Fit model to surveyed nodes</button>
+      <div class="hint" id="autonote">Least-squares over every link whose true
+      distance is known, solving reference power, exponent and AP gain at once.
+      Until it is run, part of the &ldquo;excess&rdquo; column is model error
+      rather than obstruction.</div>
+    </div>
+
+    <div class="grp">
+      <h2>Links &mdash; true vs RF</h2>
+      <table id="tbl"></table>
+    </div>
+    <div class="sub" id="stamp"></div>
+  </aside>
+</div>
+
+<script>
+// ---- state ---------------------------------------------------------------
+var links = [], ids = [], pos = {}, az = 0.6, el = 0.4, zoom = 1, drag = null;
+var truth = null;      // /api/v1/config/room, when a node's position is known
+var M2F = 3.28084;
+
+// Known positions win over inference.
+//
+// MDS exists to place nodes when we do not know where they are. For nodes we
+// DO know, inferring a position from RSSI and then comparing it to the answer
+// we already had is worse than useless -- it hides the measurement behind a
+// reconstruction. So a node with a surveyed position is drawn there, and the
+// RF estimate is spent on the thing we actually want: how much longer the
+// signal path is than the straight line.
+//
+// Unknown nodes still get MDS, anchored against the known ones -- which is
+// what a newly plugged-in board looks like before it has been surveyed.
+// Room space is x=east, y=south, z=up. The projector below treats y as the
+// VERTICAL screen axis and rotates azimuth in the x-z plane, so surveyed
+// positions have to be remapped or the building is drawn lying on its side --
+// north-south pointing at the ceiling, and no amount of orbiting can align it
+// to the real house. Swapping here rather than in project() keeps MDS output
+// (which has no meaningful orientation anyway) in the same convention.
+function toView(east, south, up){ return {x: east, y: up, z: south}; }
+
+function truthPos(id){
+  if (!truth) return null;
+  if (id === 'AP') {
+    var a = truth.ap_position;
+    return a ? toView(a[0]*M2F, a[1]*M2F, a[2]*M2F) : null;
+  }
+  var n = (truth.nodes || []).filter(function(x){ return String(x.id) === String(id); })[0];
+  return n ? toView(n.x*M2F, n.y*M2F, n.z*M2F) : null;
+}
+function trueFeet(a, b){
+  var A = truthPos(a), B = truthPos(b);
+  if (!A || !B) return null;
+  return Math.sqrt(Math.pow(A.x-B.x,2) + Math.pow(A.y-B.y,2) + Math.pow(A.z-B.z,2));
+}
+var P0 = -40, PLE = 3.0;   // dBm at 1 ft for a NODE transmitter
+var AP_GAIN = 8;           // dB the AP transmits harder than a node
+
+// Separate reference power per transmitter class.
+//
+// d = d0 * 10^((P0 - RSSI) / (10 * n)) assumes a fixed transmit power, so one
+// P0 across mixed transmitters is a real error: an AP with more output and a
+// better antenna reads stronger at the same distance, and a single P0 would
+// place it too close. The AP's stronger link is still the *better* measurement
+// — higher SNR means a steadier RSSI — but only once its extra output is
+// accounted for rather than mistaken for proximity.
+function rssiToFeet(dbm, isAp){
+  var ref = isAp ? (P0 + AP_GAIN) : P0;
+  return Math.pow(10, (ref - dbm) / (10 * PLE));
+}
+
+// ---- MDS by gradient descent --------------------------------------------
+// Positions are pushed toward satisfying every observed distance. Missing
+// pairs contribute nothing rather than being guessed at.
+function layout(pairs, idlist){
+  var p = {};
+  idlist.forEach(function(id, i){
+    // Deterministic spread, so the map does not jump on every refresh.
+    var a = i * 2.399, r = 20 + i * 3;
+    p[id] = {x: Math.cos(a) * r, y: Math.sin(a) * r, z: ((i % 3) - 1) * 12};
+  });
+  for (var it = 0; it < 600; it++){
+    var lr = 0.10 * (1 - it / 600);
+    pairs.forEach(function(pr){
+      var A = p[pr.a], B = p[pr.b];
+      var dx = B.x - A.x, dy = B.y - A.y, dz = B.z - A.z;
+      var d = Math.sqrt(dx*dx + dy*dy + dz*dz) || 1e-6;
+      var err = (d - pr.d) / d * lr * 0.5;
+      A.x += dx * err; A.y += dy * err; A.z += dz * err;
+      B.x -= dx * err; B.y -= dy * err; B.z -= dz * err;
+    });
+  }
+  // Centre it so orbiting feels natural.
+  var c = {x:0,y:0,z:0}, k = idlist.length || 1;
+  idlist.forEach(function(id){ c.x+=p[id].x; c.y+=p[id].y; c.z+=p[id].z; });
+  idlist.forEach(function(id){ p[id].x-=c.x/k; p[id].y-=c.y/k; p[id].z-=c.z/k; });
+  return p;
+}
+
+function residual(pairs, p){
+  var s = 0, n = 0;
+  pairs.forEach(function(pr){
+    var A=p[pr.a], B=p[pr.b];
+    var d = Math.sqrt(Math.pow(B.x-A.x,2)+Math.pow(B.y-A.y,2)+Math.pow(B.z-A.z,2));
+    s += Math.abs(d - pr.d) / pr.d; n++;
+  });
+  return n ? s / n : 0;
+}
+
+// ---- render --------------------------------------------------------------
+var cv = document.getElementById('cv'), ctx = cv.getContext('2d');
+
+function project(pt, w, h){
+  var ca=Math.cos(az), sa=Math.sin(az), ce=Math.cos(el), se=Math.sin(el);
+  var x = pt.x*ca - pt.z*sa;
+  var z = pt.x*sa + pt.z*ca;
+  var y = pt.y*ce - z*se;
+  var depth = pt.y*se + z*ce;
+  var s = zoom * Math.min(w,h) / 140;
+  return {x: w/2 + x*s, y: h/2 - y*s, d: depth};
+}
+
+function draw(){
+  var w = cv.clientWidth, h = cv.clientHeight;
+  if (cv.width !== w || cv.height !== h){ cv.width = w; cv.height = h; }
+  ctx.clearRect(0,0,w,h);
+  if (!ids.length){
+    ctx.fillStyle = '#8b949e'; ctx.font = '13px ui-monospace';
+    ctx.fillText('waiting for links…', 18, 26); return;
+  }
+
+  var pairs = buildPairs();
+  // Edges first, far ones dimmer.
+  pairs.forEach(function(pr){
+    var A = project(pos[pr.a], w, h), B = project(pos[pr.b], w, h);
+    var bad;
+    if (pr.ratio !== null) {
+      // Excess over the straight line is the diagnostic: 1.0x is clear air,
+      // anything well above it is something in the way.
+      bad = pr.ratio > 1.8 ? 2 : (pr.ratio > 1.25 ? 1 : 0);
+    } else {
+      bad = pr.d > 40 ? 2 : (pr.d > 20 ? 1 : 0);
+    }
+    ctx.strokeStyle = bad === 2 ? 'rgba(248,81,73,.6)'
+                    : bad === 1 ? 'rgba(210,153,34,.6)' : 'rgba(46,160,67,.65)';
+    ctx.lineWidth = bad === 2 ? 2.4 : 1.6;
+    ctx.beginPath(); ctx.moveTo(A.x,A.y); ctx.lineTo(B.x,B.y); ctx.stroke();
+    var mx=(A.x+B.x)/2, my=(A.y+B.y)/2;
+    ctx.fillStyle = bad ? '#e6edf3' : '#8b949e'; ctx.font = '10px ui-monospace';
+    ctx.fillText(pr.truth !== null
+      ? pr.truth.toFixed(0) + ' ft → ' + pr.d.toFixed(0)
+      : pr.d.toFixed(0) + ' ft', mx + 3, my - 3);
+  });
+
+  ids.map(function(id){ return {id:id, p:project(pos[id], w, h)}; })
+     .sort(function(a,b){ return a.p.d - b.p.d; })
+     .forEach(function(o){
+       var r = 9 + o.p.d * 0.02;
+       ctx.beginPath(); ctx.arc(o.p.x, o.p.y, Math.max(5,r), 0, Math.PI*2);
+       ctx.fillStyle = o.id === 'AP' ? '#388bfd' : '#e6edf3';
+       ctx.fill();
+       ctx.fillStyle = '#0d1117'; ctx.font = 'bold 10px ui-monospace';
+       ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+       ctx.fillText(o.id === 'AP' ? 'AP' : o.id, o.p.x, o.p.y);
+       ctx.textAlign = 'start'; ctx.textBaseline = 'alphabetic';
+     });
+}
+
+function buildPairs(){
+  var best = {};
+  links.forEach(function(l){
+    var tx = (l.tx_node_inferred === null || l.tx_node_inferred === undefined)
+             ? 'AP' : String(l.tx_node_inferred);
+    var rx = String(l.rx_node);
+    if (tx === rx) return;
+    var k = [rx,tx].sort().join('|');
+    // Average the two directions where both exist — propagation is reciprocal,
+    // so disagreement is noise and the mean is the better estimate.
+    if (!best[k]) best[k] = {a:k.split('|')[0], b:k.split('|')[1], v:[]};
+    best[k].v.push(l.rssi_dbm);
+  });
+  return Object.keys(best).map(function(k){
+    var e = best[k];
+    var mean = e.v.reduce(function(s,x){return s+x;},0) / e.v.length;
+    var isAp = (e.a === 'AP' || e.b === 'AP');
+    var rf = rssiToFeet(mean, isAp), tf = trueFeet(e.a, e.b);
+    return {a:e.a, b:e.b, d:rf, rssi:mean, ap:isAp,
+            truth:tf, excess:(tf ? rf - tf : null), ratio:(tf ? rf / tf : null)};
+  });
+}
+
+function recompute(){
+  var pairs = buildPairs();
+  var set = {};
+  pairs.forEach(function(p){ set[p.a]=1; set[p.b]=1; });
+  ids = Object.keys(set).sort();
+  // Solve only for nodes without a surveyed position; pin the rest.
+  pos = layout(pairs, ids);
+  var anchored = 0;
+  ids.forEach(function(id){
+    var t = truthPos(id);
+    if (t) { pos[id] = {x:t.x, y:t.y, z:t.z}; anchored++; }
+  });
+  if (anchored) {
+    // Re-run with anchors held fixed so unsurveyed nodes settle around them.
+    for (var it = 0; it < 400; it++){
+      var lr = 0.08 * (1 - it/400);
+      pairs.forEach(function(pr){
+        var A = pos[pr.a], B = pos[pr.b];
+        var fa = !truthPos(pr.a), fb = !truthPos(pr.b);
+        if (!fa && !fb) return;
+        var dx=B.x-A.x, dy=B.y-A.y, dz=B.z-A.z;
+        var d = Math.sqrt(dx*dx+dy*dy+dz*dz) || 1e-6;
+        var err = (d - pr.d)/d * lr * 0.5;
+        if (fa){ A.x += dx*err; A.y += dy*err; A.z += dz*err; }
+        if (fb){ B.x -= dx*err; B.y -= dy*err; B.z -= dz*err; }
+      });
+    }
+  }
+
+  // Re-centre on the whole layout.
+  //
+  // layout() centres the MDS cloud, but anchoring then overwrites nodes with
+  // RAW room coordinates, which run 0..44 ft from the north-west corner. Since
+  // project() rotates about the origin, the building ended up orbiting a point
+  // at its own corner -- outside the house -- which reads as "it picks an
+  // anchor and pivots around that". Once every node is surveyed, every node is
+  // overwritten, so the centring done inside layout() is entirely discarded.
+  var cc = {x:0, y:0, z:0}, ck = ids.length || 1;
+  ids.forEach(function(id){ cc.x += pos[id].x; cc.y += pos[id].y; cc.z += pos[id].z; });
+  ids.forEach(function(id){
+    pos[id].x -= cc.x/ck; pos[id].y -= cc.y/ck; pos[id].z -= cc.z/ck;
+  });
+
+  var rows = '<tr><td>pair</td><td class="n">true</td><td class="n">rf</td><td class="n">excess</td></tr>';
+  pairs.sort(function(a,b){
+    return (b.ratio || 0) - (a.ratio || 0);
+  }).forEach(function(p){
+    var col = p.ratio === null ? '#8b949e'
+            : p.ratio > 1.8 ? '#f85149' : p.ratio > 1.25 ? '#d29922' : '#2ea043';
+    rows += '<tr><td>' + p.a + ' &harr; ' + p.b + '</td>' +
+            '<td class="n">' + (p.truth === null ? '&mdash;' : p.truth.toFixed(0)) + '</td>' +
+            '<td class="n">' + p.d.toFixed(0) + '</td>' +
+            '<td class="n" style="color:' + col + '">' +
+            (p.excess === null ? '&mdash;'
+              : (p.excess > 0 ? '+' : '') + p.excess.toFixed(0) + ' ft') + '</td></tr>';
+  });
+  document.getElementById('tbl').innerHTML = rows;
+  document.getElementById('stamp').textContent =
+    ids.length + ' nodes · ' + pairs.length + ' links · fit residual ' +
+    (residual(pairs, pos)*100).toFixed(1) + '%' +
+    (truth ? ' · ' + ids.filter(function(i){return !!truthPos(i);}).length + ' surveyed' : '') +
+    (ids.length <= 3 ? ' — degenerate below 4 nodes' : '');
+  draw();
+}
+
+// ---- controls ------------------------------------------------------------
+function syncLabels(){
+  document.getElementById('p0v').textContent = P0 + ' dBm';
+  document.getElementById('nv').textContent = PLE.toFixed(1);
+  document.getElementById('apv').textContent = AP_GAIN + ' dB';
+}
+document.getElementById('p0').oninput = function(){
+  P0 = +this.value; syncLabels(); recompute();
+};
+document.getElementById('n').oninput = function(){
+  PLE = +this.value / 10; syncLabels(); recompute();
+};
+document.getElementById('apg').oninput = function(){
+  AP_GAIN = +this.value; syncLabels(); recompute();
+};
+document.getElementById('solve').onclick = function(){
+  var a = document.getElementById('ka').value.trim();
+  var b = document.getElementById('kb').value.trim();
+  var want = parseFloat(document.getElementById('kd').value);
+  var note = document.getElementById('fitnote');
+  if (!(want > 0)) { note.innerHTML = '<span class="err">enter a distance in feet</span>'; return; }
+  var pr = buildPairs().filter(function(p){
+    return (p.a===a&&p.b===b) || (p.a===b&&p.b===a); })[0];
+  if (!pr) { note.innerHTML = '<span class="err">no link between those two</span>'; return; }
+  // Solve n directly: want = 10^((P0 - rssi)/(10n))  ->  n = (P0-rssi)/(10*log10(want))
+  var lg = Math.log(want) / Math.LN10;
+  if (Math.abs(lg) < 1e-6) { note.innerHTML = '<span class="err">pick a pair not 1 ft apart</span>'; return; }
+  var ref = pr.ap ? (P0 + AP_GAIN) : P0;
+  var n = (ref - pr.rssi) / (10 * lg);
+  if (!(n > 1.5 && n < 4.5)) {
+    note.innerHTML = '<span class="err">that implies exponent ' + n.toFixed(2) +
+      ', outside the physical 1.5&ndash;4.5 range. Check the node numbers or the distance.</span>';
+    return;
+  }
+  PLE = n; document.getElementById('n').value = Math.round(n*10);
+  syncLabels(); recompute();
+  note.textContent = 'exponent set to ' + n.toFixed(2) +
+    ' — every other distance is now scaled against that pair.';
+};
+
+// Path loss is linear in log-distance:  RSSI = P0 + G*isAP - (10n)*log10(d)
+// so the three parameters fall out of an ordinary least-squares fit over the
+// surveyed links. Worth doing before reading the excess column: an uncalibrated
+// model contributes its own error there, which is indistinguishable by eye from
+// something physically in the way.
+document.getElementById('auto').onclick = function(){
+  var note = document.getElementById('autonote');
+  var all = buildPairs().filter(function(p){ return p.truth !== null && p.truth > 0.5; });
+  if (all.length < 4) {
+    note.innerHTML = '<span class="err">need at least 4 surveyed links, have ' +
+                     all.length + '</span>';
+    return;
+  }
+
+  function fit(set){
+    var A=[[0,0,0],[0,0,0],[0,0,0]], y=[0,0,0];
+    set.forEach(function(p){
+      var r=[1, p.ap?1:0, -Math.log(p.truth)/Math.LN10];
+      for (var i=0;i<3;i++){
+        for (var j=0;j<3;j++) A[i][j]+=r[i]*r[j];
+        y[i]+=r[i]*p.rssi;
+      }
+    });
+    var M=[[A[0][0],A[0][1],A[0][2],y[0]],
+           [A[1][0],A[1][1],A[1][2],y[1]],
+           [A[2][0],A[2][1],A[2][2],y[2]]];
+    for (var c=0;c<3;c++){
+      var piv=c;
+      for (var r2=c+1;r2<3;r2++) if (Math.abs(M[r2][c])>Math.abs(M[piv][c])) piv=r2;
+      if (Math.abs(M[piv][c])<1e-12) return null;
+      var t=M[c]; M[c]=M[piv]; M[piv]=t;
+      for (var r3=0;r3<3;r3++){
+        if (r3===c) continue;
+        var f=M[r3][c]/M[c][c];
+        for (var k=c;k<4;k++) M[r3][k]-=f*M[c][k];
+      }
+    }
+    return {p0:M[0][3]/M[0][0], g:M[1][3]/M[1][1], n:(M[2][3]/M[2][2])/10};
+  }
+
+  // Robust fit: an obstructed link is an outlier in dB, and a single blocked
+  // link can invert the slope entirely — the cage-shadowed pair here is both
+  // the closest and the weakest, which a plain least-squares reads as "closer
+  // is weaker". So fit, drop the worst offender, refit, and keep going while
+  // the model is unphysical or the residual is dominated by one point.
+  //
+  // The excluded links are not a nuisance: they are the obstructed ones, and
+  // naming them is the actual output.
+  var set = all.slice(), dropped = [], f = null;
+  while (set.length >= 4) {
+    f = fit(set);
+    if (f) {
+      var resid = set.map(function(p){
+        var pred = f.p0 + (p.ap?f.g:0) - 10*f.n*Math.log(p.truth)/Math.LN10;
+        return {p:p, e:Math.abs(pred - p.rssi)};
+      });
+      var worst = resid.reduce(function(a,b){ return a.e>b.e ? a : b; });
+      var ok = (f.n>1.2 && f.n<5 && f.g>-6 && f.g<25);
+      if (ok && worst.e < 8) break;              // physical, and no wild outlier
+      if (set.length === 4) break;
+      dropped.push({pair:worst.p, dB:worst.e});
+      set = set.filter(function(p){ return p !== worst.p; });
+      continue;
+    }
+    break;
+  }
+
+  if (!f || !(f.n>1.2 && f.n<5) || !(f.g>-6 && f.g<25)) {
+    note.innerHTML = '<span class="err">no physical fit even after excluding ' +
+      dropped.length + ' link(s). Check the surveyed positions.</span>';
+    return;
+  }
+
+  P0 = Math.round(f.p0); PLE = f.n; AP_GAIN = Math.round(f.g);
+  document.getElementById('p0').value = P0;
+  document.getElementById('n').value = Math.round(f.n*10);
+  document.getElementById('apg').value = AP_GAIN;
+  syncLabels(); recompute();
+
+  var msg = 'fitted on ' + set.length + ' clear link(s): exponent ' +
+            f.n.toFixed(2) + ', AP gain ' + AP_GAIN + ' dB.';
+  if (dropped.length) {
+    msg += '<br><b>Excluded as obstructed:</b> ' + dropped.map(function(d){
+      return d.pair.a + '&harr;' + d.pair.b + ' (' + d.dB.toFixed(0) + ' dB off)';
+    }).join(', ') + '. Those are the blocked paths &mdash; the model is now ' +
+    'calibrated on the clear ones, so the excess column reads the room.';
+  }
+  note.innerHTML = msg;
+};
+
+// Fixed viewpoints. Orbiting from an arbitrary angle to a recognisable one is
+// fiddly, and the whole point of the surveyed layout is that it CAN be matched
+// to the real building -- so give it known orientations to snap to.
+function setView(a, e2){ az = a; el = e2; zoom = 1; draw(); }
+document.getElementById('vTop').onclick   = function(){ setView(0, 1.4); };
+document.getElementById('vNorth').onclick = function(){ setView(0, 0.12); };
+document.getElementById('vWest').onclick  = function(){ setView(Math.PI/2, 0.12); };
+document.getElementById('vIso').onclick   = function(){ setView(0.6, 0.4); };
+
+cv.addEventListener('mousedown', function(e){ drag = {x:e.clientX, y:e.clientY}; });
+window.addEventListener('mouseup', function(){ drag = null; });
+window.addEventListener('mousemove', function(e){
+  if (!drag) return;
+  az += (e.clientX - drag.x) * 0.01;
+  el += (e.clientY - drag.y) * 0.01;
+  el = Math.max(-1.4, Math.min(1.4, el));
+  drag = {x:e.clientX, y:e.clientY};
+  draw();
+});
+cv.addEventListener('wheel', function(e){
+  e.preventDefault();
+  zoom *= e.deltaY > 0 ? 0.92 : 1.08;
+  zoom = Math.max(0.2, Math.min(6, zoom));
+  draw();
+}, {passive:false});
+window.addEventListener('resize', draw);
+
+function load(){
+  fetch('/api/v1/config/room', {cache:'no-store'})
+    .then(function(r){ return r.json(); })
+    .then(function(c){ if (c && c.nodes) truth = c; })
+    .catch(function(){ /* unsurveyed is a valid state — fall back to pure MDS */ })
+    .then(loadLinks);
+}
+function loadLinks(){
+  fetch('/api/v1/links', {cache:'no-store'})
+    .then(function(r){ return r.json(); })
+    .then(function(d){ links = d.links || []; recompute(); })
+    .catch(function(){
+      document.getElementById('stamp').innerHTML = '<span class="err">server unreachable</span>';
+    });
+}
+syncLabels(); load(); setInterval(load, 5000);
+</script>
+</body>
+</html>

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1449,9 +1449,78 @@ pub(crate) struct RoomNode {
     pub id: u8,
     pub x: f32,
     pub y: f32,
+    /// Height above the FIRST floor's surface, not above this node's own
+    /// floor. A node on the second storey at 1.2 m sits at z = elevation of
+    /// that floor + 1.2, so z stays a single global axis and distances between
+    /// nodes on different floors are just Euclidean.
     pub z: f32,
+    /// Which storey this node is on. `None` means the first floor, so configs
+    /// written before floors existed keep working unchanged.
+    ///
+    /// Redundant with `z` for geometry, and deliberately so: it is what the
+    /// Room Builder groups by and what walls are associated with. Deriving it
+    /// from `z` would guess wrong for a node mounted high on a stairwell.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub floor: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+}
+
+/// One storey of the building.
+///
+/// `level` is the storey number, 1 for the ground floor. `elevation_m` is the
+/// height of that storey's *floor surface* above the origin, so level 1 is
+/// 0.0 by definition and level 2 is roughly first-floor ceiling plus joist
+/// depth.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Floor {
+    pub level: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub elevation_m: f32,
+    /// Ceiling height above this storey's own floor surface (not above the
+    /// origin), because that is the number a person reads off a tape measure.
+    pub ceiling_m: f32,
+    /// Thickness of the structure between this storey's ceiling and the next
+    /// storey's floor surface: joists, subfloor, and any service void.
+    ///
+    /// Recorded so `elevation_m` can be DERIVED rather than measured. Nobody
+    /// can put a tape measure on the height of a second floor above a first
+    /// floor, but everyone can measure a ceiling and look up a joist depth.
+    /// Without it, siting a node meant arithmetic like "8 ft + 16 in + 20 in"
+    /// at every measurement, and arithmetic done nine times is arithmetic done
+    /// wrong at least once.
+    #[serde(default)]
+    pub subfloor_m: f32,
+}
+
+/// An interior or exterior wall segment, in plan view.
+///
+/// Walls are 2D segments plus a height rather than 3D solids: for RF purposes
+/// what matters is whether the straight line between two nodes crosses one,
+/// and a segment answers that with a cheap intersection test. Modelling
+/// thickness or openings would add cost to every link evaluation for accuracy
+/// the rest of the pipeline cannot yet use.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Wall {
+    /// Storey this wall belongs to. A wall only obstructs links whose
+    /// endpoints are on that storey; a floor slab is a different thing and is
+    /// implied by two nodes having different `floor` values.
+    pub level: i32,
+    pub x1: f32,
+    pub y1: f32,
+    pub x2: f32,
+    pub y2: f32,
+    /// Height above this storey's floor. Defaults to full height when absent —
+    /// a half-wall or a pony wall is the exception, not the rule.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height_m: Option<f32>,
+    /// Free text: "exterior", "interior", "glass", "brick". Not interpreted
+    /// yet. Recorded now because it is knowledge the person drawing the plan
+    /// has and will not have later, and attenuation per material is the
+    /// obvious next use of this data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
 }
 
 /// Room geometry (a simple rectangle) plus sensor node placements, as
@@ -1461,6 +1530,42 @@ pub(crate) struct RoomConfig {
     pub width_m: f32,
     pub depth_m: f32,
     pub nodes: Vec<RoomNode>,
+    /// The WiFi access point's position, same room-space meters/NW-origin
+    /// convention as `nodes`. Optional — `None` means not yet configured, not
+    /// "AP is at the origin". Needed for bistatic Doppler-geometry position
+    /// estimation (a link's Doppler shift decomposes into a 2D velocity
+    /// constraint only once both endpoints — AP and node — are known; see
+    /// `doppler_weighted_centroid`'s doc comment for why raw per-node Doppler
+    /// magnitude alone isn't full geometric triangulation). Deliberately a
+    /// single point, not a list: real position estimation needs one known,
+    /// fixed link endpoint per node, and supporting multiple candidate APs
+    /// would require knowing which AP each CSI frame's traffic actually came
+    /// from, which isn't tracked anywhere today. A house with more rooms is
+    /// future scope; this stays "one room, one AP, up to a few nodes."
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ap_position: Option<[f32; 3]>,
+    /// Storeys, ascending. Empty means a single implicit ground floor, which
+    /// is how every config written before this field existed behaves.
+    ///
+    /// ORIGIN: (0, 0, 0) is the north-west corner of the FIRST floor, at floor
+    /// level. x runs east, y runs south, z runs up. Every storey shares that
+    /// origin — the second floor is not re-zeroed — so a node's coordinates
+    /// mean the same thing regardless of which storey it is on, and a
+    /// through-floor distance is just Euclidean.
+    #[serde(default)]
+    pub floors: Vec<Floor>,
+    /// Wall segments in plan view, tagged by storey.
+    #[serde(default)]
+    pub walls: Vec<Wall>,
+    /// Which storey the access point is on. `None` means the first floor.
+    ///
+    /// `ap_position` already carries an absolute z, so this is not needed for
+    /// geometry. It exists so the Room Builder can show the AP's height the
+    /// way it was measured -- above its own floor -- rather than as a total
+    /// from the ground floor, and so the AP appears on the storey it is
+    /// actually on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ap_floor: Option<i32>,
 }
 
 /// Load persisted room config from `<data_dir>/room_config.json`.
@@ -1490,6 +1595,181 @@ pub(crate) fn save_room_config(data_dir: &std::path::Path, config: &RoomConfig) 
 mod room_config_tests {
     use super::*;
 
+    fn base() -> RoomConfig {
+        RoomConfig {
+            width_m: 13.4,
+            depth_m: 10.4,
+            nodes: Vec::new(),
+            ap_position: None,
+            ap_floor: None,
+            floors: Vec::new(),
+            walls: Vec::new(),
+        }
+    }
+
+    fn floor(level: i32, elevation_m: f32) -> Floor {
+        Floor { level, name: None, elevation_m, ceiling_m: 2.7, subfloor_m: 0.3 }
+    }
+
+    /// The whole coordinate system hangs off this. If floor 1 is allowed to
+    /// float, every node coordinate in the building is silently offset and
+    /// nothing downstream can detect it.
+    #[test]
+    fn first_floor_must_sit_at_the_origin() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.3)];
+        let err = validate_room_config(&c).unwrap_err();
+        assert!(err.contains("floor 1"), "{err}");
+
+        c.floors = vec![floor(1, 0.0)];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    /// A second storey below the first is a typo every time, and it would
+    /// invert every through-floor distance without erroring anywhere.
+    #[test]
+    fn storeys_must_ascend() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0), floor(2, -2.9)];
+        let err = validate_room_config(&c).unwrap_err();
+        assert!(err.contains("floor 2"), "{err}");
+
+        c.floors = vec![floor(1, 0.0), floor(2, 2.9)];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    #[test]
+    fn duplicate_floor_levels_are_rejected() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0), floor(1, 2.9)];
+        assert!(validate_room_config(&c).unwrap_err().contains("duplicate floor"));
+    }
+
+    #[test]
+    fn a_node_cannot_live_on_a_storey_that_does_not_exist() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0)];
+        c.nodes = vec![RoomNode {
+            id: 3, x: 1.0, y: 1.0, z: 3.5, floor: Some(2), label: None,
+        }];
+        assert!(validate_room_config(&c).unwrap_err().contains("undefined floor"));
+    }
+
+    /// Configs written before floors existed must keep loading and validating
+    /// unchanged — the fleet's own room_config.json is one of them.
+    #[test]
+    fn pre_floors_configs_remain_valid() {
+        let mut c = base();
+        c.nodes = vec![RoomNode {
+            id: 0, x: 1.2, y: 0.0, z: 0.56, floor: None, label: Some("front right".into()),
+        }];
+        assert!(c.floors.is_empty());
+        assert!(validate_room_config(&c).is_ok(), "no floors declared is still a valid room");
+    }
+
+    /// Zero-length walls make any segment-intersection test degenerate rather
+    /// than merely wrong, so they are rejected at the door.
+    #[test]
+    fn negative_subfloor_is_rejected() {
+        let mut c = base();
+        let mut f = floor(2, 3.0);
+        f.subfloor_m = -0.1;
+        c.floors = vec![floor(1, 0.0), f];
+        assert!(validate_room_config(&c).unwrap_err().contains("subfloor_m"));
+    }
+
+    /// A flat slab between storeys is legitimate (a concrete floor), so zero
+    /// must be allowed even though negative is not.
+    #[test]
+    fn zero_subfloor_is_allowed() {
+        let mut c = base();
+        let mut f = floor(2, 3.0);
+        f.subfloor_m = 0.0;
+        c.floors = vec![floor(1, 0.0), f];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    #[test]
+    fn ap_cannot_be_on_an_undeclared_floor() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0)];
+        c.ap_position = Some([2.0, 2.0, 2.2]);
+        c.ap_floor = Some(3);
+        assert!(validate_room_config(&c).unwrap_err().contains("ap_floor"));
+        c.ap_floor = Some(1);
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    /// Elevations are derived in the UI from ceiling + subfloor, so the
+    /// arithmetic that produces them has to survive a round trip intact --
+    /// otherwise every height on the upper storey silently shifts.
+    #[test]
+    fn ceiling_and_subfloor_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = base();
+        let mut f1 = floor(1, 0.0);
+        f1.ceiling_m = 2.44;   // 8 ft
+        f1.subfloor_m = 0.41;  // 16 in
+        let mut f2 = floor(2, 2.85);
+        f2.ceiling_m = 2.44;
+        f2.subfloor_m = 0.0;
+        c.floors = vec![f1, f2];
+        save_room_config(dir.path(), &c);
+        let loaded = load_room_config(dir.path());
+        assert!((loaded.floors[0].ceiling_m - 2.44).abs() < 1e-6);
+        assert!((loaded.floors[0].subfloor_m - 0.41).abs() < 1e-6);
+        // floor 2 sits at floor 1's ceiling plus its structure
+        let derived = loaded.floors[0].ceiling_m + loaded.floors[0].subfloor_m;
+        assert!((loaded.floors[1].elevation_m - derived).abs() < 1e-6,
+                "elevation must equal ceiling + subfloor of the storey below");
+    }
+
+    #[test]
+    fn zero_length_walls_are_rejected() {
+        let mut c = base();
+        c.walls = vec![Wall {
+            level: 1, x1: 2.0, y1: 2.0, x2: 2.0, y2: 2.0,
+            height_m: None, kind: None,
+        }];
+        assert!(validate_room_config(&c).unwrap_err().contains("zero length"));
+    }
+
+    #[test]
+    fn walls_round_trip_with_their_storey_and_kind() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0), floor(2, 2.9)];
+        c.walls = vec![
+            Wall { level: 1, x1: 0.0, y1: 0.0, x2: 5.0, y2: 0.0,
+                   height_m: None, kind: Some("exterior".into()) },
+            Wall { level: 2, x1: 0.0, y1: 3.0, x2: 4.0, y2: 3.0,
+                   height_m: Some(1.1), kind: Some("pony".into()) },
+        ];
+        save_room_config(dir.path(), &c);
+        let loaded = load_room_config(dir.path());
+        assert_eq!(loaded.walls.len(), 2);
+        assert_eq!(loaded.walls[1].level, 2, "storey survives the round trip");
+        assert_eq!(loaded.walls[1].height_m, Some(1.1));
+        assert_eq!(loaded.walls[0].kind.as_deref(), Some("exterior"));
+        assert_eq!(loaded.floors[1].elevation_m, 2.9);
+    }
+
+    #[test]
+    fn node_storey_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0), floor(2, 2.9)];
+        c.nodes = vec![RoomNode {
+            id: 7, x: 2.0, y: 3.0, z: 4.1, floor: Some(2), label: Some("landing".into()),
+        }];
+        save_room_config(dir.path(), &c);
+        let loaded = load_room_config(dir.path());
+        assert_eq!(loaded.nodes[0].floor, Some(2));
+        // z stays a single global axis: a second-floor node is above the
+        // storey's own elevation, not re-zeroed to it.
+        assert!(loaded.nodes[0].z > loaded.floors[1].elevation_m);
+    }
+
     #[test]
     fn load_missing_file_returns_default() {
         let dir = tempfile::tempdir().unwrap();
@@ -1515,9 +1795,13 @@ mod room_config_tests {
             width_m: 5.0,
             depth_m: 4.0,
             nodes: vec![
-                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, label: Some("front-right".into()) },
-                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, label: None },
+                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, floor: None, label: Some("front-right".into()) },
+                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, floor: None, label: None },
             ],
+            ap_position: Some([2.5, -1.0, 2.2]),
+            ap_floor: None,
+        floors: Vec::new(),
+        walls: Vec::new(),
         };
         save_room_config(dir.path(), &saved);
         let loaded = load_room_config(dir.path());
@@ -1534,9 +1818,13 @@ mod room_config_tests {
             width_m: 5.0,
             depth_m: 4.0,
             nodes: vec![
-                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, label: None },
-                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, label: None },
+                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, floor: None, label: None },
+                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, floor: None, label: None },
             ],
+            ap_position: None,
+            ap_floor: None,
+        floors: Vec::new(),
+        walls: Vec::new(),
         }
     }
 
@@ -10104,16 +10392,19 @@ async fn config_get_room(State(state): State<SharedState>) -> Json<serde_json::V
         .node_positions_config
         .iter()
         .map(|(&id, p)| {
-            let label = saved
-                .nodes
-                .iter()
-                .find(|n| n.id == id)
-                .and_then(|n| n.label.clone());
+            let saved_node = saved.nodes.iter().find(|n| n.id == id);
+            let label = saved_node.and_then(|n| n.label.clone());
+            // Storey is carried on the persisted config, not on the live
+            // position map, so it has to be looked up rather than derived --
+            // deriving it from z would guess wrong for a node mounted high on
+            // a stairwell.
+            let floor = saved_node.and_then(|n| n.floor);
             RoomNode {
                 id,
                 x: p[0],
                 y: p[1],
                 z: p[2],
+                floor,
                 label,
             }
         })
@@ -10122,6 +10413,21 @@ async fn config_get_room(State(state): State<SharedState>) -> Json<serde_json::V
         "width_m": saved.width_m,
         "depth_m": saved.depth_m,
         "nodes": nodes,
+        // Storeys, walls, and the AP's position and storey are pure geometry
+        // with no live counterpart in memory, so they are served straight from
+        // the persisted config.
+        //
+        // These were being saved correctly and never served, which looked
+        // exactly like "the setting will not stick": the round trip lost them
+        // on the way OUT, so the editor reopened with its defaults and an AP
+        // height was then shown as if measured from the ground floor.
+        //
+        // Any field added to RoomConfig has to be added here too -- this list
+        // is hand-maintained and will not complain when it falls behind.
+        "ap_position": saved.ap_position,
+        "floors": saved.floors,
+        "walls": saved.walls,
+        "ap_floor": saved.ap_floor,
     }))
 }
 
@@ -10150,6 +10456,102 @@ pub(crate) fn validate_room_config(config: &RoomConfig) -> Result<(), String> {
             return Err(format!("node {} has a non-finite coordinate", n.id));
         }
     }
+    if let Some([x, y, z]) = config.ap_position {
+        if !x.is_finite() || !y.is_finite() || !z.is_finite() {
+            return Err("ap_position has a non-finite coordinate".to_string());
+        }
+        // Deliberately no room-bounds check here (unlike nothing else checks
+        // node bounds either, but worth stating): a real AP is very often
+        // physically outside the sensed room (another floor, a hallway
+        // closet), and that's fine — ap_position only needs to be a real,
+        // finite point in the same coordinate frame, not inside width_m/depth_m.
+    }
+
+    // ── Storeys ──────────────────────────────────────────────────────────
+    let mut levels = std::collections::HashSet::new();
+    for f in &config.floors {
+        if !levels.insert(f.level) {
+            return Err(format!("duplicate floor level {}", f.level));
+        }
+        if !f.elevation_m.is_finite() || !f.ceiling_m.is_finite() {
+            return Err(format!("floor {} has a non-finite height", f.level));
+        }
+        if f.ceiling_m <= 0.0 {
+            return Err(format!("floor {} ceiling_m must be positive", f.level));
+        }
+        if !f.subfloor_m.is_finite() || f.subfloor_m < 0.0 {
+            return Err(format!(
+                "floor {} subfloor_m must be zero or positive",
+                f.level
+            ));
+        }
+        // Level 1 defines the origin, so it cannot float. Catching this here
+        // stops a plan whose every coordinate is silently offset.
+        if f.level == 1 && f.elevation_m != 0.0 {
+            return Err(
+                "floor 1 must have elevation_m = 0: the origin is the \
+                 north-west corner of the first floor, at floor level"
+                    .to_string(),
+            );
+        }
+    }
+    // Ascending storeys must ascend. A second floor below a first is a typo
+    // every time, and it would silently invert every through-floor distance.
+    let mut sorted: Vec<&Floor> = config.floors.iter().collect();
+    sorted.sort_by_key(|f| f.level);
+    for w in sorted.windows(2) {
+        if w[1].elevation_m <= w[0].elevation_m {
+            return Err(format!(
+                "floor {} is at or below floor {} ({} m vs {} m)",
+                w[1].level, w[0].level, w[1].elevation_m, w[0].elevation_m
+            ));
+        }
+    }
+
+    // A node may only sit on a storey that exists — but only once storeys are
+    // being used at all, so pre-floors configs stay valid.
+    if !config.floors.is_empty() {
+        for n in &config.nodes {
+            let lvl = n.floor.unwrap_or(1);
+            if !levels.contains(&lvl) {
+                return Err(format!("node {} is on undefined floor {}", n.id, lvl));
+            }
+        }
+    }
+
+    if !config.floors.is_empty() {
+        if let Some(lvl) = config.ap_floor {
+            if !levels.contains(&lvl) {
+                return Err(format!("ap_floor {lvl} is not a declared floor"));
+            }
+        }
+    }
+
+    // ── Walls ────────────────────────────────────────────────────────────
+    for (i, wall) in config.walls.iter().enumerate() {
+        if ![wall.x1, wall.y1, wall.x2, wall.y2]
+            .iter()
+            .all(|v| v.is_finite())
+        {
+            return Err(format!("wall {i} has a non-finite endpoint"));
+        }
+        // A zero-length wall is not a wall. It would also make any
+        // segment-intersection test degenerate rather than merely wrong.
+        let dx = wall.x2 - wall.x1;
+        let dy = wall.y2 - wall.y1;
+        if (dx * dx + dy * dy).sqrt() < 1e-3 {
+            return Err(format!("wall {i} has zero length"));
+        }
+        if let Some(h) = wall.height_m {
+            if !h.is_finite() || h <= 0.0 {
+                return Err(format!("wall {i} height_m must be positive"));
+            }
+        }
+        if !config.floors.is_empty() && !levels.contains(&wall.level) {
+            return Err(format!("wall {i} is on undefined floor {}", wall.level));
+        }
+    }
+
     Ok(())
 }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1439,6 +1439,153 @@ pub(crate) fn save_runtime_config(data_dir: &std::path::Path, config: &RuntimeCo
     }
 }
 
+/// A single sensor node's position in room space, as placed via the Room
+/// Builder UI. `id` must match the node's provisioned `--node-id` on the
+/// physical board — it is not implied by array position, so nodes can be
+/// added/removed/reordered in the UI without breaking the id-to-position
+/// mapping (the same mapping issue #228/#249 was about).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RoomNode {
+    pub id: u8,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// Room geometry (a simple rectangle) plus sensor node placements, as
+/// defined via the Room Builder UI (`POST /api/v1/config/room`).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RoomConfig {
+    pub width_m: f32,
+    pub depth_m: f32,
+    pub nodes: Vec<RoomNode>,
+}
+
+/// Load persisted room config from `<data_dir>/room_config.json`.
+/// Falls back to [`RoomConfig::default`] (empty room, no nodes) if the file
+/// is absent or malformed.
+pub(crate) fn load_room_config(data_dir: &std::path::Path) -> RoomConfig {
+    let path = data_dir.join("room_config.json");
+    match std::fs::read_to_string(&path) {
+        Ok(json) => serde_json::from_str(&json).unwrap_or_default(),
+        Err(_) => RoomConfig::default(),
+    }
+}
+
+/// Persist room config to `<data_dir>/room_config.json`.
+pub(crate) fn save_room_config(data_dir: &std::path::Path, config: &RoomConfig) {
+    let path = data_dir.join("room_config.json");
+    if let Ok(json) = serde_json::to_string_pretty(config) {
+        if let Err(e) = std::fs::write(&path, json) {
+            warn!("Failed to save room config to {}: {e}", path.display());
+        } else {
+            info!("Room config saved to {}", path.display());
+        }
+    }
+}
+
+#[cfg(test)]
+mod room_config_tests {
+    use super::*;
+
+    #[test]
+    fn load_missing_file_returns_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = load_room_config(dir.path());
+        assert_eq!(cfg.width_m, 0.0);
+        assert_eq!(cfg.depth_m, 0.0);
+        assert!(cfg.nodes.is_empty());
+    }
+
+    #[test]
+    fn load_malformed_file_falls_back_to_default() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("room_config.json"), "{ not valid json").unwrap();
+        let cfg = load_room_config(dir.path());
+        assert_eq!(cfg.width_m, 0.0);
+        assert!(cfg.nodes.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let saved = RoomConfig {
+            width_m: 5.0,
+            depth_m: 4.0,
+            nodes: vec![
+                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, label: Some("front-right".into()) },
+                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, label: None },
+            ],
+        };
+        save_room_config(dir.path(), &saved);
+        let loaded = load_room_config(dir.path());
+        assert_eq!(loaded.width_m, 5.0);
+        assert_eq!(loaded.depth_m, 4.0);
+        assert_eq!(loaded.nodes.len(), 2);
+        assert_eq!(loaded.nodes[0].id, 0);
+        assert_eq!(loaded.nodes[0].label.as_deref(), Some("front-right"));
+        assert_eq!(loaded.nodes[1].label, None);
+    }
+
+    fn valid_config() -> RoomConfig {
+        RoomConfig {
+            width_m: 5.0,
+            depth_m: 4.0,
+            nodes: vec![
+                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, label: None },
+                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, label: None },
+            ],
+        }
+    }
+
+    #[test]
+    fn validate_accepts_a_sane_config() {
+        assert!(validate_room_config(&valid_config()).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_non_positive_width() {
+        let mut cfg = valid_config();
+        cfg.width_m = 0.0;
+        assert!(validate_room_config(&cfg).is_err());
+        cfg.width_m = -1.0;
+        assert!(validate_room_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_depth() {
+        let mut cfg = valid_config();
+        cfg.depth_m = f32::NAN;
+        assert!(validate_room_config(&cfg).is_err());
+        cfg.depth_m = f32::INFINITY;
+        assert!(validate_room_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_node_ids() {
+        let mut cfg = valid_config();
+        cfg.nodes[1].id = 0; // collide with nodes[0]
+        let err = validate_room_config(&cfg).unwrap_err();
+        assert!(err.contains("duplicate"), "unexpected error message: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_node_coordinate() {
+        let mut cfg = valid_config();
+        cfg.nodes[0].x = f32::NAN;
+        assert!(validate_room_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn validate_allows_empty_node_list() {
+        let mut cfg = valid_config();
+        cfg.nodes.clear();
+        assert!(validate_room_config(&cfg).is_ok());
+    }
+}
+
 /// Shared application state
 struct AppStateInner {
     latest_update: Option<SensingUpdate>,
@@ -9943,6 +10090,94 @@ async fn config_set_dedup_factor(
     Json(serde_json::json!({
         "status": "ok",
         "dedup_factor": clamped,
+    }))
+}
+
+/// `GET /api/v1/config/room` — read the current room geometry + node
+/// positions. Reflects live in-memory state (`node_positions_config`), not
+/// just whatever was last saved to disk, so a fresh page load in the Room
+/// Builder UI shows what the server is actually using right now.
+async fn config_get_room(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let s = state.read().await;
+    let saved = load_room_config(&s.data_dir);
+    let nodes: Vec<RoomNode> = s
+        .node_positions_config
+        .iter()
+        .map(|(&id, p)| {
+            let label = saved
+                .nodes
+                .iter()
+                .find(|n| n.id == id)
+                .and_then(|n| n.label.clone());
+            RoomNode {
+                id,
+                x: p[0],
+                y: p[1],
+                z: p[2],
+                label,
+            }
+        })
+        .collect();
+    Json(serde_json::json!({
+        "width_m": saved.width_m,
+        "depth_m": saved.depth_m,
+        "nodes": nodes,
+    }))
+}
+
+/// `POST /api/v1/config/room` — set room geometry + node positions from the
+/// Room Builder UI. Takes effect immediately (updates `node_positions_config`
+/// and the live `MultistaticFuser`, no restart needed) and persists to
+/// `<data_dir>/room_config.json` so it's picked up on the next launch too.
+///
+/// Body: a full `RoomConfig` (`{ "width_m", "depth_m", "nodes": [...] }`).
+/// Validate a `RoomConfig` submitted via `POST /api/v1/config/room`. Pure
+/// and side-effect-free so it's directly unit-testable without standing up
+/// a full `SharedState`/axum test harness.
+pub(crate) fn validate_room_config(config: &RoomConfig) -> Result<(), String> {
+    if !config.width_m.is_finite() || config.width_m <= 0.0 {
+        return Err("width_m must be a positive, finite number".to_string());
+    }
+    if !config.depth_m.is_finite() || config.depth_m <= 0.0 {
+        return Err("depth_m must be a positive, finite number".to_string());
+    }
+    let mut seen = std::collections::HashSet::new();
+    for n in &config.nodes {
+        if !seen.insert(n.id) {
+            return Err(format!("duplicate node id {}", n.id));
+        }
+        if !n.x.is_finite() || !n.y.is_finite() || !n.z.is_finite() {
+            return Err(format!("node {} has a non-finite coordinate", n.id));
+        }
+    }
+    Ok(())
+}
+
+async fn config_set_room(
+    State(state): State<SharedState>,
+    Json(config): Json<RoomConfig>,
+) -> Json<serde_json::Value> {
+    if let Err(e) = validate_room_config(&config) {
+        return Json(serde_json::json!({"error": e}));
+    }
+
+    let mut s = state.write().await;
+    s.node_positions_config.clear();
+    let max_id = config.nodes.iter().map(|n| n.id).max().unwrap_or(0);
+    let mut positions = vec![[0.0f32, 0.0, 0.0]; max_id as usize + 1];
+    for n in &config.nodes {
+        s.node_positions_config.insert(n.id, [n.x, n.y, n.z]);
+        positions[n.id as usize] = [n.x, n.y, n.z];
+    }
+    s.multistatic_fuser.set_node_positions(positions);
+    let data_dir = s.data_dir.clone();
+    drop(s);
+    save_room_config(&data_dir, &config);
+    Json(serde_json::json!({
+        "status": "ok",
+        "width_m": config.width_m,
+        "depth_m": config.depth_m,
+        "nodes": config.nodes,
     }))
 }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -10391,7 +10391,13 @@ async fn config_get_room(State(state): State<SharedState>) -> Json<serde_json::V
     let nodes: Vec<RoomNode> = s
         .node_positions_config
         .iter()
-        .map(|(&id, p)| {
+        .enumerate()
+        .map(|(idx, p)| {
+            // #1791 made node_positions_config a POSITIONAL Vec rather than a
+            // map keyed by node_id, so identity here is the list index. Kept
+            // consistent with that convention deliberately: the Room Builder
+            // must describe the same binding the fusion path actually uses.
+            let id = idx as u8;
             let saved_node = saved.nodes.iter().find(|n| n.id == id);
             let label = saved_node.and_then(|n| n.label.clone());
             // Storey is carried on the persisted config, not on the live
@@ -10564,13 +10570,12 @@ async fn config_set_room(
     }
 
     let mut s = state.write().await;
-    s.node_positions_config.clear();
     let max_id = config.nodes.iter().map(|n| n.id).max().unwrap_or(0);
     let mut positions = vec![[0.0f32, 0.0, 0.0]; max_id as usize + 1];
     for n in &config.nodes {
-        s.node_positions_config.insert(n.id, [n.x, n.y, n.z]);
         positions[n.id as usize] = [n.x, n.y, n.z];
     }
+    s.node_positions_config = positions.clone();
     s.multistatic_fuser.set_node_positions(positions);
     let data_dir = s.data_dir.clone();
     drop(s);


### PR DESCRIPTION
Extends the Room Builder from a single flat rectangle to a building: multiple
storeys, walls drawn per storey, and a placed access point.

Storeys share one origin. The origin (0, 0, 0) is the north-west corner of the
first floor at floor level, and every storey is measured from it rather than
being re-zeroed, so a node's X/Y means the same thing on every floor and
distances between nodes on different storeys are plain Euclidean. Nodes and
walls on other storeys are drawn faintly rather than hidden, which is what lets
an upper-floor node be lined up against the wall below it.

Storey elevation is derived from ceiling height plus subfloor thickness rather
than typed in directly, because those are the two numbers someone can actually
measure. Heights are entered in inches.

A node carries `floor` alongside `z`. That is redundant for geometry and
deliberately so: it is what the builder groups by and what walls are associated
with, and deriving it from `z` would guess wrong for a node mounted high in a
stairwell. `floor` is optional, so a config written before storeys existed keeps
working unchanged.

Every persisted field is served back by GET /api/v1/config/room. That response
body is hand-maintained and will not complain when it falls behind the struct,
so it carries a comment saying so at the point where the next field will be
added -- a field that is saved but not served looks exactly like "the setting
will not stick".

Wall entry takes a start and an end and refuses a zero-length wall, which is
otherwise easy to stage by double-tapping a corner.

---

Rebased onto current `main` before opening: staged before today's seven merges, so it needed replaying to avoid reading as a revert of them. Clean rebase, no files deleted.