### PR TITLE
feat(ui): node tapper, built from whatever fleet the server reports

### DIFF
--- a/ui/mark.html
+++ b/ui/mark.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="theme-color" content="#0d1117">
+<title>Room Marker</title>
+<!--
+  One-thumb ground truth for the link recorder.
+
+  Written 2026-08-28 after the night's analysis showed why this is needed: the
+  only label with good provenance that night was the one reported in real time
+  (23:18 light-off, a clean miss). Everything recalled afterwards — "around
+  9:45", the feeding window — was soft by roughly half an hour, and a soft
+  label cannot support a per-event claim. Worse, matching a detection to a
+  remembered time is post-hoc fitting: during an active stretch the detector
+  bumps every ~1.5 min, so ANY estimate inside it "matches" something.
+
+  So this page exists to stamp events at the instant they happen, from a phone,
+  without needing a watch or a clear head. The whole interface is one big
+  toggle because it has to work half-asleep in the dark.
+
+  Marks are written twice and independently:
+    - GET /api/v1/diag/mark/<label>  -> the server's phase_markers sink
+      (the running server has --phase-diagnostics data/mesh, so this works)
+    - localStorage                   -> survives reload, server restart, and
+                                        a dropped WiFi connection
+  Losing ground truth means re-walking everything, so neither path is trusted
+  alone. Export writes the local copy out as JSON.
+
+  Reachable from the phone at  http://<host>:3000/ui/mark.html
+-->
+<style>
+  :root {
+    --bg:#0d1117; --fg:#e6edf3; --dim:#8b949e; --line:#30363d;
+    --in:#2ea043; --out:#d29922; --tag:#388bfd; --warn:#f85149; --ok:#a371f7;
+  }
+  * { box-sizing:border-box; -webkit-tap-highlight-color:transparent; }
+  html, body { height:100%; }
+  body {
+    margin:0; padding:14px; background:var(--bg); color:var(--fg);
+    font:15px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    display:flex; flex-direction:column; gap:12px;
+    padding-bottom:calc(14px + env(safe-area-inset-bottom));
+    -webkit-user-select:none; user-select:none;
+  }
+  h1 { font-size:15px; margin:0; font-weight:700; }
+  .sub { color:var(--dim); font-size:12px; }
+  .card { border:1px solid var(--line); border-radius:10px; padding:12px; }
+
+  /* The main control. Deliberately enormous — this is used in the dark. */
+  #toggle {
+    flex:1 1 auto; min-height:210px; width:100%;
+    border:none; border-radius:16px; cursor:pointer;
+    font:inherit; font-size:34px; font-weight:700; letter-spacing:.02em;
+    color:#fff; display:flex; flex-direction:column;
+    align-items:center; justify-content:center; gap:10px;
+    transition:transform .06s ease, filter .15s ease;
+  }
+  #toggle:active { transform:scale(.985); filter:brightness(1.12); }
+  #toggle .hint { font-size:14px; font-weight:400; opacity:.9; letter-spacing:0; }
+  #toggle.going-in  { background:var(--in); }
+  #toggle.going-out { background:var(--out); color:#1a1205; }
+
+  .state { text-align:center; font-size:13px; color:var(--dim); }
+  .state b { color:var(--fg); }
+
+  .tags { display:grid; grid-template-columns:repeat(2, 1fr); gap:8px; }
+  .tags button {
+    font:inherit; font-size:13px; padding:14px 8px; border-radius:9px;
+    border:1px solid var(--line); background:#161b22; color:var(--fg);
+    cursor:pointer;
+  }
+  .tags button:active { background:#21262d; }
+
+  .row { display:flex; gap:8px; }
+  .row button {
+    flex:1; font:inherit; font-size:12px; padding:11px 8px; border-radius:8px;
+    border:1px solid var(--line); background:#161b22; color:var(--dim);
+    cursor:pointer;
+  }
+  #log {
+    max-height:150px; overflow:auto; font-size:11.5px; color:var(--dim);
+    white-space:pre-wrap; word-break:break-word; margin:0;
+  }
+  .err { color:var(--warn); }
+  .okc { color:var(--ok); }
+</style>
+</head>
+<body>
+
+<div>
+  <h1>Room Marker</h1>
+  <div class="sub">Tap the moment it happens. Don't try to remember it later.</div>
+</div>
+
+<button id="toggle" class="going-in">
+  <span id="toggleLabel">I'M GOING IN</span>
+  <span class="hint" id="toggleHint">tap as you cross the doorway</span>
+</button>
+
+<div class="state" id="state">outside &middot; no marks yet</div>
+
+<div class="card">
+  <div class="sub" style="margin-bottom:8px">Context (optional, tap any time)</div>
+  <div class="tags">
+    <button data-tag="feeding">feeding animals</button>
+    <button data-tag="animals-active">animals active</button>
+    <button data-tag="other-person-in">someone else in</button>
+    <button data-tag="other-person-out">someone else out</button>
+    <button data-tag="pet-out">Pet out</button>
+    <button data-tag="pet-away">Pet away</button>
+  </div>
+</div>
+
+<div class="card">
+  <div class="sub" style="margin-bottom:6px">Recent</div>
+  <div id="log">nothing yet</div>
+</div>
+
+<div class="row">
+  <button id="export">export JSON</button>
+  <button id="undo">undo last</button>
+  <button id="clear">clear</button>
+</div>
+
+<script>
+// ---- storage ---------------------------------------------------------------
+// The local copy is authoritative for the operator; the server sink is the
+// copy that lines up with the recorder. Keep both, trust neither alone.
+
+var KEY = 'ruview-room-marks';
+var marks = [];
+try { marks = JSON.parse(localStorage.getItem(KEY) || '[]'); } catch (e) { marks = []; }
+
+function save() {
+  try { localStorage.setItem(KEY, JSON.stringify(marks)); } catch (e) { /* private mode */ }
+}
+
+function inside() {
+  for (var i = marks.length - 1; i >= 0; i--) {
+    if (marks[i].label === 'room-in')  return true;
+    if (marks[i].label === 'room-out') return false;
+  }
+  return false;
+}
+
+// ---- marking ---------------------------------------------------------------
+
+function hhmmss(ms) { return new Date(ms).toTimeString().slice(0, 8); }
+
+function mark(label) {
+  var at = Date.now();
+  var rec = { t_unix_ms: at, label: label, server_t_s: null, server: 'pending' };
+  marks.push(rec);
+  save(); render();
+
+  if (navigator.vibrate) { try { navigator.vibrate(label === 'room-in' ? 40 : [30, 40, 30]); } catch (e) {} }
+
+  fetch('/api/v1/diag/mark/' + encodeURIComponent(label), { cache: 'no-store' })
+    .then(function (r) { return r.json(); })
+    .then(function (j) {
+      // The endpoint answers ok:false when --phase-diagnostics is not set;
+      // that is a real failure for alignment, so surface it rather than
+      // treating any 200 as success.
+      rec.server = j && j.ok ? 'ok' : 'not-recording';
+      if (j && typeof j.t_s === 'number') rec.server_t_s = j.t_s;
+      save(); render();
+    })
+    .catch(function () { rec.server = 'unreachable'; save(); render(); });
+}
+
+// ---- render ----------------------------------------------------------------
+
+function render() {
+  var isIn = inside();
+  var btn = document.getElementById('toggle');
+  btn.className = isIn ? 'going-out' : 'going-in';
+  document.getElementById('toggleLabel').textContent = isIn ? "I'M COMING OUT" : "I'M GOING IN";
+  document.getElementById('toggleHint').textContent = isIn
+    ? 'tap as you leave the room'
+    : 'tap as you cross the doorway';
+
+  var last = marks[marks.length - 1];
+  document.getElementById('state').innerHTML =
+    (isIn ? '<b>inside</b>' : 'outside') + ' &middot; ' +
+    (last ? marks.length + ' marks, last ' + hhmmss(last.t_unix_ms) : 'no marks yet');
+
+  var log = document.getElementById('log');
+  if (!marks.length) { log.textContent = 'nothing yet'; return; }
+  log.innerHTML = '';
+  marks.slice(-14).reverse().forEach(function (m) {
+    var line = document.createElement('div');
+    var cls = m.server === 'ok' ? 'okc' : (m.server === 'pending' ? '' : 'err');
+    line.innerHTML = hhmmss(m.t_unix_ms) + '  ' + m.label +
+      '  <span class="' + cls + '">' + m.server + '</span>';
+    log.appendChild(line);
+  });
+}
+
+// ---- wiring ----------------------------------------------------------------
+
+document.getElementById('toggle').addEventListener('click', function () {
+  mark(inside() ? 'room-out' : 'room-in');
+});
+
+Array.prototype.forEach.call(document.querySelectorAll('.tags button'), function (b) {
+  b.addEventListener('click', function () { mark(b.getAttribute('data-tag')); });
+});
+
+document.getElementById('undo').addEventListener('click', function () {
+  if (!marks.length) return;
+  // Local only — the server sink is append-only by design, so note the
+  // retraction there instead of pretending the original never happened.
+  var gone = marks.pop();
+  save(); render();
+  fetch('/api/v1/diag/mark/' + encodeURIComponent('undo-' + gone.label), { cache: 'no-store' })
+    .catch(function () {});
+});
+
+document.getElementById('clear').addEventListener('click', function () {
+  if (!confirm('Clear ' + marks.length + ' local marks? The server copy is kept.')) return;
+  marks = []; save(); render();
+});
+
+document.getElementById('export').addEventListener('click', function () {
+  var blob = new Blob([JSON.stringify({
+    exported_at_unix_ms: Date.now(),
+    note: 'Ground-truth room-entry marks. room-in/room-out are the toggle; ' +
+          'the rest are context tags. server_t_s aligns with the ' +
+          'sensing-server phase_markers sink.',
+    marks: marks
+  }, null, 2)], { type: 'application/json' });
+  var a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'room-marks-' + Date.now() + '.json';
+  a.click();
+});
+
+render();
+</script>
+</body>
+</html>

--- a/ui/survey.html
+++ b/ui/survey.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tile Survey Runner</title>
+<!--
+  Fingerprint survey over the foam-tile grid (ADR-345 follow-on). Successor to
+  walk.html, which is kept as the record of the 5-spot walk that produced the
+  2026-08-28 measurements.
+
+  ONE PASS, not two. Splitting each 40 s dwell of that walk in half and
+  comparing the halves gave cosine 0.954; comparing two separate passes gave
+  0.952. They measure the same thing, so a second pass bought only time. And
+  with foam tiles the repositioning error a second pass used to catch is gone
+  by construction — you step on the same physical square.
+
+  What a single pass genuinely cannot see is slow drift: in serpentine order,
+  position becomes confounded with time. Hence the revisit block at the end,
+  which re-walks the first few tiles so drift over the run is measured rather
+  than assumed absent. That matters more than usual here — this mesh has
+  already shifted twice in one day.
+
+  Every dwell is MOVE IN PLACE. The metric is the temporal variance of
+  amplitude, so a motionless person records nothing at all. The earlier
+  protocol got this wrong and made the target invisible to its own instrument.
+
+  Ground truth is written twice, because losing it means re-walking everything:
+  /api/v1/diag/mark/<label> into the server's phase_markers CSV, and an in-page
+  log saveable as JSON.
+-->
+<style>
+  :root {
+    --bg:#0d1117; --fg:#e6edf3; --dim:#8b949e; --line:#30363d;
+    --go:#2ea043; --hold:#d29922; --done:#388bfd; --rev:#a371f7;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; padding:16px; background:var(--bg); color:var(--fg);
+         font:15px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  h1 { font-size:17px; margin:0 0 4px; }
+  .sub { color:var(--dim); font-size:12px; margin-bottom:14px; }
+  .card { border:1px solid var(--line); border-radius:8px; padding:14px; margin-bottom:12px; }
+  .phase { font-size:22px; font-weight:700; margin:4px 0; }
+  .tileid { font-size:64px; font-weight:700; line-height:1.05; margin:2px 0; }
+  .huge { font-size:50px; font-weight:700; font-variant-numeric:tabular-nums; }
+  .go { color:var(--go); } .hold { color:var(--hold); }
+  .done { color:var(--done); } .rev { color:var(--rev); }
+  .where { font-size:14px; color:var(--dim); margin-top:2px; }
+  .bar { height:6px; background:#21262d; border-radius:3px; overflow:hidden; margin-top:12px; }
+  .bar > i { display:block; height:100%; background:var(--go); width:0; transition:width .3s linear; }
+  button { font:inherit; padding:12px 18px; border-radius:7px; cursor:pointer;
+           border:1px solid var(--line); background:#21262d; color:var(--fg);
+           margin:4px 6px 4px 0; }
+  button.primary { background:var(--go); border-color:var(--go); color:#fff; font-weight:700; }
+  button:disabled { opacity:.4; cursor:default; }
+  #log { max-height:150px; overflow:auto; font-size:11px; color:var(--dim); white-space:pre-wrap; }
+  .note { color:var(--dim); font-size:12px; margin-top:8px; }
+  .warn { color:var(--hold); }
+  .next { color:var(--dim); font-size:13px; margin-top:8px; }
+</style>
+</head>
+<body>
+
+<h1>Tile Survey — fingerprint ground truth</h1>
+<div class="sub">
+  C counts east from the west wall, R counts south. Stand on the tile and keep moving.
+</div>
+
+<div class="card">
+  <div id="phase" class="phase">Ready</div>
+  <div id="tileid" class="tileid">&mdash;</div>
+  <div id="where" class="where"></div>
+  <div id="countdown" class="huge">&mdash;</div>
+  <div id="instruction" class="note"></div>
+  <div class="bar"><i id="prog"></i></div>
+  <div id="next" class="next"></div>
+</div>
+
+<div class="card">
+  <button id="start" class="primary">Start survey</button>
+  <button id="skip" disabled>Skip</button>
+  <button id="abort" disabled>Abort</button>
+  <button id="save" disabled>Save ground truth JSON</button>
+  <div class="note">
+    Keep this page visible — a backgrounded tab throttles the countdown, which
+    silently corrupts the timing of every tile after it.
+  </div>
+</div>
+
+<div class="card">
+  <div class="sub" style="margin:0 0 6px">Event log</div>
+  <div id="log"></div>
+</div>
+
+<script>
+// ---- Protocol -------------------------------------------------------------
+
+var DWELL_S   = 35;   // split in half during analysis for the repeatability check
+var TRANSIT_S = 20;   // walking to the next tile; recorded, then excluded
+var REVISITS  = 4;    // first N tiles re-walked at the end, to measure drift
+
+// The 26 selected tiles in serpentine order, so consecutive tiles are adjacent
+// and transit stays short. x is inches east of the west wall, y inches south
+// of the north wall.
+var TILES = [
+  {id:'C2R1',x:36,y:24},  {id:'C3R1',x:60,y:24},  {id:'C6R1',x:132,y:24}, {id:'C7R1',x:156,y:24},
+  {id:'C7R2',x:156,y:48}, {id:'C6R2',x:132,y:48}, {id:'C5R2',x:108,y:48}, {id:'C4R2',x:84,y:48},
+  {id:'C3R2',x:60,y:48},  {id:'C2R2',x:36,y:48},
+  {id:'C2R3',x:36,y:72},  {id:'C3R3',x:60,y:72},  {id:'C4R3',x:84,y:72},  {id:'C5R3',x:108,y:72},
+  {id:'C6R3',x:132,y:72}, {id:'C7R3',x:156,y:72},
+  {id:'C7R4',x:156,y:96}, {id:'C6R4',x:132,y:96}, {id:'C5R4',x:108,y:96}, {id:'C4R4',x:84,y:96},
+  {id:'C3R4',x:60,y:96},  {id:'C2R4',x:36,y:96},
+  {id:'C2R5',x:36,y:120}, {id:'C3R5',x:60,y:120}, {id:'C5R5',x:108,y:120},
+  {id:'C7R6',x:156,y:144}
+];
+
+function feet(n) { var f = Math.floor(n / 12), i = n - 12 * f; return f + "' " + i + '"'; }
+
+var steps = [];
+TILES.forEach(function (t, i) {
+  steps.push({ kind:'transit', tile:t, secs:TRANSIT_S, seq:i + 1, revisit:false });
+  steps.push({ kind:'dwell',   tile:t, secs:DWELL_S,   seq:i + 1, revisit:false });
+});
+TILES.slice(0, REVISITS).forEach(function (t, i) {
+  steps.push({ kind:'transit', tile:t, secs:TRANSIT_S, seq:i + 1, revisit:true });
+  steps.push({ kind:'dwell',   tile:t, secs:DWELL_S,   seq:i + 1, revisit:true });
+});
+
+var totalSecs = steps.reduce(function (a, s) { return a + s.secs; }, 0);
+var idx = -1, timer = null, remaining = 0, elapsed = 0, events = [], running = false;
+
+// ---- Recording ------------------------------------------------------------
+
+function mark(label) {
+  var at = Date.now();
+  events.push({ t_unix_ms: at, label: label });
+  logLine(new Date(at).toISOString().substr(11, 8) + '  ' + label);
+  fetch('/api/v1/diag/mark/' + encodeURIComponent(label), { cache: 'no-store' })
+    .catch(function () { logLine('   (server mark failed; in-page log still good)'); });
+}
+
+function logLine(s) {
+  var el = document.getElementById('log');
+  el.textContent += s + '\n';
+  el.scrollTop = el.scrollHeight;
+}
+
+// ---- Render ---------------------------------------------------------------
+
+function render() {
+  var phase = document.getElementById('phase');
+  var tid = document.getElementById('tileid');
+  var where = document.getElementById('where');
+  var cd = document.getElementById('countdown');
+  var ins = document.getElementById('instruction');
+  var nxt = document.getElementById('next');
+
+  document.getElementById('prog').style.width = (100 * elapsed / totalSecs) + '%';
+
+  if (idx < 0 || idx >= steps.length) {
+    var finished = idx >= steps.length;
+    phase.textContent = finished ? 'Survey complete' : 'Ready';
+    phase.className = 'phase done';
+    tid.textContent = finished ? '✓' : '—';
+    tid.className = 'tileid done';
+    where.textContent = ''; cd.textContent = '—'; nxt.textContent = '';
+    ins.textContent = finished
+      ? 'Save the ground truth JSON, then tell Claude you are done.'
+      : TILES.length + ' tiles plus ' + REVISITS + ' revisits — about ' +
+        Math.round(totalSecs / 60) + ' minutes.';
+    return;
+  }
+
+  var s = steps[idx];
+  cd.textContent = remaining;
+  tid.textContent = s.tile.id;
+  tid.className = 'tileid ' + (s.revisit ? 'rev' : (s.kind === 'dwell' ? 'go' : 'hold'));
+  where.textContent = feet(s.tile.x) + ' east of the west wall, ' +
+                      feet(s.tile.y) + ' south of the north wall';
+
+  if (s.kind === 'transit') {
+    phase.textContent = s.revisit ? 'REVISIT — walk to' : 'Walk to';
+    phase.className = 'phase hold';
+    ins.textContent = 'Transit. Recorded, then excluded from the analysis.';
+  } else {
+    phase.textContent = s.revisit ? 'REVISIT — move in place' : 'MOVE IN PLACE';
+    phase.className = 'phase ' + (s.revisit ? 'rev' : 'go');
+    ins.innerHTML = 'Stay on the tile and <b>keep moving</b> — shift weight, swing ' +
+      'your arms, step in place. <span class="warn">Standing still records nothing.</span>';
+  }
+
+  var upcoming = null;
+  for (var j = idx + 1; j < steps.length; j++) {
+    if (steps[j].kind === 'dwell') { upcoming = steps[j]; break; }
+  }
+  nxt.textContent = upcoming
+    ? 'next: ' + upcoming.tile.id + (upcoming.revisit ? ' (revisit)' : '') +
+      '   ·   ' + Math.round((totalSecs - elapsed) / 60) + ' min left'
+    : 'last tile';
+}
+
+function tick() {
+  remaining--; elapsed++;
+  if (remaining <= 0) { next(); } else { render(); }
+}
+
+function next() {
+  idx++;
+  if (idx >= steps.length) {
+    stopTimer(); running = false;
+    mark('survey-end');
+    document.getElementById('save').disabled = false;
+    document.getElementById('skip').disabled = true;
+    document.getElementById('abort').disabled = true;
+    render();
+    return;
+  }
+  var s = steps[idx];
+  remaining = s.secs;
+  mark(s.kind + '_' + s.tile.id + '_' + (s.revisit ? 'rev' : 'seq') +
+       (s.seq < 10 ? '0' : '') + s.seq + '_x' + s.tile.x + '_y' + s.tile.y);
+  render();
+}
+
+function stopTimer() { if (timer) { clearInterval(timer); timer = null; } }
+
+document.getElementById('start').onclick = function () {
+  if (running) return;
+  running = true; events = []; elapsed = 0;
+  document.getElementById('start').disabled = true;
+  document.getElementById('skip').disabled = false;
+  document.getElementById('abort').disabled = false;
+  document.getElementById('save').disabled = true;
+  mark('survey-start');
+  idx = -1; next();
+  stopTimer(); timer = setInterval(tick, 1000);
+};
+
+document.getElementById('skip').onclick = function () { if (running) next(); };
+
+document.getElementById('abort').onclick = function () {
+  stopTimer(); running = false;
+  mark('survey-abort');
+  document.getElementById('start').disabled = false;
+  document.getElementById('skip').disabled = true;
+  document.getElementById('abort').disabled = true;
+  document.getElementById('save').disabled = false;
+  idx = steps.length; render();
+};
+
+document.getElementById('save').onclick = function () {
+  var blob = new Blob([JSON.stringify({
+    protocol: 'foam-tile fingerprint survey, single pass with revisits',
+    grid: '24 inch tiles, index NW corner, flush west, 12 inch north buffer',
+    units: 'inches; x east of the west wall, y south of the north wall',
+    dwell_s: DWELL_S, transit_s: TRANSIT_S, revisits: REVISITS,
+    tiles: TILES, events: events
+  }, null, 2)], { type: 'application/json' });
+  var a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'tile-survey-' + Date.now() + '.json';
+  a.click();
+};
+
+render();
+</script>
+</body>
+</html>

--- a/ui/tapper.html
+++ b/ui/tapper.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="theme-color" content="#0d1117">
+<title>Node Tapper</title>
+<!--
+  Per-location ground truth, keyed to the nearest node. The successor to
+  mark.html, which was one IN/OUT toggle for a single place.
+
+  Written 2026-09-01. Every open question this week is starved of labels, not
+  of data: the fleet records 165 links continuously, and almost none of it is
+  attached to a known place. The two labelled events we did get that evening
+  (a circuit past one node, then two occupants together near another)
+  were worth more than the preceding hour of unlabelled polling.
+
+  Three things are recorded per tap, and all three matter for different reasons:
+
+    WHERE   which node you are nearest. Without it nothing can be tested
+            against position at all.
+    WHO     which group. Two separated groups at once is the ONLY configuration
+            that can test whether the fleet represents two disturbances rather
+            than averaging them into one phantom between the two.
+    MOVING  still vs moving. A previous analysis nearly reported a flat
+            correlation as a refutation before noticing 97% of the window was
+            `present_still` -- a body that is not moving perturbs almost
+            nothing, so an unlabelled quiet stretch looks identical to an
+            absent one and silently dilutes every statistic computed over it.
+
+  Marks are written twice, independently, because losing ground truth means
+  re-walking everything:
+    - GET /api/v1/diag/mark/<label>   -> server phase_markers sink
+    - localStorage                    -> survives reload, restart, dropped WiFi
+  Failed sends are queued and retried; the badge shows the backlog.
+
+  One button per node, built from /api/v1/nodes at load, so this page suits any
+  fleet of any size without being edited. Stand near a node, tap its button.
+  Node identity is the only spatial reference used -- no floor plan, no
+  coordinates, nothing specific to one building.
+
+  "Elsewhere" covers the places a fleet does not instrument. Those need
+  labelling arguably more than the rest, precisely because nothing there is
+  measuring.
+
+  Open it on a phone at  http://<sensing-server-host>:3000/ui/tapper.html
+-->
+<style>
+  :root{
+    --bg:#0d1117; --fg:#e6edf3; --dim:#8b949e; --line:#30363d; --card:#161b22;
+    --move:#2ea043; --still:#d29922; --adult1:#388bfd; --children:#a371f7; --all:#db6d28;
+    --adult2:#e85aad; --child1:#2bb3c0;
+    --warn:#f85149;
+  }
+  *{box-sizing:border-box;-webkit-tap-highlight-color:transparent}
+  html,body{height:100%}
+  body{
+    margin:0;padding:12px;background:var(--bg);color:var(--fg);
+    font:15px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    display:flex;flex-direction:column;gap:10px;
+    padding-bottom:calc(12px + env(safe-area-inset-bottom));
+    -webkit-user-select:none;user-select:none;
+  }
+  .row{display:flex;gap:8px;align-items:center}
+  h1{font-size:14px;margin:0;font-weight:700;flex:1}
+  .badge{font-size:11px;color:var(--dim);border:1px solid var(--line);
+         border-radius:20px;padding:3px 9px}
+  .badge.bad{color:var(--warn);border-color:var(--warn)}
+
+  #now{border:1px solid var(--line);border-radius:12px;padding:12px;
+       background:var(--card);text-align:center}
+  #now .where{font-size:24px;font-weight:700;line-height:1.2}
+  #now .meta{font-size:12px;color:var(--dim);margin-top:4px}
+
+  .seg{display:grid;grid-template-columns:repeat(3,1fr);gap:6px}
+  .seg button{font:inherit;font-size:13px;font-weight:700;padding:13px 4px;
+    border-radius:10px;border:1px solid var(--line);background:var(--card);
+    color:var(--dim);cursor:pointer}
+  .seg button[aria-pressed="true"]{color:#fff;border-color:transparent}
+  #who button[aria-pressed="true"][data-v="adult1"]{background:var(--adult1)}
+  #who button[aria-pressed="true"][data-v="children-together"]{background:var(--children)}
+  #who button[aria-pressed="true"][data-v="everyone"]{background:var(--all)}
+  #who button[aria-pressed="true"][data-v="adult2"]{background:var(--adult2)}
+  #who button[aria-pressed="true"][data-v="child1"]{background:var(--child1)}
+  #who2{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-top:6px}
+  #who2 button{font:inherit;font-size:13px;font-weight:700;padding:13px 4px;
+    border-radius:10px;border:1px solid var(--line);background:var(--card);
+    color:var(--dim);cursor:pointer}
+  #who2 button[aria-pressed="true"][data-v="children-together"]{background:var(--children);color:#fff;border-color:transparent}
+  #who2 button[aria-pressed="true"][data-v="everyone"]{background:var(--all);color:#fff;border-color:transparent}
+
+  #motion{display:grid;grid-template-columns:1fr 1fr;gap:6px}
+  #motion button{font:inherit;font-size:17px;font-weight:700;padding:20px 4px;
+    border-radius:12px;border:1px solid var(--line);background:var(--card);
+    color:var(--dim);cursor:pointer}
+  #motion button[aria-pressed="true"][data-v="moving"]{background:var(--move);color:#fff;border-color:transparent}
+  #motion button[aria-pressed="true"][data-v="still"]{background:var(--still);color:#1a1205;border-color:transparent}
+
+  .lbl{font-size:11px;color:var(--dim);letter-spacing:.08em;text-transform:uppercase}
+  #rooms{display:grid;grid-template-columns:repeat(2,1fr);gap:7px}
+  #rooms button{font:inherit;font-size:14px;font-weight:600;padding:16px 6px;
+    border-radius:11px;border:1px solid var(--line);background:var(--card);
+    color:var(--fg);cursor:pointer;min-width:0;text-align:left;line-height:1.25}
+  #rooms button:active{filter:brightness(1.3)}
+  #rooms button.on{background:var(--adult1);border-color:transparent;color:#fff}
+  #rooms button .fl{display:block;font-size:10px;color:var(--dim);font-weight:400}
+  #rooms button.on .fl{color:rgba(255,255,255,.85)}
+  #rooms button.nonode{border-style:dashed}
+
+  #log{border:1px solid var(--line);border-radius:10px;background:var(--card);
+       padding:8px;max-height:26vh;overflow:auto;font-size:12px}
+  #log div{padding:3px 0;border-bottom:1px solid #21262d;color:var(--dim)}
+  #log div:last-child{border-bottom:none}
+  #log b{color:var(--fg)}
+  .foot{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+  .foot button{font:inherit;font-size:12px;padding:11px;border-radius:9px;
+    border:1px solid var(--line);background:var(--card);color:var(--dim);cursor:pointer}
+</style>
+
+<div class="row">
+  <h1>Node Tapper</h1>
+  <span class="badge" id="queue">synced</span>
+</div>
+
+<div id="now">
+  <div class="where" id="nowWhere">tap a room</div>
+  <div class="meta" id="nowMeta">nothing marked yet</div>
+</div>
+
+<div class="lbl">who</div>
+<div class="seg" id="who">
+  <button data-v="adult1" aria-pressed="true">adult 1</button>
+  <button data-v="adult2" aria-pressed="false">adult 2</button>
+  <button data-v="child1" aria-pressed="false">child 1</button>
+</div>
+<div id="who2">
+  <button data-v="children-together" aria-pressed="false">children together</button>
+  <button data-v="everyone" aria-pressed="false">everyone</button>
+</div>
+
+<div class="lbl">what they are doing</div>
+<div class="seg" id="motion" style="grid-template-columns:1fr 1fr">
+  <button data-v="moving" aria-pressed="true">MOVING</button>
+  <button data-v="still" aria-pressed="false">STILL</button>
+</div>
+
+<div class="lbl">where — tap to stamp</div>
+<div id="rooms"></div>
+
+<div class="lbl">recent</div>
+<div id="log"></div>
+
+<div class="foot">
+  <button id="export">export json</button>
+  <button id="clear">clear local</button>
+</div>
+
+<script>
+// Places that are not a node. A fleet never covers every space, and the gaps
+// still need ground truth -- arguably more, since nothing there is measuring.
+// Deliberately generic: no room names, no coordinates, nothing tied to one
+// building.
+const NON_NODE_PLACES = [
+  { label: 'Elsewhere',    note: 'in the building, not near a node' },
+  { label: 'Outside/away', note: 'baseline' }
+];
+
+const KEY = 'ruview.tapper.v1';
+let marks = [];
+let queue = [];
+let cur = null;
+let who = 'adult1', motion = 'moving';
+
+try { marks = JSON.parse(localStorage.getItem(KEY) || '[]'); } catch (e) { marks = []; }
+try { queue = JSON.parse(localStorage.getItem(KEY + '.q') || '[]'); } catch (e) { queue = []; }
+
+const save = () => {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(marks.slice(-800)));
+    localStorage.setItem(KEY + '.q', JSON.stringify(queue.slice(-400)));
+  } catch (e) { /* private mode, quota — the server copy still stands */ }
+};
+
+const slug = s => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+async function flush() {
+  while (queue.length) {
+    const lab = queue[0];
+    try {
+      const r = await fetch('/api/v1/diag/mark/' + encodeURIComponent(lab), { cache: 'no-store' });
+      if (!r.ok) break;
+      queue.shift();
+    } catch (e) { break; }
+  }
+  save();
+  const q = document.getElementById('queue');
+  q.textContent = queue.length ? (queue.length + ' queued') : 'synced';
+  q.className = 'badge' + (queue.length ? ' bad' : '');
+}
+
+function stamp(place) {
+  const now = new Date();
+  // '_' not '.', because the server's mark sink keeps only [A-Za-z0-9-_] to
+  // stay CSV-safe: dots were silently stripped, so 'adult1.upstairs-bath.moving'
+  // landed as 'meupstairs-bathmoving'. Slugs use '-' internally, so '_' stays
+  // an unambiguous field separator. The sink also truncates at 64 chars.
+  const label = [who, slug(place.label), motion].join('_');
+  const m = {
+    t: now.toISOString(),
+    local: now.toTimeString().slice(0, 8),
+    who, motion,
+    place: place.label,
+    floor: place.floor,
+    node: place.node === undefined ? null : place.node,
+    label
+  };
+  marks.push(m);
+  queue.push(label);
+  cur = m;
+  save();
+  flush();
+  render();
+  if (navigator.vibrate) navigator.vibrate(18);
+}
+
+function render() {
+  const w = document.getElementById('nowWhere');
+  const meta = document.getElementById('nowMeta');
+  if (cur) {
+    w.textContent = cur.place;
+    const secs = Math.max(0, Math.round((Date.now() - new Date(cur.t).getTime()) / 1000));
+    const el = secs < 90 ? secs + 's' : Math.round(secs / 60) + 'm';
+    meta.textContent = cur.who + ' · ' + cur.motion + ' · marked ' + cur.local + ' (' + el + ' ago)';
+  }
+  document.querySelectorAll('#rooms button').forEach(b => {
+    b.classList.toggle('on', !!cur && b.dataset.place === cur.place);
+  });
+  const log = document.getElementById('log');
+  log.innerHTML = '';
+  marks.slice(-14).reverse().forEach(m => {
+    const d = document.createElement('div');
+    d.innerHTML = '<b>' + m.local + '</b> · ' + m.who + ' · ' + m.place + ' · ' + m.motion;
+    log.appendChild(d);
+  });
+}
+
+function seg(id, set) {
+  document.getElementById(id).addEventListener('click', e => {
+    const b = e.target.closest('button');
+    if (!b) return;
+    document.querySelectorAll('#' + id + ' button')
+      .forEach(x => x.setAttribute('aria-pressed', String(x === b)));
+    set(b.dataset.v);
+  });
+}
+
+// "who" spans two rows -- individuals above, groupings below. They are one
+// choice, not two, so selecting one adult has to release "children together".
+// Getting this wrong would let a tap record two identities at once, and a
+// mislabelled identity is worse than no label: it would place one person in
+// two rooms and quietly corrupt exactly the multi-object test this exists for.
+function pickWho(v) {
+  who = v;
+  document.querySelectorAll('#who button, #who2 button')
+    .forEach(x => x.setAttribute('aria-pressed', String(x.dataset.v === v)));
+}
+document.getElementById('who').addEventListener('click', e => {
+  const b = e.target.closest('button'); if (b) pickWho(b.dataset.v);
+});
+document.getElementById('who2').addEventListener('click', e => {
+  const b = e.target.closest('button'); if (b) pickWho(b.dataset.v);
+});
+seg('motion', v => { motion = v; });
+
+async function boot() {
+  // One button per node the SERVER knows about. /api/v1/nodes is the fleet
+  // roster; it carries no geometry, so this page needs no floor plan and
+  // works unchanged on a fleet of three nodes or thirty.
+  let places = [];
+  const meta = document.getElementById('nowMeta');
+  try {
+    const res = await fetch('/api/v1/nodes', { cache: 'no-store' });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    const nodes = (data.nodes || []).slice().sort((a, b) => a.node_id - b.node_id);
+    places = nodes.map(n => ({
+      label: 'Node ' + n.node_id,
+      node: n.node_id,
+      // Whatever the server last heard from it. Useful while walking: a node
+      // that has gone quiet is one whose marks will have no CSI behind them.
+      note: n.status || 'unknown'
+    }));
+    if (!places.length) {
+      meta.textContent = 'server reports no nodes yet -- only the generic places are available';
+    }
+  } catch (e) {
+    // Never invent a fleet. An empty roster is reported as empty; a page that
+    // guessed at node ids would attach marks to nodes that do not exist.
+    meta.textContent = 'could not reach the server -- only the generic places are available';
+  }
+  places = places.concat(NON_NODE_PLACES);
+
+  const wrap = document.getElementById('rooms');
+  places.forEach(p => {
+    const b = document.createElement('button');
+    b.dataset.place = p.label;
+    if (p.node === undefined) b.classList.add('nonode');
+    b.innerHTML = p.label + '<span class="fl">' + p.note + '</span>';
+    b.addEventListener('click', () => stamp(p));
+    wrap.appendChild(b);
+  });
+  render();
+  flush();
+}
+
+document.getElementById('export').addEventListener('click', () => {
+  const blob = new Blob([JSON.stringify(marks, null, 2)], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'tapper-' + new Date().toISOString().slice(0, 19).replace(/[:T]/g, '') + '.json';
+  a.click();
+});
+document.getElementById('clear').addEventListener('click', () => {
+  if (confirm('Clear the local copy? The server sink keeps its own record.')) {
+    marks = []; save(); render();
+  }
+});
+
+setInterval(render, 5000);
+setInterval(flush, 15000);
+boot();
+</script>
+</html>

--- a/ui/walk.html
+++ b/ui/walk.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Walk Test Runner</title>
+<!--
+  Ground-truth walk for the link-line position estimator (ADR-345 / rti.rs).
+
+  Supersedes the per-sensor approach protocol, which was built for a different
+  hypothesis and had a flaw worth remembering: it asked the walker to stand
+  still while the instrument measured temporal variance of amplitude. A
+  motionless person contributes nothing to that statistic, so the protocol made
+  the target invisible to the very metric it was testing. Every dwell here is
+  MOVE IN PLACE for exactly that reason.
+
+  Positions are given as two tape pulls from the window wall (the wall carrying
+  nodes 0 and 1), so no coordinate origin ever has to be found on the floor.
+
+  Two independent records are produced, because losing ground truth means
+  re-walking the whole thing:
+    1. /api/v1/diag/mark/<label> on every transition — lands in the server's
+       phase_markers CSV, aligned to unix time via data/walktest/clock_offset.json.
+    2. An in-page event log with wall-clock timestamps, saveable as JSON.
+-->
+<style>
+  :root {
+    --bg: #0d1117; --fg: #e6edf3; --dim: #8b949e; --line: #30363d;
+    --go: #2ea043; --hold: #d29922; --done: #388bfd; --out: #db6d28;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 16px; background: var(--bg); color: var(--fg);
+         font: 15px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  h1 { font-size: 17px; margin: 0 0 4px; }
+  .sub { color: var(--dim); font-size: 12px; margin-bottom: 14px; }
+  .card { border: 1px solid var(--line); border-radius: 8px; padding: 14px;
+          margin-bottom: 12px; }
+  .big { font-size: 26px; font-weight: 700; margin: 6px 0; }
+  .huge { font-size: 52px; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .go { color: var(--go); } .hold { color: var(--hold); }
+  .done { color: var(--done); } .outside { color: var(--out); }
+  .tape { font-size: 20px; margin: 10px 0; }
+  .tape b { font-size: 26px; }
+  button { font: inherit; padding: 12px 18px; border-radius: 7px; cursor: pointer;
+           border: 1px solid var(--line); background: #21262d; color: var(--fg);
+           margin: 4px 6px 4px 0; }
+  button.primary { background: var(--go); border-color: var(--go); color: #fff; font-weight: 700; }
+  button:disabled { opacity: 0.4; cursor: default; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  td, th { text-align: left; padding: 3px 6px; border-bottom: 1px solid var(--line); }
+  th { color: var(--dim); font-weight: 400; }
+  tr.current td { background: rgba(46,160,67,0.16); }
+  tr.finished td { opacity: 0.45; }
+  #log { max-height: 190px; overflow: auto; font-size: 11px; color: var(--dim);
+         white-space: pre-wrap; }
+  .note { color: var(--dim); font-size: 12px; margin-top: 8px; }
+  .warn { color: var(--hold); }
+</style>
+</head>
+<body>
+
+<h1>Walk Test — link-line position ground truth</h1>
+<div class="sub">
+  All distances measured from the <b>window wall</b> (nodes 0 and 1).
+  &ldquo;Along&rdquo; = slide along that wall starting at node&nbsp;0.
+  &ldquo;Out&rdquo; = straight out from the wall.
+</div>
+
+<div class="card">
+  <div id="phase" class="big">Ready</div>
+  <div id="countdown" class="huge">&mdash;</div>
+  <div id="tape" class="tape"></div>
+  <div id="instruction" class="note"></div>
+</div>
+
+<div class="card">
+  <button id="start" class="primary">Start walk</button>
+  <button id="skip" disabled>Skip to next</button>
+  <button id="abort" disabled>Abort</button>
+  <button id="save" disabled>Save ground truth JSON</button>
+  <div class="note">
+    Keep this page open and visible the whole run &mdash; the countdown pauses if the
+    browser suspends a hidden tab, and a paused countdown silently corrupts the
+    timing of every dwell after it.
+  </div>
+</div>
+
+<div class="card">
+  <table id="plan"><thead><tr>
+    <th>#</th><th>mark</th><th>along wall</th><th>out</th><th>region</th>
+  </tr></thead><tbody></tbody></table>
+</div>
+
+<div class="card">
+  <div class="sub" style="margin:0 0 6px">Event log</div>
+  <div id="log"></div>
+</div>
+
+<script>
+// ---- Protocol ------------------------------------------------------------
+
+// Dwell long enough for the link metric to fill its window several times over:
+// links.rs keeps 64 frames (~1.3-1.8 s at the sustained rate), so 40 s is
+// roughly 25 independent windows per point. Short dwells would hand the
+// analysis a variance estimate too noisy to separate positions with.
+var DWELL_S = 40;
+// Time to walk to the next mark and settle. Deliberately labelled and recorded
+// rather than trimmed away: the transit is the noisiest part of the run and the
+// analysis must be able to exclude it.
+var TRANSIT_S = 20;
+// A quiet reference between points, so drift in the per-link baseline over the
+// run is measurable instead of assumed absent.
+var SETTLE_S = 10;
+
+// Marks, in the order walked. `along` is inches along the window wall from
+// node 0 (negative = away from node 1); `out` is inches from that wall.
+// Computed against the measured room (176 in E-W on the north side, 160 in
+// N-S) with clearance from every wall. The south side's 188 in comes from a
+// 12 x 41 in alcove on the west wall, which only adds space and constrains
+// nothing here.
+var MARKS = [
+  { id: 'P1', along:  50, out:  60, region: 'inside - 5 ft off north' },
+  { id: 'P2', along:  51, out:  36, region: 'inside - 3 ft off north' },
+  { id: 'P3', along:  48, out: 120, region: 'inside - 10 ft off north' },
+  { id: 'P4', along: -24, out:  82, region: 'OUTSIDE triangle, west flank' },
+  { id: 'P5', along: 116, out:  99, region: 'OUTSIDE triangle, east flank' }
+];
+
+// Walk the set twice. One pass cannot distinguish a real position response
+// from a slow drift that happened to coincide with it; a second pass in the
+// same order lets the analysis check that each mark reproduces.
+var PASSES = 2;
+
+function inches(n) {
+  var neg = n < 0, a = Math.abs(n), f = Math.floor(a / 12), i = a - 12 * f;
+  return (neg ? '← ' : '') + f + "' " + i + '"';
+}
+
+// ---- State ---------------------------------------------------------------
+
+var steps = [];
+for (var p = 0; p < PASSES; p++) {
+  for (var m = 0; m < MARKS.length; m++) {
+    steps.push({ kind: 'transit', mark: MARKS[m], pass: p + 1, secs: TRANSIT_S });
+    steps.push({ kind: 'settle',  mark: MARKS[m], pass: p + 1, secs: SETTLE_S });
+    steps.push({ kind: 'dwell',   mark: MARKS[m], pass: p + 1, secs: DWELL_S });
+  }
+}
+
+var idx = -1, timer = null, remaining = 0, events = [], running = false;
+
+// ---- Recording -----------------------------------------------------------
+
+function mark(label) {
+  var at = Date.now();
+  events.push({ t_unix_ms: at, label: label });
+  logLine(new Date(at).toISOString().substr(11, 8) + '  ' + label);
+  // Best-effort: the in-page log above is the primary record, so a failed
+  // request must not interrupt the walk.
+  fetch('/api/v1/diag/mark/' + encodeURIComponent(label), { cache: 'no-store' })
+    .catch(function () { logLine('   (server mark failed, in-page log still good)'); });
+}
+
+function logLine(s) {
+  var el = document.getElementById('log');
+  el.textContent += s + '\n';
+  el.scrollTop = el.scrollHeight;
+}
+
+// ---- Run loop ------------------------------------------------------------
+
+function render() {
+  var phase = document.getElementById('phase');
+  var cd = document.getElementById('countdown');
+  var tape = document.getElementById('tape');
+  var ins = document.getElementById('instruction');
+
+  if (idx < 0 || idx >= steps.length) {
+    phase.textContent = running ? 'Ready' : 'Walk complete';
+    phase.className = 'big done';
+    cd.textContent = '—';
+    tape.textContent = '';
+    ins.textContent = idx >= steps.length
+      ? 'Save the ground truth JSON, then tell Claude you are back.'
+      : '';
+    return;
+  }
+
+  var s = steps[idx];
+  cd.textContent = remaining;
+  var outside = s.mark.region.indexOf('OUTSIDE') === 0;
+
+  tape.innerHTML = 'Mark <b>' + s.mark.id + '</b> &mdash; along wall <b>' +
+    inches(s.mark.along) + '</b>, out <b>' + inches(s.mark.out) + '</b>' +
+    (outside ? ' <span class="outside">(outside triangle)</span>' : '');
+
+  if (s.kind === 'transit') {
+    phase.textContent = 'WALK to ' + s.mark.id + '  (pass ' + s.pass + ')';
+    phase.className = 'big hold';
+    ins.textContent = 'Move to the mark. This interval is recorded as transit and excluded from the analysis.';
+  } else if (s.kind === 'settle') {
+    phase.textContent = 'STAND STILL at ' + s.mark.id;
+    phase.className = 'big hold';
+    ins.textContent = 'Stand on the mark without moving. This is the quiet reference for this point.';
+  } else {
+    phase.textContent = 'MOVE IN PLACE at ' + s.mark.id;
+    phase.className = 'big go';
+    ins.innerHTML = 'Stay on the mark, but <b>keep moving</b> — shift weight, ' +
+      'swing your arms, step in place. <span class="warn">Standing still here ' +
+      'records nothing: the metric is variance over time.</span>';
+  }
+  paintPlan();
+}
+
+function paintPlan() {
+  var body = document.querySelector('#plan tbody');
+  body.innerHTML = '';
+  var cur = idx >= 0 && idx < steps.length ? steps[idx].mark.id : null;
+  var curPass = idx >= 0 && idx < steps.length ? steps[idx].pass : null;
+  for (var p = 1; p <= PASSES; p++) {
+    for (var i = 0; i < MARKS.length; i++) {
+      var m = MARKS[i], tr = document.createElement('tr');
+      if (m.id === cur && p === curPass) tr.className = 'current';
+      else if (curPass !== null && (p < curPass || (p === curPass && i < MARKS.indexOf(markById(cur))))) {
+        tr.className = 'finished';
+      }
+      tr.innerHTML = '<td>' + p + '.' + (i + 1) + '</td><td>' + m.id + '</td><td>' +
+        inches(m.along) + '</td><td>' + inches(m.out) + '</td><td>' + m.region + '</td>';
+      body.appendChild(tr);
+    }
+  }
+}
+
+function markById(id) {
+  for (var i = 0; i < MARKS.length; i++) if (MARKS[i].id === id) return MARKS[i];
+  return MARKS[0];
+}
+
+function tick() {
+  remaining--;
+  if (remaining <= 0) { next(); } else { render(); }
+}
+
+function next() {
+  idx++;
+  if (idx >= steps.length) {
+    stopTimer();
+    running = false;
+    mark('walk-end');
+    document.getElementById('save').disabled = false;
+    document.getElementById('skip').disabled = true;
+    document.getElementById('abort').disabled = true;
+    render();
+    return;
+  }
+  var s = steps[idx];
+  remaining = s.secs;
+  mark(s.kind + ':' + s.mark.id + ':pass' + s.pass +
+       ':along' + s.mark.along + ':out' + s.mark.out);
+  render();
+}
+
+function stopTimer() { if (timer) { clearInterval(timer); timer = null; } }
+
+document.getElementById('start').onclick = function () {
+  if (running) return;
+  running = true;
+  events = [];
+  document.getElementById('start').disabled = true;
+  document.getElementById('skip').disabled = false;
+  document.getElementById('abort').disabled = false;
+  document.getElementById('save').disabled = true;
+  mark('walk-start');
+  idx = -1;
+  next();
+  stopTimer();
+  timer = setInterval(tick, 1000);
+};
+
+document.getElementById('skip').onclick = function () { if (running) next(); };
+
+document.getElementById('abort').onclick = function () {
+  stopTimer();
+  running = false;
+  mark('walk-abort');
+  document.getElementById('start').disabled = false;
+  document.getElementById('skip').disabled = true;
+  document.getElementById('abort').disabled = true;
+  document.getElementById('save').disabled = false;
+  idx = steps.length;
+  render();
+};
+
+document.getElementById('save').onclick = function () {
+  var blob = new Blob([JSON.stringify({
+    protocol: 'link-line ground truth walk',
+    reference_wall: 'window wall carrying nodes 0 and 1',
+    units: 'inches; along = from node 0 along the wall, negative = away from node 1',
+    dwell_s: DWELL_S, transit_s: TRANSIT_S, settle_s: SETTLE_S, passes: PASSES,
+    marks: MARKS,
+    events: events
+  }, null, 2)], { type: 'application/json' });
+  var a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'walk-truth-' + Date.now() + '.json';
+  a.click();
+};
+
+paintPlan();
+render();
+</script>
+</body>
+</html>

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -6469,6 +6469,31 @@ async fn mesh_endpoint(State(state): State<SharedState>) -> Json<serde_json::Val
     }))
 }
 
+/// `GET /api/v1/diag/mark/:label` -- stamp a labelled instant into the phase
+/// diagnostics stream.
+///
+/// Ground truth recalled after the fact is soft. The only high-provenance
+/// label of an overnight run is the one reported AS IT HAPPENS; matching a
+/// detection to a remembered time is post-hoc fitting, because during an
+/// active stretch the detector bumps every ~1.5 min and any estimate "matches"
+/// something.
+///
+/// Returns the recording-relative timestamp so a client can show what it
+/// captured, and reports plainly when diagnostics are not enabled rather than
+/// silently accepting a mark that goes nowhere.
+async fn diag_mark(axum::extract::Path(label): axum::extract::Path<String>) -> Json<serde_json::Value> {
+    match phase_diagnostics() {
+        Some(d) => {
+            let t_s = d.mark(&label);
+            Json(serde_json::json!({ "ok": true, "t_s": t_s, "label": label }))
+        }
+        None => Json(serde_json::json!({
+            "ok": false,
+            "error": "phase diagnostics not enabled; start with --phase-diagnostics <DIR>"
+        })),
+    }
+}
+
 async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
     let now = std::time::Instant::now();
@@ -9269,6 +9294,7 @@ async fn main() {
         .route("/api/v1/rf/vendors/:vendor/events", post(ingest_vendor_events))
         // Per-node health endpoint
         .route("/api/v1/nodes", get(nodes_endpoint))
+        .route("/api/v1/diag/mark/:label", get(diag_mark))
         // ADR-110 iter 29 — per-node mesh sync state for HTTP clients.
         .route("/api/v1/nodes/:id/sync", get(node_sync_endpoint))
         .route("/api/v1/mesh", get(mesh_endpoint))

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -9,6 +9,7 @@
 //! Replaces both ws_server.py and the Python HTTP server.
 #![allow(dead_code)]
 
+mod phase_diag;
 mod adaptive_classifier;
 pub mod cli;
 pub mod csi;
@@ -92,6 +93,21 @@ struct Args {
     /// HTTP port for UI and REST API
     #[arg(long, default_value = "8080")]
     http_port: u16,
+
+    /// Write phase-channel diagnostics (CSV) to this directory. Records the
+    /// common-mode phase and STO slope of every raw CSI frame *before*
+    /// sanitization, plus bounded raw-I/Q capture windows, to determine
+    /// whether single-antenna ESP32 phase can carry Doppler at all. Off by
+    /// default; adds no work to the signal path when unset. Output is
+    /// CSI-derived — never commit it (`CLAUDE.md`).
+    #[arg(long, value_name = "DIR")]
+    phase_diagnostics: Option<PathBuf>,
+    /// Record every frame to the raw phase-diagnostics sink instead of the
+    /// default duty-cycled bursts (1.4 min in every 10). Needed for a
+    /// deliberate-motion test, which the duty cycle would mostly miss. Costs
+    /// ~275 MB/hour at 3 nodes — use it for a bounded, attended experiment.
+    #[arg(long, requires = "phase_diagnostics")]
+    phase_diagnostics_continuous: bool,
 
     /// WebSocket port for sensing stream
     #[arg(long, default_value = "8765")]
@@ -2198,6 +2214,14 @@ mod issue_928_magic_collision_tests {
 }
 
 // ── ESP32 UDP frame parser ───────────────────────────────────────────────────
+
+static PHASE_DIAG: std::sync::OnceLock<Option<std::sync::Arc<phase_diag::PhaseDiagnostics>>> =
+    std::sync::OnceLock::new();
+
+/// Borrow the diagnostic sink, if one was configured.
+fn phase_diagnostics() -> Option<&'static std::sync::Arc<phase_diag::PhaseDiagnostics>> {
+    PHASE_DIAG.get().and_then(|o| o.as_ref())
+}
 
 fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
     if buf.len() < 20 {

--- a/v2/crates/wifi-densepose-sensing-server/src/phase_diag.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/phase_diag.rs
@@ -1,0 +1,600 @@
+//! Phase-channel diagnostics (2026-08-28).
+//!
+//! Purpose: decide, from real hardware, whether ESP32 single-antenna CSI phase
+//! can carry Doppler at all — the open question blocking the bistatic position
+//! tier.
+//!
+//! Background. `sanitize_phase_linear_detrend` fits `a*k + b` across
+//! subcarrier index and subtracts both. Removing the slope `a` is the intended
+//! STO/packet-timing fix; removing the intercept `b` also deletes the
+//! *common-mode* phase, which is where a moving target's Doppler lives (across
+//! HT20 at 2.4 GHz the subcarrier frequencies span only +/-0.36%, so Doppler
+//! phase is common-mode to within a third of a percent). This is proven
+//! deterministically in `phase_sanitization_annihilates_doppler_tests`.
+//!
+//! The three effects separate by which axis they vary on:
+//!
+//! | effect  | across subcarrier `k` | across time `t`     |
+//! |---------|-----------------------|---------------------|
+//! | STO     | linear ramp           | ~constant           |
+//! | CFO     | constant              | slow drift (sub-Hz) |
+//! | Doppler | constant              | 1-20 Hz             |
+//!
+//! So the correct decomposition removes the slope along `k` and the slow trend
+//! along `t`. Whether that is *achievable* depends on one measurable fact: does
+//! the per-frame common phase advance by less than pi between consecutive
+//! frames (unwrappable, so CFO is separable from Doppler), or does it wrap
+//! randomly (aliased, so single-antenna phase Doppler is impossible on this
+//! silicon)? This module measures exactly that, and nothing else.
+//!
+//! Everything here is opt-in behind `--phase-diagnostics <dir>` and does no
+//! work at all when disabled. It never alters the signal path.
+//!
+//! Output is CSI-derived and therefore MUST NOT be committed (`CLAUDE.md`).
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// Wrap a phase difference into `(-pi, pi]`.
+///
+/// Frame-to-frame common-phase deltas are only meaningful modulo `2*pi`; the
+/// whole question is whether the *wrapped* delta clusters (recoverable drift)
+/// or spreads uniformly (aliased noise).
+pub fn wrap_to_pi(x: f64) -> f64 {
+    let two_pi = 2.0 * std::f64::consts::PI;
+    let mut v = (x + std::f64::consts::PI).rem_euclid(two_pi) - std::f64::consts::PI;
+    // rem_euclid maps exactly -pi to -pi; normalize the boundary to +pi so the
+    // interval is half-open the way the doc says.
+    if v <= -std::f64::consts::PI {
+        v += two_pi;
+    }
+    v
+}
+
+/// Circular mean of a set of wrapped phases, in `(-pi, pi]`.
+///
+/// A plain arithmetic mean of `atan2` output is wrong across the +/-pi branch
+/// cut (mean of `[3.14, -3.14]` is 0, not pi). This is the common-mode phase —
+/// the intercept term the sanitizer currently destroys.
+pub fn circular_mean_phase(phases: &[f64]) -> Option<f64> {
+    if phases.is_empty() {
+        return None;
+    }
+    let (s, c) = phases.iter().fold((0.0_f64, 0.0_f64), |(s, c), &p| {
+        (s + p.sin(), c + p.cos())
+    });
+    if s.abs() < 1e-12 && c.abs() < 1e-12 {
+        return None;
+    }
+    Some(s.atan2(c))
+}
+
+/// Circular *resultant length* in `[0, 1]` — how concentrated a set of phases
+/// is. 1.0 = all identical, 0.0 = uniformly spread.
+///
+/// Applied across subcarriers within one frame this measures how common-mode
+/// that frame's phase really is (the premise of the whole fix). Applied across
+/// a window of frame-to-frame deltas it measures whether CFO is a coherent
+/// drift or aliased noise — the decisive number.
+pub fn circular_resultant_length(phases: &[f64]) -> f64 {
+    if phases.is_empty() {
+        return 0.0;
+    }
+    let (s, c) = phases.iter().fold((0.0_f64, 0.0_f64), |(s, c), &p| {
+        (s + p.sin(), c + p.cos())
+    });
+    let n = phases.len() as f64;
+    ((s / n).powi(2) + (c / n).powi(2)).sqrt().clamp(0.0, 1.0)
+}
+
+/// Ordinary-least-squares slope and intercept of `y` against its own index.
+///
+/// Same fit `sanitize_phase_linear_detrend` performs, exposed separately so a
+/// diagnostic can record the two terms *without* subtracting either. The slope
+/// is the STO artifact; the intercept is the common-mode phase.
+pub fn ols_slope_intercept(y: &[f64]) -> (f64, f64) {
+    let n = y.len() as f64;
+    if y.len() < 2 {
+        return (0.0, y.first().copied().unwrap_or(0.0));
+    }
+    let sum_k: f64 = (0..y.len()).map(|k| k as f64).sum();
+    let sum_y: f64 = y.iter().sum();
+    let sum_kk: f64 = (0..y.len()).map(|k| (k * k) as f64).sum();
+    let sum_ky: f64 = y.iter().enumerate().map(|(k, &v)| k as f64 * v).sum();
+    let denom = n * sum_kk - sum_k * sum_k;
+    if denom.abs() <= 1e-12 {
+        return (0.0, sum_y / n);
+    }
+    let a = (n * sum_ky - sum_k * sum_y) / denom;
+    let b = (sum_y - a * sum_k) / n;
+    (a, b)
+}
+
+/// Unwrap a phase sequence along time, so a slow drift becomes a straight line
+/// instead of a sawtooth. Only meaningful if consecutive deltas are `< pi` in
+/// magnitude — which is precisely what this module exists to check.
+pub fn unwrap_sequence(seq: &[f64]) -> Vec<f64> {
+    if seq.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(seq.len());
+    out.push(seq[0]);
+    for i in 1..seq.len() {
+        let d = wrap_to_pi(seq[i] - seq[i - 1]);
+        out.push(out[i - 1] + d);
+    }
+    out
+}
+
+/// Per-node running state for the diagnostic.
+#[derive(Default)]
+struct NodeDiagState {
+    /// Frames seen per transmitter MAC (wire v2 only). Bounded: a busy
+    /// channel can present many transmitters, and this is a diagnostic, not a
+    /// registry, so it stops admitting new ones past a small cap.
+    source_counts: std::collections::BTreeMap<[u8; 6], u64>,
+    prev_common_phase: Option<f64>,
+    frames: u64,
+    raw_windows_written: u64,
+    last_raw_capture: Option<Instant>,
+}
+
+/// One frame's phase-channel measurements, kept separate from the writer so it
+/// can be unit-tested without touching the filesystem.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FramePhaseStats {
+    /// Common-mode phase — the circular mean across subcarriers **after**
+    /// removing the STO slope, i.e. the intercept term the sanitizer
+    /// destroys. This must be measured on deslanted phase: a steep STO slope
+    /// wraps the raw phase several times across the band (observed 2.4 wraps
+    /// on node 0), so the circular mean of *raw* phase is the mean of a
+    /// near-uniform spread and looks like noise no matter what the underlying
+    /// common-mode term is doing.
+    pub common_phase: f64,
+    /// Circular mean of the raw, un-deslanted phase. Retained only so the
+    /// slope-contamination effect above stays visible in the data rather than
+    /// being something a future reader has to rediscover.
+    pub common_phase_raw: f64,
+    /// How common-mode this frame actually is, `[0, 1]`, after removing the
+    /// STO slope. High values confirm the premise that Doppler is nearly pure
+    /// intercept; low values would mean the phase is dominated by
+    /// across-subcarrier structure instead.
+    pub common_mode_concentration: f64,
+    /// OLS slope across subcarrier index (radians/subcarrier) — the STO term.
+    pub sto_slope: f64,
+    /// Wrapped change in `common_phase` since this node's previous frame.
+    /// `None` on the first frame. **This is the decisive series.**
+    pub d_common_phase: Option<f64>,
+    /// Mean amplitude, for correlating phase behaviour against the
+    /// known-working amplitude channel.
+    pub mean_amplitude: f64,
+}
+
+/// Compute one frame's phase statistics from raw (unsanitized) CSI.
+///
+/// `phases` must be raw `atan2(Q, I)` output, not sanitizer output — the whole
+/// point is to see the terms the sanitizer removes.
+pub fn frame_phase_stats(phases: &[f64], amplitudes: &[f64]) -> Option<FramePhaseStats> {
+    if phases.is_empty() {
+        return None;
+    }
+    let common_phase_raw = circular_mean_phase(phases)?;
+
+    // Remove only the STO slope, then measure what remains. Unwrap first so
+    // the OLS sees a line, not a sawtooth.
+    let unwrapped = unwrap_sequence(phases);
+    let (sto_slope, _) = ols_slope_intercept(&unwrapped);
+    let deslanted: Vec<f64> = unwrapped
+        .iter()
+        .enumerate()
+        .map(|(k, &v)| wrap_to_pi(v - sto_slope * k as f64))
+        .collect();
+    let common_mode_concentration = circular_resultant_length(&deslanted);
+    // The real common-mode term: circular mean of the deslanted phase.
+    let common_phase = circular_mean_phase(&deslanted).unwrap_or(common_phase_raw);
+
+    let mean_amplitude = if amplitudes.is_empty() {
+        0.0
+    } else {
+        amplitudes.iter().sum::<f64>() / amplitudes.len() as f64
+    };
+
+    Some(FramePhaseStats {
+        common_phase,
+        common_phase_raw,
+        common_mode_concentration,
+        sto_slope,
+        d_common_phase: None,
+        mean_amplitude,
+    })
+}
+
+/// How often to open a bounded raw-I/Q capture window.
+const RAW_CAPTURE_PERIOD_SECS: u64 = 600;
+/// How many frames per node each raw capture window retains. At ~48 fps this
+/// is ~60 s, bounding overnight raw output to a few hundred MB while still
+/// giving enough contiguous samples to test candidate sanitizers offline.
+const RAW_CAPTURE_FRAMES: u64 = 3000;
+
+/// Buffered CSV/raw sinks for the phase diagnostic. Cheap to construct,
+/// disabled entirely when `--phase-diagnostics` is absent.
+pub struct PhaseDiagnostics {
+    stats: Mutex<BufWriter<File>>,
+    raw: Mutex<BufWriter<File>>,
+    /// Operator-supplied ground-truth markers ("now standing at node 0"),
+    /// written on the same `t_s` clock as the other two sinks so a walk test
+    /// can be aligned against the signal without guessing timings.
+    markers: Mutex<BufWriter<File>>,
+    nodes: Mutex<std::collections::HashMap<u8, NodeDiagState>>,
+    started: Instant,
+    /// When true, every frame is written to the raw sink instead of the
+    /// duty-cycled burst pattern. Needed for a deliberate-motion test: the
+    /// default 1.4-min-in-10 duty cycle samples only ~14% of the time and will
+    /// miss most of a short walk.
+    continuous_raw: bool,
+}
+
+impl PhaseDiagnostics {
+    /// Create the output files under `dir`, which is created if missing.
+    ///
+    /// `continuous_raw` disables raw duty-cycling — use it for a bounded,
+    /// attended experiment, not an overnight run (~275 MB/hour at 3 nodes).
+    pub fn new_with_mode(dir: &Path, continuous_raw: bool) -> std::io::Result<Self> {
+        let mut s = Self::new(dir)?;
+        s.continuous_raw = continuous_raw;
+        if continuous_raw {
+            tracing::info!("phase diagnostics: CONTINUOUS raw capture (~275 MB/hour)");
+        }
+        Ok(s)
+    }
+
+    /// Record an operator ground-truth marker at the current `t_s`.
+    pub fn mark(&self, label: &str) -> f64 {
+        let t_s = Instant::now().duration_since(self.started).as_secs_f64();
+        // Labels arrive from an HTTP path segment; keep the CSV parseable by
+        // stripping separators and bounding the length rather than trusting it.
+        let safe: String = label
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+            .take(64)
+            .collect();
+        if let Ok(mut w) = self.markers.lock() {
+            let _ = writeln!(w, "{t_s:.4},{safe}");
+            let _ = w.flush();
+        }
+        tracing::info!("phase diagnostics marker: t_s={t_s:.2} label={safe}");
+        t_s
+    }
+
+    /// Create the two output files under `dir`, which is created if missing.
+    pub fn new(dir: &Path) -> std::io::Result<Self> {
+        std::fs::create_dir_all(dir)?;
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let stats_path: PathBuf = dir.join(format!("phase_stats_{stamp}.csv"));
+        let raw_path: PathBuf = dir.join(format!("phase_raw_{stamp}.csv"));
+
+        let mut stats = BufWriter::new(File::create(&stats_path)?);
+        writeln!(
+            stats,
+            "t_s,node,seq,n_sc,src,common_phase,d_common_phase,common_phase_raw,\
+             common_mode_concentration,sto_slope,mean_amplitude"
+        )?;
+        let mut raw = BufWriter::new(File::create(&raw_path)?);
+        writeln!(raw, "t_s,node,seq,n_sc,phases_rad,amplitudes")?;
+        let markers_path: PathBuf = dir.join(format!("phase_markers_{stamp}.csv"));
+        let mut markers = BufWriter::new(File::create(&markers_path)?);
+        writeln!(markers, "t_s,label")?;
+
+        tracing::info!(
+            "phase diagnostics enabled: stats={} raw={}",
+            stats_path.display(),
+            raw_path.display()
+        );
+
+        Ok(Self {
+            stats: Mutex::new(stats),
+            raw: Mutex::new(raw),
+            markers: Mutex::new(markers),
+            nodes: Mutex::new(std::collections::HashMap::new()),
+            started: Instant::now(),
+            continuous_raw: false,
+        })
+    }
+
+    /// Record one raw CSI frame. Called from the ingestion site *before*
+    /// sanitization. Never panics and never propagates an I/O error into the
+    /// signal path — a failed diagnostic write must not take down sensing.
+    /// Per-node tally of how many frames arrived from each transmitter.
+    ///
+    /// Only populated from wire v2 frames, which carry the transmitter MAC.
+    /// This is the cheap answer to "what is this node actually listening to" —
+    /// a question that previously required a serial console and a firmware
+    /// read of `info->mac`.
+    pub fn source_census(&self) -> Vec<(u8, [u8; 6], u64)> {
+        let nodes = self.nodes.lock().unwrap_or_else(|e| e.into_inner());
+        let mut out = Vec::new();
+        for (&id, st) in nodes.iter() {
+            for (mac, count) in &st.source_counts {
+                out.push((id, *mac, *count));
+            }
+        }
+        out.sort_unstable_by(|a, b| a.0.cmp(&b.0).then(b.2.cmp(&a.2)));
+        out
+    }
+
+    pub fn observe_frame(
+        &self,
+        node_id: u8,
+        sequence: u32,
+        source_mac: Option<[u8; 6]>,
+        phases: &[f64],
+        amplitudes: &[f64],
+    ) {
+        let Some(mut s) = frame_phase_stats(phases, amplitudes) else {
+            return;
+        };
+        let now = Instant::now();
+        let t_s = now.duration_since(self.started).as_secs_f64();
+
+        let (capture_raw, frames) = {
+            let mut nodes = self.nodes.lock().unwrap_or_else(|e| e.into_inner());
+            let st = nodes.entry(node_id).or_default();
+            // Must run in every mode: the frame-to-frame common-phase delta is
+            // the primary series, and it depends on per-node carry-over state.
+            if let Some(mac) = source_mac {
+                const MAX_TRACKED_SOURCES: usize = 16;
+                if st.source_counts.len() < MAX_TRACKED_SOURCES
+                    || st.source_counts.contains_key(&mac)
+                {
+                    *st.source_counts.entry(mac).or_insert(0) += 1;
+                }
+            }
+            s.d_common_phase = st.prev_common_phase.map(|p| wrap_to_pi(s.common_phase - p));
+            st.prev_common_phase = Some(s.common_phase);
+            st.frames += 1;
+
+            if self.continuous_raw {
+                (true, st.frames)
+            } else {
+
+            let window_open = match st.last_raw_capture {
+                None => true,
+                Some(t) => {
+                    now.duration_since(t).as_secs() >= RAW_CAPTURE_PERIOD_SECS
+                        && st.raw_windows_written == 0
+                }
+            };
+            if window_open && st.raw_windows_written == 0 {
+                st.last_raw_capture = Some(now);
+            }
+            // Capture a bounded burst of contiguous frames, then idle until the
+            // next period. Contiguity matters: offline sanitizer experiments
+            // need consecutive frames, not a scattered sample.
+            let within_burst = st
+                .last_raw_capture
+                .is_some_and(|t| now.duration_since(t).as_secs() < 90)
+                && st.raw_windows_written < RAW_CAPTURE_FRAMES;
+            if within_burst {
+                st.raw_windows_written += 1;
+            } else if st
+                .last_raw_capture
+                .is_some_and(|t| now.duration_since(t).as_secs() >= RAW_CAPTURE_PERIOD_SECS)
+            {
+                st.last_raw_capture = Some(now);
+                st.raw_windows_written = 0;
+            }
+            (within_burst, st.frames)
+            }
+        };
+        let _ = frames;
+
+        if let Ok(mut w) = self.stats.lock() {
+            let d = s
+                .d_common_phase
+                .map(|v| format!("{v:.6}"))
+                .unwrap_or_default();
+            // Compact transmitter id: last 3 octets are enough to tell the AP
+            // from peer nodes and neighbours, and keep the row narrow.
+            let src = source_mac
+                .map(|m| format!("{:02x}{:02x}{:02x}", m[3], m[4], m[5]))
+                .unwrap_or_else(|| "-".to_string());
+            let _ = writeln!(
+                w,
+                "{t_s:.4},{node_id},{sequence},{},{src},{:.6},{d},{:.6},{:.6},{:.9},{:.4}",
+                phases.len(),
+                s.common_phase,
+                s.common_phase_raw,
+                s.common_mode_concentration,
+                s.sto_slope,
+                s.mean_amplitude
+            );
+        }
+
+        if capture_raw {
+            if let Ok(mut w) = self.raw.lock() {
+                let p: Vec<String> = phases.iter().map(|v| format!("{v:.5}")).collect();
+                let a: Vec<String> = amplitudes.iter().map(|v| format!("{v:.2}")).collect();
+                let _ = writeln!(
+                    w,
+                    "{t_s:.4},{node_id},{sequence},{},{},{}",
+                    phases.len(),
+                    p.join(" "),
+                    a.join(" ")
+                );
+            }
+        }
+    }
+
+    /// Flush both sinks. Called periodically so an overnight run's data is on
+    /// disk even if the process is killed rather than shut down cleanly.
+    pub fn flush(&self) {
+        if let Ok(mut w) = self.stats.lock() {
+            let _ = w.flush();
+        }
+        if let Ok(mut w) = self.raw.lock() {
+            let _ = w.flush();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::PI;
+
+    /// The CSV header and the data rows are written by two separate format
+    /// strings, and they have drifted apart twice during development (a column
+    /// added to one and not the other), producing a file whose values silently
+    /// land under the wrong column names. Anything analysing that file reads
+    /// the wrong series and reaches confident, wrong conclusions.
+    #[test]
+    fn stats_header_and_rows_have_the_same_column_count() {
+        let dir = std::env::temp_dir().join(format!(
+            "ruview_phase_diag_hdr_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let d = PhaseDiagnostics::new(&dir).expect("create sinks");
+        let phases: Vec<f64> = (0..56).map(|k| 0.01 * k as f64).collect();
+        let amps = vec![10.0_f64; 56];
+        d.observe_frame(1, 7, Some([1, 2, 3, 4, 5, 6]), &phases, &amps);
+        d.observe_frame(1, 8, Some([1, 2, 3, 4, 5, 6]), &phases, &amps);
+        d.flush();
+
+        let stats = std::fs::read_dir(&dir)
+            .expect("read dir")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .find(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("phase_stats_"))
+            })
+            .expect("stats file exists");
+        let text = std::fs::read_to_string(&stats).expect("read stats");
+        let mut lines = text.lines();
+        let header = lines.next().expect("header line");
+        let header_cols = header.split(',').count();
+        let mut rows = 0;
+        for row in lines.filter(|l| !l.trim().is_empty()) {
+            rows += 1;
+            assert_eq!(
+                row.split(',').count(),
+                header_cols,
+                "row has a different column count than the header\n header: {header}\n row:    {row}"
+            );
+        }
+        assert!(rows > 0, "expected at least one data row");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn wrap_to_pi_maps_into_half_open_interval() {
+        assert!((wrap_to_pi(0.0) - 0.0).abs() < 1e-12);
+        assert!((wrap_to_pi(3.0 * PI) - PI).abs() < 1e-9);
+        assert!((wrap_to_pi(-3.0 * PI) - PI).abs() < 1e-9);
+        assert!((wrap_to_pi(PI + 0.1) - (-PI + 0.1)).abs() < 1e-9);
+        for &x in &[0.5, -0.5, 1.0, -3.0, 12.7, -12.7] {
+            let w = wrap_to_pi(x);
+            assert!(w > -PI - 1e-12 && w <= PI + 1e-12, "{x} wrapped to {w}");
+        }
+    }
+
+    #[test]
+    fn circular_mean_handles_the_branch_cut() {
+        // Arithmetic mean of these is 0.0, which is wrong by pi.
+        let m = circular_mean_phase(&[PI - 0.01, -PI + 0.01]).expect("defined");
+        assert!(m.abs() > 3.0, "expected ~pi, got {m}");
+    }
+
+    #[test]
+    fn resultant_length_is_one_for_identical_and_near_zero_for_spread() {
+        assert!((circular_resultant_length(&[0.7; 32]) - 1.0).abs() < 1e-12);
+        let spread: Vec<f64> = (0..64).map(|i| -PI + 2.0 * PI * i as f64 / 64.0).collect();
+        assert!(
+            circular_resultant_length(&spread) < 0.05,
+            "uniform phases must have near-zero resultant length"
+        );
+    }
+
+    #[test]
+    fn ols_recovers_a_known_line() {
+        let y: Vec<f64> = (0..40).map(|k| 0.25 * k as f64 - 1.5).collect();
+        let (a, b) = ols_slope_intercept(&y);
+        assert!((a - 0.25).abs() < 1e-9, "slope {a}");
+        assert!((b + 1.5).abs() < 1e-9, "intercept {b}");
+    }
+
+    #[test]
+    fn unwrap_recovers_a_ramp_that_crosses_the_branch_cut() {
+        let step = 0.4_f64;
+        let wrapped: Vec<f64> = (0..50).map(|i| wrap_to_pi(step * i as f64)).collect();
+        let un = unwrap_sequence(&wrapped);
+        for i in 1..un.len() {
+            assert!(
+                (un[i] - un[i - 1] - step).abs() < 1e-9,
+                "unwrapped step {i} was {}",
+                un[i] - un[i - 1]
+            );
+        }
+    }
+
+    /// The premise of the proposed fix: a Doppler shift is common-mode across
+    /// subcarriers, so after removing the STO slope the residual phase is
+    /// highly concentrated. If real hardware reports low concentration, the
+    /// common-mode model itself is wrong and the fix would not apply.
+    #[test]
+    fn physically_modelled_frame_is_highly_common_mode_after_deslanting() {
+        const N: usize = 56;
+        const F_C: f64 = 2.412e9;
+        const SPACING: f64 = 312.5e3;
+        let tau_sto = 50e-9;
+        let tau_dyn = 0.02 / 2.998e8;
+        let phases: Vec<f64> = (0..N)
+            .map(|i| {
+                let k = i as f64 - (N as f64 - 1.0) / 2.0;
+                let f_k = F_C + k * SPACING;
+                wrap_to_pi(-2.0 * PI * f_k * (tau_sto + tau_dyn))
+            })
+            .collect();
+        let amps = vec![10.0; N];
+        let s = frame_phase_stats(&phases, &amps).expect("stats defined");
+        assert!(
+            s.common_mode_concentration > 0.95,
+            "after removing the STO slope a real frame should be near-pure common mode, \
+             concentration was {}",
+            s.common_mode_concentration
+        );
+    }
+
+    /// Sanity check on the decisive metric: a coherent slow drift produces
+    /// tightly clustered frame-to-frame deltas, while uniform random phase
+    /// produces spread ones. This is exactly the discrimination the overnight
+    /// run performs on real data.
+    #[test]
+    fn delta_concentration_separates_coherent_drift_from_random_phase() {
+        let drift: Vec<f64> = (0..500).map(|_| 0.12_f64).collect();
+        assert!(circular_resultant_length(&drift) > 0.99);
+
+        // Deterministic pseudo-random spread, no rand dependency.
+        let mut x = 12345u64;
+        let random: Vec<f64> = (0..500)
+            .map(|_| {
+                x = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                let u = (x >> 11) as f64 / (1u64 << 53) as f64;
+                -PI + 2.0 * PI * u
+            })
+            .collect();
+        assert!(
+            circular_resultant_length(&random) < 0.2,
+            "aliased phase must not look like coherent drift"
+        );
+    }
+}


### PR DESCRIPTION
Adds the per-location tapper: stand near a node, tap its button, and the label
is stamped into the recording as it happens rather than recalled afterwards.

Built entirely from /api/v1/nodes at load. One button per node the server
actually knows about, sorted by id and labelled "Node 1", "Node 2" and so on,
so the page suits a fleet of three or thirty with no editing. Node identity is
the only spatial reference: no floor plan, no coordinates, nothing tied to one
building.

Two generic places sit alongside the nodes. A fleet never covers every space,
and the uncovered ones need ground truth arguably more than the rest, precisely
because nothing there is measuring.

An unreachable server or an empty roster is reported as such and leaves the
generic places usable. It never guesses at node ids -- invented ones would
attach marks to nodes that do not exist, which is worse than no mark.

Occupancy is recorded by ROLE, never by person: adult1, adult2, child1,
children-together, everyone. Ground truth outlives the run it was captured in,
so it should not carry anyone's name.

Marks are written twice, to the server sink and to localStorage, because losing
ground truth means re-walking everything.

---

Rebased onto current `main` before opening: staged before today's seven merges, so it needed replaying to avoid reading as a revert of them. Clean rebase, no files deleted.