### PR TITLE
Persist a safe empty room bootstrap prior

### DIFF
--- a/docs/adr/ADR-355-local-empty-room-bootstrap-prior.md
+++ b/docs/adr/ADR-355-local-empty-room-bootstrap-prior.md
@@ -1,0 +1,82 @@
+# ADR 355: Local empty room bootstrap prior
+
+Status: Accepted
+
+Date: 2026-09-04
+
+## Context
+
+Most installations are occupied when RuView first starts. An uncalibrated
+signal heuristic can interpret HVAC, clock error, neighboring motion, or a
+short covariance window as a person. It can also surface plausible numeric
+vitals before a room model establishes occupant attribution.
+
+One empty home is not representative training data for all homes and contains
+no positive human examples. It is useful only as a recent negative prior for
+the same installation. It cannot define a universal human signal model.
+
+The field model was memory only. The server also used a relative `data/`
+directory, which is unreliable for embedded application hosts.
+
+## Decision
+
+RuView may persist a completed empty room field model as a local bootstrap
+prior only after two server controlled stages:
+
+1. Normal calibration reaches both 12,000 accepted frames and 600 seconds.
+2. Promotion observes 12 new one second samples. At least 10 must resolve
+   empty, all ticks must be fresh, and none may publish numeric vital signs.
+
+The stored image contains aggregate means, environmental modes, mode energies,
+noise statistics, configuration, contributing node IDs, and a server generated
+model ID. It excludes raw CSI, waveforms, device addresses, room names, pose,
+identity, credentials, and positive human labels.
+
+The image is bound to a SHA 256 digest of the stable installation ID, carries
+an integrity digest, is capped at 1 MiB, and inherits the field model expiry.
+Files with an invalid schema, dimensions, values, node set, installation
+binding, digest, size, or lifetime fail closed.
+
+Restoring an image creates a field model in `bootstrap_only` mode. It may
+reduce an uncalibrated false person count, but it cannot authorize calibrated
+evidence or numeric heart and breathing rates. Explicit calibration replaces
+it with fresh statistics. Cancelling an unfinished capture restores a valid
+prior. Administrator scoped reset removes it.
+
+The server accepts `--data-dir` or `RUVIEW_DATA_DIR`, allowing an application
+host to provide a protected state directory.
+
+## Consequences
+
+Startup can use recent measured background structure instead of only generic
+heuristics. No accuracy lift is claimed until occupied and empty held out data
+from multiple installations is recorded.
+
+The largest failure mode is overfitting to a temporarily quiet home and
+suppressing a weak occupant. Controls are low authority, 24 hour expiry,
+installation binding, vital abstention, explicit recalibration, and reset.
+
+A human signal model still requires positive, consented, leakage separated
+occupied sequences. Empty data is never relabeled as human training.
+
+## Implementation
+
+1. `wifi-densepose-signal::ruvsense::field_model` exports and validates
+   `FieldModelSnapshotV1`.
+2. `wifi-densepose-sensing-server::bootstrap_baseline` owns schema, integrity,
+   storage, lifetime, and the held out gate.
+3. `POST /api/v1/calibration/bootstrap/promote` measures the validation window
+   and stores the image only on pass.
+4. `GET /api/v1/calibration/status` reports bootstrap authority and explicitly
+   denies calibrated evidence and numeric vital authority.
+5. Numeric vitals fail closed unless an explicit fresh calibration resolves
+   exactly one occupant at sufficient signal quality and confidence.
+
+## Acceptance test
+
+With a physically empty room, complete calibration on stable nodes, promote
+the model, and restart the server with the same installation ID and data
+directory. Status must report `binding_mode=bootstrap_only`, zero collection
+frames, and false authority for calibrated evidence and numeric vitals. Twelve
+fresh empty samples must contain no numeric vital signs. Starting a new room
+calibration must replace the prior and begin at frame zero.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,6 +96,7 @@ Statuses: **Proposed** (under discussion), **Accepted** (approved and/or impleme
 | [ADR-349](ADR-349-governed-local-and-fal-forecast-training.md) | Governed local and fal.ai forecast training | Proposed |
 | [ADR-350](ADR-350-ruvector-predictive-memory-and-ruvllm-boundary.md) | RuVector predictive memory and RuVLLM authority boundary | Proposed |
 | [ADR-354](ADR-354-forecast-governance-enforcement-in-ruforecast-submodule.md) | fal.ai forecast governance and spend enforcement now real, in the vendored RuForecast submodule | Accepted |
+| [ADR-355](ADR-355-local-empty-room-bootstrap-prior.md) | Local empty room bootstrap prior | Accepted |
 
 ### Platform and UI
 

--- a/v2/crates/wifi-densepose-sensing-server/README.md
+++ b/v2/crates/wifi-densepose-sensing-server/README.md
@@ -43,6 +43,8 @@ per ADR-022 Phase 3.
 - **WebSocket broadcast** -- Real-time sensing updates pushed to all connected clients at
   `ws://localhost:8765/ws/sensing`.
 - **Static file serving** -- Hosts the sensing UI on port 8080 with CORS headers.
+- **Private startup baseline** -- Restores a recent, installation-bound empty-room field model
+  without storing raw CSI or authorizing numeric vital signs (ADR-355).
 
 ## Modules
 
@@ -73,6 +75,23 @@ cargo run -p wifi-densepose-sensing-server -- \
     --udp-port 5005 \
     --static-dir ./ui
 ```
+
+### Empty-room startup baseline
+
+Provide a stable installation ID and an application-owned private state directory:
+
+```bash
+cargo run -p wifi-densepose-sensing-server -- \
+    --installation-id installation-01 \
+    --data-dir /path/to/private/application-state
+```
+
+Complete the normal empty-room calibration, then call
+`POST /api/v1/calibration/bootstrap/promote`. The server measures a separate 12-sample holdout
+before storing an aggregate field-model snapshot. On a later start with the same installation ID,
+the snapshot is restored with `bootstrap_only` authority. It can reduce startup background false
+positives, but cannot authorize calibrated evidence or numeric heart and breathing rates. Use
+`POST /api/v1/calibration/reset` with administrator scope to remove it.
 
 ### Using as a library
 

--- a/v2/crates/wifi-densepose-sensing-server/src/bearer_auth.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/bearer_auth.rs
@@ -491,6 +491,10 @@ const READ_SAFE_MUTATIONS: &[&str] = &[
     // Capture and calibration: create data, never destroy it.
     "/api/v1/calibration/start",
     "/api/v1/calibration/stop",
+    // Promotion consumes only server measured held out evidence and stores a
+    // bounded privacy reduced prior. Cancel discards only an unfinished run.
+    "/api/v1/calibration/bootstrap/promote",
+    "/api/v1/calibration/cancel",
     "/api/v1/pose/calibrate",
     "/api/v1/recording/start",
     "/api/v1/recording/stop",
@@ -1970,6 +1974,7 @@ mod scope_gate_polarity_tests {
             (Method::DELETE, "/api/v1/models/m1"),
             (Method::DELETE, "/api/v1/recording/r1"),
             (Method::POST, "/api/v1/config/ground-truth"),
+            (Method::POST, "/api/v1/calibration/reset"),
         ] {
             assert_eq!(
                 required_scope_for(&m, p),

--- a/v2/crates/wifi-densepose-sensing-server/src/bootstrap_baseline.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/bootstrap_baseline.rs
@@ -1,0 +1,388 @@
+//! Local, privacy reduced empty room bootstrap model persistence.
+//!
+//! A bootstrap image is deliberately lower authority than a completed room
+//! calibration. It can suppress background perturbations while the server
+//! starts, but restoring it never authorizes calibrated evidence or vitals.
+
+use rand::{rngs::OsRng, RngCore};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use wifi_densepose_signal::ruvsense::field_model::{
+    FieldModel, FieldModelError, FieldModelSnapshotV1,
+};
+
+pub const BOOTSTRAP_BASELINE_SCHEMA: &str = "ruview.bootstrap-empty-field-model.v1";
+pub const BOOTSTRAP_BASELINE_AUTHORITY: &str = "bootstrap_only";
+pub const BOOTSTRAP_VALIDATION_SAMPLES: usize = 12;
+pub const BOOTSTRAP_VALIDATION_MIN_EMPTY: usize = 10;
+const BOOTSTRAP_MAX_FILE_BYTES: u64 = 1_048_576;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct BootstrapPayloadV1 {
+    schema: String,
+    authority: String,
+    installation_binding_sha256: String,
+    source_node_ids: Vec<u8>,
+    source_model_id: String,
+    created_at_unix_ms: u64,
+    expires_at_unix_ms: u64,
+    field_model: FieldModelSnapshotV1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct BootstrapImageV1 {
+    payload: BootstrapPayloadV1,
+    content_sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BootstrapBaselineMetadata {
+    pub authority: &'static str,
+    pub source_node_ids: Vec<u8>,
+    pub source_model_id: String,
+    pub created_at_unix_ms: u64,
+    pub expires_at_unix_ms: u64,
+    pub content_sha256: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BootstrapValidationSample {
+    pub fresh_tick: bool,
+    pub calibrated_empty: bool,
+    pub vital_signs_absent: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct BootstrapValidationResult {
+    pub sample_count: usize,
+    pub empty_sample_count: usize,
+    pub stale_sample_count: usize,
+    pub vital_sign_sample_count: usize,
+    pub passed: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum BootstrapBaselineError {
+    #[error("a stable installation_id is required for a local bootstrap baseline")]
+    MissingInstallationId,
+    #[error("bootstrap baseline path is invalid")]
+    InvalidPath,
+    #[error("bootstrap baseline file is too large")]
+    FileTooLarge,
+    #[error("bootstrap baseline image is malformed: {0}")]
+    Malformed(String),
+    #[error("bootstrap baseline belongs to another installation")]
+    InstallationMismatch,
+    #[error("bootstrap baseline has expired")]
+    Expired,
+    #[error("bootstrap baseline digest does not verify")]
+    DigestMismatch,
+    #[error("field model snapshot is invalid: {0}")]
+    FieldModel(#[from] FieldModelError),
+    #[error("bootstrap baseline storage failed: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("bootstrap baseline serialization failed: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+pub fn path_in(data_dir: &Path) -> PathBuf {
+    data_dir.join("calibration").join("bootstrap-empty-v1.json")
+}
+
+pub fn installation_binding(installation_id: &str) -> Result<String, BootstrapBaselineError> {
+    let installation_id = installation_id.trim();
+    if installation_id.is_empty() || installation_id.len() > 128 {
+        return Err(BootstrapBaselineError::MissingInstallationId);
+    }
+    Ok(hex_sha256(installation_id.as_bytes()))
+}
+
+pub fn evaluate_validation(samples: &[BootstrapValidationSample]) -> BootstrapValidationResult {
+    let empty_sample_count = samples
+        .iter()
+        .filter(|sample| sample.fresh_tick && sample.calibrated_empty)
+        .count();
+    let stale_sample_count = samples.iter().filter(|sample| !sample.fresh_tick).count();
+    let vital_sign_sample_count = samples
+        .iter()
+        .filter(|sample| !sample.vital_signs_absent)
+        .count();
+    BootstrapValidationResult {
+        sample_count: samples.len(),
+        empty_sample_count,
+        stale_sample_count,
+        vital_sign_sample_count,
+        passed: samples.len() == BOOTSTRAP_VALIDATION_SAMPLES
+            && empty_sample_count >= BOOTSTRAP_VALIDATION_MIN_EMPTY
+            && stale_sample_count == 0
+            && vital_sign_sample_count == 0,
+    }
+}
+
+pub fn store(
+    path: &Path,
+    installation_id: &str,
+    source_node_ids: &[u8],
+    source_model_id: &str,
+    created_at_unix_ms: u64,
+    field_model: &FieldModel,
+) -> Result<BootstrapBaselineMetadata, BootstrapBaselineError> {
+    let snapshot = field_model.export_snapshot()?;
+    let calibrated_at_ms = snapshot.modes.calibrated_at_us / 1_000;
+    let expiry_ms = (snapshot.config.baseline_expiry_s * 1_000.0) as u64;
+    let payload = BootstrapPayloadV1 {
+        schema: BOOTSTRAP_BASELINE_SCHEMA.to_string(),
+        authority: BOOTSTRAP_BASELINE_AUTHORITY.to_string(),
+        installation_binding_sha256: installation_binding(installation_id)?,
+        source_node_ids: source_node_ids.to_vec(),
+        source_model_id: source_model_id.to_string(),
+        created_at_unix_ms,
+        expires_at_unix_ms: calibrated_at_ms.saturating_add(expiry_ms),
+        field_model: snapshot,
+    };
+    validate_payload(&payload, installation_id, created_at_unix_ms)?;
+    let content_sha256 = payload_digest(&payload)?;
+    let image = BootstrapImageV1 {
+        payload,
+        content_sha256,
+    };
+    let bytes = serde_json::to_vec(&image)?;
+    if bytes.len() as u64 > BOOTSTRAP_MAX_FILE_BYTES {
+        return Err(BootstrapBaselineError::FileTooLarge);
+    }
+    atomic_write_private(path, &bytes)?;
+    Ok(metadata(&image))
+}
+
+pub fn load(
+    path: &Path,
+    installation_id: &str,
+    current_unix_ms: u64,
+) -> Result<(FieldModel, BootstrapBaselineMetadata), BootstrapBaselineError> {
+    let file_metadata = fs::symlink_metadata(path)?;
+    if file_metadata.file_type().is_symlink() || !file_metadata.is_file() {
+        return Err(BootstrapBaselineError::InvalidPath);
+    }
+    if file_metadata.len() > BOOTSTRAP_MAX_FILE_BYTES {
+        return Err(BootstrapBaselineError::FileTooLarge);
+    }
+    let mut bytes = Vec::with_capacity(file_metadata.len() as usize);
+    OpenOptions::new()
+        .read(true)
+        .open(path)?
+        .take(BOOTSTRAP_MAX_FILE_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > BOOTSTRAP_MAX_FILE_BYTES {
+        return Err(BootstrapBaselineError::FileTooLarge);
+    }
+    let image: BootstrapImageV1 = serde_json::from_slice(&bytes)?;
+    validate_payload(&image.payload, installation_id, current_unix_ms)?;
+    if payload_digest(&image.payload)? != image.content_sha256 {
+        return Err(BootstrapBaselineError::DigestMismatch);
+    }
+    let model = FieldModel::from_snapshot(
+        image.payload.field_model.clone(),
+        current_unix_ms.saturating_mul(1_000),
+    )?;
+    Ok((model, metadata(&image)))
+}
+
+pub fn remove(path: &Path) -> Result<bool, BootstrapBaselineError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(BootstrapBaselineError::InvalidPath);
+            }
+            fs::remove_file(path)?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn validate_payload(
+    payload: &BootstrapPayloadV1,
+    installation_id: &str,
+    current_unix_ms: u64,
+) -> Result<(), BootstrapBaselineError> {
+    if payload.schema != BOOTSTRAP_BASELINE_SCHEMA
+        || payload.authority != BOOTSTRAP_BASELINE_AUTHORITY
+        || payload.source_model_id.is_empty()
+        || payload.source_model_id.len() > 128
+        || payload.source_node_ids.is_empty()
+        || payload.source_node_ids.len() > 16
+        || payload
+            .source_node_ids
+            .windows(2)
+            .any(|pair| pair[0] >= pair[1])
+        || payload.created_at_unix_ms == 0
+        || payload.expires_at_unix_ms <= payload.created_at_unix_ms
+    {
+        return Err(BootstrapBaselineError::Malformed(
+            "invalid schema, authority, identity, node set, or lifetime".into(),
+        ));
+    }
+    if payload.installation_binding_sha256 != installation_binding(installation_id)? {
+        return Err(BootstrapBaselineError::InstallationMismatch);
+    }
+    if current_unix_ms > payload.expires_at_unix_ms {
+        return Err(BootstrapBaselineError::Expired);
+    }
+    Ok(())
+}
+
+fn payload_digest(payload: &BootstrapPayloadV1) -> Result<String, serde_json::Error> {
+    Ok(hex_sha256(&serde_json::to_vec(payload)?))
+}
+
+fn metadata(image: &BootstrapImageV1) -> BootstrapBaselineMetadata {
+    BootstrapBaselineMetadata {
+        authority: BOOTSTRAP_BASELINE_AUTHORITY,
+        source_node_ids: image.payload.source_node_ids.clone(),
+        source_model_id: image.payload.source_model_id.clone(),
+        created_at_unix_ms: image.payload.created_at_unix_ms,
+        expires_at_unix_ms: image.payload.expires_at_unix_ms,
+        content_sha256: image.content_sha256.clone(),
+    }
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn atomic_write_private(path: &Path, bytes: &[u8]) -> Result<(), BootstrapBaselineError> {
+    let parent = path.parent().ok_or(BootstrapBaselineError::InvalidPath)?;
+    fs::create_dir_all(parent)?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or(BootstrapBaselineError::InvalidPath)?;
+    let mut nonce = [0_u8; 8];
+    OsRng.fill_bytes(&mut nonce);
+    let temporary = parent.join(format!(
+        ".{file_name}.{:016x}.tmp",
+        u64::from_le_bytes(nonce)
+    ));
+
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let write_result = (|| -> Result<(), std::io::Error> {
+        let mut file = options.open(&temporary)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    write_result.map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wifi_densepose_signal::ruvsense::field_model::FieldModelConfig;
+
+    fn completed_model(now_us: u64) -> FieldModel {
+        let mut model = FieldModel::new(FieldModelConfig {
+            n_links: 1,
+            n_subcarriers: 4,
+            n_modes: 2,
+            min_calibration_frames: 3,
+            min_calibration_duration_s: 0.0,
+            baseline_expiry_s: 3_600.0,
+        })
+        .unwrap();
+        for index in 0..3 {
+            model
+                .feed_calibration(&[vec![1.0 + index as f64, 2.0, 3.0, 4.0]])
+                .unwrap();
+        }
+        model.finalize_calibration(now_us, 7).unwrap();
+        model
+    }
+
+    #[test]
+    fn round_trip_is_installation_bound_and_contains_no_raw_frames() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = path_in(dir.path());
+        let now_ms = 1_000_000;
+        let model = completed_model(now_ms * 1_000);
+        let stored = store(&path, "home-a", &[5], "model", now_ms, &model).unwrap();
+        let text = String::from_utf8(fs::read(&path).unwrap()).unwrap();
+        assert!(!text.contains("home-a"));
+        assert!(!text.contains("raw_csi"));
+
+        let (restored, loaded) = load(&path, "home-a", now_ms + 1).unwrap();
+        assert_eq!(stored, loaded);
+        assert_eq!(
+            restored.export_snapshot().unwrap(),
+            model.export_snapshot().unwrap()
+        );
+        assert!(matches!(
+            load(&path, "home-b", now_ms + 1),
+            Err(BootstrapBaselineError::InstallationMismatch)
+        ));
+    }
+
+    #[test]
+    fn tamper_and_expiry_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = path_in(dir.path());
+        let now_ms = 1_000_000;
+        let model = completed_model(now_ms * 1_000);
+        store(&path, "home-a", &[5], "model", now_ms, &model).unwrap();
+
+        let mut image: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        image["payload"]["source_model_id"] = serde_json::json!("forged");
+        fs::write(&path, serde_json::to_vec(&image).unwrap()).unwrap();
+        assert!(matches!(
+            load(&path, "home-a", now_ms + 1),
+            Err(BootstrapBaselineError::DigestMismatch)
+        ));
+
+        store(&path, "home-a", &[5], "model", now_ms, &model).unwrap();
+        assert!(matches!(
+            load(&path, "home-a", now_ms + 3_600_001),
+            Err(BootstrapBaselineError::Expired)
+                | Err(BootstrapBaselineError::FieldModel(
+                    FieldModelError::BaselineExpired { .. }
+                ))
+        ));
+    }
+
+    #[test]
+    fn promotion_gate_requires_twelve_fresh_samples_and_zero_vitals() {
+        let passing = vec![
+            BootstrapValidationSample {
+                fresh_tick: true,
+                calibrated_empty: true,
+                vital_signs_absent: true,
+            };
+            BOOTSTRAP_VALIDATION_SAMPLES
+        ];
+        assert!(evaluate_validation(&passing).passed);
+
+        let mut stale = passing.clone();
+        stale[0].fresh_tick = false;
+        assert!(!evaluate_validation(&stale).passed);
+        let mut vital = passing;
+        vital[0].vital_signs_absent = false;
+        assert!(!evaluate_validation(&vital).passed);
+    }
+}

--- a/v2/crates/wifi-densepose-sensing-server/src/lib.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/lib.rs
@@ -9,6 +9,7 @@
 //! - Real-time CSI introspection / low-latency tap (`introspection`, ADR-099)
 
 pub mod bearer_auth;
+pub mod bootstrap_baseline;
 pub mod browser_session;
 pub mod ws_ticket;
 pub mod cli;

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -39,11 +39,15 @@ use wifi_densepose_sensing_server::{
     dataset, embedding, error_response, graph_transformer, rufield_surface, semconv, telemetry,
     trainer,
 };
+use wifi_densepose_sensing_server::bootstrap_baseline::{
+    self, BootstrapBaselineMetadata, BootstrapValidationSample, BOOTSTRAP_VALIDATION_SAMPLES,
+};
 // ADR-295 / ADR-297: canonical provenance state + per-node/room inference.
 use wifi_densepose_sensing_server::inference::{fuse_room, NodeInference, RoomInference};
 use wifi_densepose_sensing_server::provenance::SourceState;
 
 use ruvector_mincut::{DynamicMinCut, MinCutBuilder};
+use rand::{rngs::OsRng, RngCore};
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -141,6 +145,11 @@ struct Args {
     /// Stable, non-secret installation routing hint published over mDNS.
     #[arg(long, env = "RUVIEW_INSTALLATION_ID")]
     installation_id: Option<String>,
+
+    /// Private server state directory used for runtime configuration and the
+    /// installation bound empty room bootstrap prior.
+    #[arg(long, default_value = "data", env = "RUVIEW_DATA_DIR")]
+    data_dir: PathBuf,
 
     /// Human-readable local service name shown by commissioning clients.
     #[arg(
@@ -1585,6 +1594,16 @@ struct AppStateInner {
     engine_bridge: engine_bridge::EngineBridge,
     /// SVD-based room field model for eigenvalue person counting (None until calibration).
     field_model: Option<FieldModel>,
+    /// Stable installation identity used only to bind local persisted state.
+    installation_id: Option<String>,
+    /// Metadata for the privacy reduced empty room image, when available.
+    bootstrap_baseline: Option<BootstrapBaselineMetadata>,
+    /// A restored prior can affect startup occupancy but cannot authorize vitals.
+    bootstrap_baseline_active: bool,
+    /// Server generated identity for the current explicit calibration model.
+    calibration_model_id: Option<String>,
+    /// Nodes that actually contributed frames to the current calibration.
+    calibration_source_node_ids: std::collections::BTreeSet<u8>,
     // ── ADR-044 §5.2: adaptive rolling-p95 normalization ─────────────────────
     /// Rolling P95 of `FeatureInfo.variance` over the last ~30 s (600 frames @ 20 Hz).
     pub(crate) p95_variance: RollingP95,
@@ -1849,6 +1868,11 @@ impl AppStateInner {
                 None,
             ),
             field_model: None,
+            installation_id: None,
+            bootstrap_baseline: None,
+            bootstrap_baseline_active: false,
+            calibration_model_id: None,
+            calibration_source_node_ids: std::collections::BTreeSet::new(),
             p95_variance: RollingP95::new(600, 60),
             p95_motion_band_power: RollingP95::new(600, 60),
             p95_spectral_power: RollingP95::new(600, 60),
@@ -3364,7 +3388,7 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
                 feat_variance.min(1.0),
                 &sub_variances,
             ),
-            vital_signs: Some(vitals),
+            vital_signs: None,
             enhanced_motion,
             enhanced_breathing,
             posture: posture_str,
@@ -3528,7 +3552,7 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
             feat_variance.min(1.0),
             &sub_variances,
         ),
-        vital_signs: Some(vitals),
+        vital_signs: None,
         enhanced_motion: None,
         enhanced_breathing: None,
         posture: None,
@@ -5979,10 +6003,96 @@ async fn adaptive_unload(State(state): State<SharedState>) -> Json<serde_json::V
     Json(serde_json::json!({ "success": true, "message": "Adaptive model unloaded." }))
 }
 
+/// Numeric RF vitals are public sensing evidence only after an explicit fresh
+/// room calibration has resolved exactly one occupant. Bootstrap priors are
+/// intentionally lower authority and can never authorize rates.
+const VITAL_PUBLICATION_MIN_CONFIDENCE: f64 = 0.55;
+const VITAL_PUBLICATION_MIN_SIGNAL_QUALITY: f64 = 0.40;
+
+fn vitals_for_publication(
+    candidates: &VitalSigns,
+    explicit_calibration_fresh: bool,
+    person_count: usize,
+) -> Option<VitalSigns> {
+    if !explicit_calibration_fresh || person_count != 1 {
+        return None;
+    }
+    let signal_quality = candidates.signal_quality.clamp(0.0, 1.0);
+    if signal_quality < VITAL_PUBLICATION_MIN_SIGNAL_QUALITY {
+        return None;
+    }
+    let breathing_rate_bpm = (candidates.breathing_confidence
+        >= VITAL_PUBLICATION_MIN_CONFIDENCE)
+        .then_some(candidates.breathing_rate_bpm)
+        .flatten();
+    let heart_rate_bpm =
+        (candidates.heartbeat_confidence >= VITAL_PUBLICATION_MIN_CONFIDENCE)
+            .then_some(candidates.heart_rate_bpm)
+            .flatten();
+    if breathing_rate_bpm.is_none() && heart_rate_bpm.is_none() {
+        return None;
+    }
+    Some(VitalSigns {
+        breathing_rate_bpm,
+        heart_rate_bpm,
+        breathing_confidence: candidates.breathing_confidence.clamp(0.0, 1.0),
+        heartbeat_confidence: candidates.heartbeat_confidence.clamp(0.0, 1.0),
+        signal_quality,
+    })
+}
+
+fn opaque_calibration_model_id() -> String {
+    let mut bytes = [0_u8; 16];
+    OsRng.fill_bytes(&mut bytes);
+    let suffix: String = bytes.iter().map(|byte| format!("{byte:02x}")).collect();
+    format!("cal-model-{suffix}")
+}
+
+#[cfg(test)]
+mod bootstrap_vital_publication_tests {
+    use super::*;
+
+    fn strong_candidates() -> VitalSigns {
+        VitalSigns {
+            breathing_rate_bpm: Some(15.0),
+            heart_rate_bpm: Some(72.0),
+            breathing_confidence: 0.9,
+            heartbeat_confidence: 0.9,
+            signal_quality: 0.9,
+        }
+    }
+
+    #[test]
+    fn uncalibrated_empty_and_multi_person_rooms_publish_no_vitals() {
+        let candidates = strong_candidates();
+        assert!(vitals_for_publication(&candidates, false, 1).is_none());
+        assert!(vitals_for_publication(&candidates, true, 0).is_none());
+        assert!(vitals_for_publication(&candidates, true, 2).is_none());
+    }
+
+    #[test]
+    fn one_explicitly_calibrated_occupant_may_publish_qualified_vitals() {
+        let published = vitals_for_publication(&strong_candidates(), true, 1).unwrap();
+        assert_eq!(published.breathing_rate_bpm, Some(15.0));
+        assert_eq!(published.heart_rate_bpm, Some(72.0));
+    }
+
+    #[test]
+    fn weak_vital_candidates_fail_closed() {
+        let mut candidates = strong_candidates();
+        candidates.signal_quality = 0.2;
+        assert!(vitals_for_publication(&candidates, true, 1).is_none());
+    }
+}
+
 // ── Field model calibration endpoints (eigenvalue person counting) ──────────
 
 async fn calibration_start(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let mut s = state.write().await;
+    if s.bootstrap_baseline_active {
+        s.field_model = None;
+        s.bootstrap_baseline_active = false;
+    }
     // Guard: don't discard an in-progress or fresh calibration
     if let Some(ref fm) = s.field_model {
         match fm.status() {
@@ -6005,9 +6115,12 @@ async fn calibration_start(State(state): State<SharedState>) -> Json<serde_json:
     match FieldModel::new(field_bridge::single_link_config()) {
         Ok(fm) => {
             s.field_model = Some(fm);
+            s.calibration_model_id = Some(opaque_calibration_model_id());
+            s.calibration_source_node_ids.clear();
             Json(serde_json::json!({
                 "success": true,
                 "message": "Calibration started — keep room empty while frames accumulate.",
+                "model_id": s.calibration_model_id,
             }))
         }
         // ADR-080 #2: FieldModel init error chain stays server-side only.
@@ -6017,6 +6130,8 @@ async fn calibration_start(State(state): State<SharedState>) -> Json<serde_json:
 
 async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let mut s = state.write().await;
+    let model_id = s.calibration_model_id.clone();
+    let source_node_ids: Vec<u8> = s.calibration_source_node_ids.iter().copied().collect();
     if let Some(ref mut fm) = s.field_model {
         // Guard: finalizing before enough empty-room frames have accumulated
         // is a client-side sequencing error, not a server fault. Return a
@@ -6062,6 +6177,8 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
                     "variance_explained": variance_explained,
                     "frame_count": fm.calibration_frame_count(),
                     "elapsed_s": elapsed_s,
+                    "model_id": model_id,
+                    "source_node_ids": source_node_ids,
                 }))
             }
             // ADR-080 #2: finalize error chain stays server-side only.
@@ -6077,24 +6194,261 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
 
 async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
-    match s.field_model.as_ref() {
-        // #1756: expose elapsed wall-clock time and the effective aggregate
-        // sample rate alongside the frame count, so a client can see the
-        // shape of the capture instead of frames alone.
-        Some(fm) => Json(serde_json::json!({
-            "active": true,
-            "status": format!("{:?}", fm.status()),
-            "frame_count": fm.calibration_frame_count(),
-            "min_frames": fm.min_calibration_frames(),
-            "elapsed_s": fm.calibration_elapsed_s(),
-            "frames_per_second": fm.calibration_frames_per_second(),
-            "min_duration_s": fm.min_calibration_duration_s(),
-        })),
-        None => Json(serde_json::json!({
+    let (active, status, frame_count, min_frames, elapsed_s, frames_per_second, min_duration_s) =
+        s.field_model.as_ref().map_or(
+            (false, "none".to_string(), 0, 0, 0.0, 0.0, 0.0),
+            |model| {
+                (
+                    true,
+                    format!("{:?}", model.status()).to_lowercase(),
+                    model.calibration_frame_count(),
+                    model.min_calibration_frames(),
+                    model.calibration_elapsed_s(),
+                    model.calibration_frames_per_second(),
+                    model.min_calibration_duration_s(),
+                )
+            },
+        );
+    Json(serde_json::json!({
+        "active": active,
+        "status": status,
+        "frame_count": frame_count,
+        "min_frames": min_frames,
+        "elapsed_s": elapsed_s,
+        "frames_per_second": frames_per_second,
+        "min_duration_s": min_duration_s,
+        "model_id": s.calibration_model_id,
+        "source_node_ids": s.calibration_source_node_ids,
+        "binding_mode": if s.bootstrap_baseline_active { "bootstrap_only" } else if active { "runtime" } else { "none" },
+        "bootstrap_baseline": s.bootstrap_baseline.as_ref().map(|metadata| serde_json::json!({
+            "stored": true,
+            "active": s.bootstrap_baseline_active,
+            "authority": metadata.authority,
+            "source_node_ids": metadata.source_node_ids,
+            "source_model_id": metadata.source_model_id,
+            "created_at_unix_ms": metadata.created_at_unix_ms,
+            "expires_at_unix_ms": metadata.expires_at_unix_ms,
+            "content_sha256": metadata.content_sha256,
+            "calibrated_evidence_authorized": false,
+            "numeric_vitals_authorized": false,
+        })).unwrap_or_else(|| serde_json::json!({
+            "stored": false,
             "active": false,
-            "status": "none",
+            "authority": "none",
+            "calibrated_evidence_authorized": false,
+            "numeric_vitals_authorized": false,
         })),
+    }))
+}
+
+/// Validate a completed empty room model against twelve fresh server observed
+/// samples, then persist only aggregate statistics. The request cannot supply
+/// scores, labels, raw CSI, or a replacement model.
+async fn calibration_promote_bootstrap(
+    State(state): State<SharedState>,
+) -> Json<serde_json::Value> {
+    let expected_model_id = {
+        let s = state.read().await;
+        if s.bootstrap_baseline_active
+            || !s.field_model.as_ref().is_some_and(|model| {
+                matches!(model.status(), CalibrationStatus::Fresh)
+            })
+        {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "calibration_not_finalized",
+                "error": "Finalize an explicit room calibration before validating a startup baseline.",
+            }));
+        }
+        match s.calibration_model_id.clone() {
+            Some(model_id) => model_id,
+            None => {
+                return Json(serde_json::json!({
+                    "success": false,
+                    "error_code": "calibration_model_identity_missing",
+                    "error": "The active calibration has no server generated model identity.",
+                }));
+            }
+        }
+    };
+
+    let mut samples = Vec::with_capacity(BOOTSTRAP_VALIDATION_SAMPLES);
+    let mut last_tick = None;
+    for _ in 0..BOOTSTRAP_VALIDATION_SAMPLES {
+        let interval_deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+        let mut sample = BootstrapValidationSample {
+            fresh_tick: false,
+            calibrated_empty: false,
+            vital_signs_absent: true,
+        };
+        while tokio::time::Instant::now() < interval_deadline {
+            let observed = {
+                let s = state.read().await;
+                if s.calibration_model_id.as_deref() != Some(expected_model_id.as_str())
+                    || s.bootstrap_baseline_active
+                {
+                    None
+                } else {
+                    s.latest_update.as_ref().and_then(|update| {
+                        (Some(update.tick) != last_tick).then_some((
+                            update.tick,
+                            s.person_count() == 0,
+                            update.vital_signs.is_none(),
+                        ))
+                    })
+                }
+            };
+            if let Some((tick, calibrated_empty, vital_signs_absent)) = observed {
+                last_tick = Some(tick);
+                sample = BootstrapValidationSample {
+                    fresh_tick: true,
+                    calibrated_empty,
+                    vital_signs_absent,
+                };
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        samples.push(sample);
+        tokio::time::sleep_until(interval_deadline).await;
     }
+
+    let validation = bootstrap_baseline::evaluate_validation(&samples);
+    if !validation.passed {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "bootstrap_validation_failed",
+            "error": "The held out empty room check did not pass. The model was not stored.",
+            "validation": validation,
+        }));
+    }
+
+    let mut s = state.write().await;
+    if s.calibration_model_id.as_deref() != Some(expected_model_id.as_str())
+        || s.bootstrap_baseline_active
+    {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "calibration_model_changed",
+            "error": "Calibration changed during validation. The model was not stored.",
+        }));
+    }
+    let Some(installation_id) = s.installation_id.clone() else {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "installation_id_required",
+            "error": "A stable installation identity is required to store a local startup baseline.",
+        }));
+    };
+    let source_node_ids: Vec<u8> = s.calibration_source_node_ids.iter().copied().collect();
+    if source_node_ids.is_empty() || source_node_ids.len() > 16 {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "calibration_source_nodes_missing",
+            "error": "The active calibration must contain between 1 and 16 contributing ESP32 nodes.",
+        }));
+    }
+    let Some(field_model) = s.field_model.as_ref() else {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "no_field_model",
+            "error": "Calibration changed during validation. The model was not stored.",
+        }));
+    };
+    let path = bootstrap_baseline::path_in(&s.data_dir);
+    let created_at_unix_ms = chrono::Utc::now().timestamp_millis() as u64;
+    let stored = match bootstrap_baseline::store(
+        &path,
+        &installation_id,
+        &source_node_ids,
+        &expected_model_id,
+        created_at_unix_ms,
+        field_model,
+    ) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return error_response::internal_error_json("bootstrap baseline store", error)
+        }
+    };
+    s.bootstrap_baseline = Some(stored.clone());
+    info!(
+        model_id = %stored.source_model_id,
+        source_node_ids = ?stored.source_node_ids,
+        content_sha256 = %stored.content_sha256,
+        "Stored validated privacy reduced startup baseline"
+    );
+    Json(serde_json::json!({
+        "success": true,
+        "message": "Validated startup baseline stored locally.",
+        "validation": validation,
+        "bootstrap_baseline": stored,
+        "calibrated_evidence_authorized": false,
+        "numeric_vitals_authorized": false,
+    }))
+}
+
+/// Cancel only an unfinished capture. Completed model deletion remains on the
+/// administrator scoped reset route.
+async fn calibration_cancel(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let mut s = state.write().await;
+    let cancellable = s.field_model.as_ref().is_some_and(|model| {
+        matches!(
+            model.status(),
+            CalibrationStatus::Uncalibrated | CalibrationStatus::Collecting
+        )
+    });
+    if !cancellable {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "calibration_not_collecting",
+            "error": "Only an unfinished empty room capture can be cancelled.",
+        }));
+    }
+    s.field_model = None;
+    s.calibration_model_id = None;
+    s.calibration_source_node_ids.clear();
+    if let Some(installation_id) = s.installation_id.clone() {
+        let path = bootstrap_baseline::path_in(&s.data_dir);
+        if let Ok((model, metadata)) = bootstrap_baseline::load(
+            &path,
+            &installation_id,
+            chrono::Utc::now().timestamp_millis() as u64,
+        ) {
+            s.field_model = Some(model);
+            s.bootstrap_baseline = Some(metadata);
+            s.bootstrap_baseline_active = true;
+        }
+    }
+    Json(serde_json::json!({
+        "success": true,
+        "message": "Unfinished empty room capture cancelled.",
+        "status": if s.bootstrap_baseline_active { "bootstrap" } else { "none" },
+    }))
+}
+
+async fn calibration_reset(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let mut s = state.write().await;
+    s.field_model = None;
+    s.calibration_model_id = None;
+    s.calibration_source_node_ids.clear();
+    s.bootstrap_baseline_active = false;
+    let path = bootstrap_baseline::path_in(&s.data_dir);
+    let bootstrap_removed = match bootstrap_baseline::remove(&path) {
+        Ok(removed) => {
+            s.bootstrap_baseline = None;
+            removed
+        }
+        Err(error) => {
+            warn!(%error, "Could not remove stored bootstrap baseline during reset");
+            false
+        }
+    };
+    Json(serde_json::json!({
+        "success": true,
+        "message": "Calibration model reset.",
+        "status": "none",
+        "bootstrap_removed": bootstrap_removed,
+    }))
 }
 
 /// Compatibility surface used by the bundled dashboard. Activity history is
@@ -6119,16 +6473,27 @@ fn chrono_timestamp() -> u64 {
 
 async fn vital_signs_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
-    let vs = &s.latest_vitals;
+    let person_count = s.person_count();
+    let explicit_calibration_fresh = !s.bootstrap_baseline_active
+        && s.field_model
+            .as_ref()
+            .is_some_and(|model| matches!(model.status(), CalibrationStatus::Fresh));
+    let published = vitals_for_publication(
+        &s.latest_vitals,
+        explicit_calibration_fresh,
+        person_count,
+    );
     let (br_len, br_cap, hb_len, hb_cap) = s.vital_detector.buffer_status();
     Json(serde_json::json!({
         "vital_signs": {
-            "breathing_rate_bpm": vs.breathing_rate_bpm,
-            "heart_rate_bpm": vs.heart_rate_bpm,
-            "breathing_confidence": vs.breathing_confidence,
-            "heartbeat_confidence": vs.heartbeat_confidence,
-            "signal_quality": vs.signal_quality,
+            "breathing_rate_bpm": published.as_ref().and_then(|value| value.breathing_rate_bpm),
+            "heart_rate_bpm": published.as_ref().and_then(|value| value.heart_rate_bpm),
+            "breathing_confidence": published.as_ref().map(|value| value.breathing_confidence),
+            "heartbeat_confidence": published.as_ref().map(|value| value.heartbeat_confidence),
+            "signal_quality": published.as_ref().map(|value| value.signal_quality),
         },
+        "authority": if published.is_some() { "explicit_calibration" } else { "abstained" },
+        "abstention_reason": if published.is_some() { serde_json::Value::Null } else { serde_json::json!("fresh explicit calibration with exactly one occupant and qualified evidence required") },
         "buffer_status": {
             "breathing_samples": br_len,
             "breathing_capacity": br_cap,
@@ -6193,6 +6558,18 @@ async fn edge_registry_endpoint(
 /// GET /api/v1/edge-vitals — latest edge vitals from ESP32 (ADR-039).
 async fn edge_vitals_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
+    let explicit_single_occupant = !s.bootstrap_baseline_active
+        && s.field_model
+            .as_ref()
+            .is_some_and(|model| matches!(model.status(), CalibrationStatus::Fresh))
+        && s.person_count() == 1;
+    if !explicit_single_occupant {
+        return Json(serde_json::json!({
+            "status": "abstained",
+            "edge_vitals": null,
+            "message": "Fresh explicit calibration with exactly one occupant is required.",
+        }));
+    }
     match &s.edge_vitals {
         Some(v) => Json(serde_json::json!({
             "status": "ok",
@@ -6831,8 +7208,15 @@ async fn udp_receiver_task(
                         .get(&node_id)
                         .map(|ns| ns.frame_history.clone())
                     {
-                        if let Some(ref mut fm) = s.field_model {
+                        let accepted = if let Some(ref mut fm) = s.field_model {
+                            let before = fm.calibration_frame_count();
                             field_bridge::maybe_feed_calibration(fm, &frame_history);
+                            fm.calibration_frame_count() > before
+                        } else {
+                            false
+                        };
+                        if accepted {
+                            s.calibration_source_node_ids.insert(node_id);
                         }
                     }
 
@@ -6903,6 +7287,24 @@ async fn udp_receiver_task(
                         (vitals.presence_score as f64).min(1.0),
                         &[],
                     );
+                    let vital_candidates = VitalSigns {
+                        breathing_rate_bpm: (vitals.breathing_rate_bpm > 0.0)
+                            .then_some(vitals.breathing_rate_bpm),
+                        heart_rate_bpm: (vitals.heartrate_bpm > 0.0)
+                            .then_some(vitals.heartrate_bpm),
+                        breathing_confidence: if vitals.presence { 0.7 } else { 0.0 },
+                        heartbeat_confidence: if vitals.presence { 0.7 } else { 0.0 },
+                        signal_quality: vitals.presence_score as f64,
+                    };
+                    let explicit_calibration_fresh = !s.bootstrap_baseline_active
+                        && s.field_model.as_ref().is_some_and(|model| {
+                            matches!(model.status(), CalibrationStatus::Fresh)
+                        });
+                    let published_vitals = vitals_for_publication(
+                        &vital_candidates,
+                        explicit_calibration_fresh,
+                        total_persons,
+                    );
 
                     let mut update = SensingUpdate {
                         msg_type: "sensing_update".to_string(),
@@ -6913,21 +7315,7 @@ async fn udp_receiver_task(
                         features: fused_features.clone(),
                         classification,
                         signal_field,
-                        vital_signs: Some(VitalSigns {
-                            breathing_rate_bpm: if vitals.breathing_rate_bpm > 0.0 {
-                                Some(vitals.breathing_rate_bpm)
-                            } else {
-                                None
-                            },
-                            heart_rate_bpm: if vitals.heartrate_bpm > 0.0 {
-                                Some(vitals.heartrate_bpm)
-                            } else {
-                                None
-                            },
-                            breathing_confidence: if vitals.presence { 0.7 } else { 0.0 },
-                            heartbeat_confidence: if vitals.presence { 0.7 } else { 0.0 },
-                            signal_quality: vitals.presence_score as f64,
-                        }),
+                        vital_signs: published_vitals,
                         enhanced_motion: None,
                         enhanced_breathing: None,
                         posture: None,
@@ -7312,8 +7700,15 @@ async fn udp_receiver_task(
                         .get(&node_id)
                         .map(|ns| ns.frame_history.clone())
                     {
-                        if let Some(ref mut fm) = s.field_model {
+                        let accepted = if let Some(ref mut fm) = s.field_model {
+                            let before = fm.calibration_frame_count();
                             field_bridge::maybe_feed_calibration(fm, &frame_history);
+                            fm.calibration_frame_count() > before
+                        } else {
+                            false
+                        };
+                        if accepted {
+                            s.calibration_source_node_ids.insert(node_id);
                         }
                     }
 
@@ -7369,6 +7764,15 @@ async fn udp_receiver_task(
                         NODE_STALE_AFTER_MS,
                     );
                     let room_classification = debounce_room_classification(&mut s, &room_inference);
+                    let explicit_calibration_fresh = !s.bootstrap_baseline_active
+                        && s.field_model.as_ref().is_some_and(|model| {
+                            matches!(model.status(), CalibrationStatus::Fresh)
+                        });
+                    let published_vitals = vitals_for_publication(
+                        &vitals,
+                        explicit_calibration_fresh,
+                        total_persons,
+                    );
 
                     let mut update = SensingUpdate {
                         msg_type: "sensing_update".to_string(),
@@ -7390,7 +7794,7 @@ async fn udp_receiver_task(
                             fused_features.variance.min(1.0),
                             &sub_variances,
                         ),
-                        vital_signs: Some(vitals),
+                        vital_signs: published_vitals,
                         enhanced_motion: None,
                         enhanced_breathing: None,
                         posture: None,
@@ -7645,7 +8049,7 @@ async fn simulated_data_task(state: SharedState, tick_ms: u64) {
                 features.variance.min(1.0),
                 &sub_variances,
             ),
-            vital_signs: Some(vitals),
+            vital_signs: None,
             enhanced_motion: None,
             enhanced_breathing: None,
             posture: None,
@@ -8810,12 +9214,49 @@ async fn main() {
     );
 
     // ADR-044 §5.3: load persisted runtime config from the data directory.
-    let data_dir = std::path::PathBuf::from("data");
+    let data_dir = args.data_dir.clone();
+    if let Err(error) = std::fs::create_dir_all(&data_dir) {
+        warn!(path = %data_dir.display(), %error, "Could not create server data directory");
+    }
     let runtime_config = load_runtime_config(&data_dir);
     // ADR-271: resolve (or generate + persist) the browser-session signing key
     // before any request can arrive. Zero-config for a single appliance; the
     // env var still wins for a multi-instance deployment that must share one.
     wifi_densepose_sensing_server::browser_session::init_secret(&data_dir);
+    let (bootstrap_field_model, bootstrap_metadata, bootstrap_baseline_active) =
+        if !args.calibrate {
+            args.installation_id.as_deref().map_or(
+                (None, None, false),
+                |installation_id| {
+                    let path = bootstrap_baseline::path_in(&data_dir);
+                    match bootstrap_baseline::load(
+                        &path,
+                        installation_id,
+                        chrono::Utc::now().timestamp_millis() as u64,
+                    ) {
+                        Ok((model, metadata)) => {
+                            info!(
+                                source_model_id = %metadata.source_model_id,
+                                source_node_ids = ?metadata.source_node_ids,
+                                "Restored privacy reduced empty room bootstrap prior"
+                            );
+                            (Some(model), Some(metadata), true)
+                        }
+                        Err(bootstrap_baseline::BootstrapBaselineError::Io(error))
+                            if error.kind() == std::io::ErrorKind::NotFound =>
+                        {
+                            (None, None, false)
+                        }
+                        Err(error) => {
+                            warn!(%error, "Ignored invalid empty room bootstrap prior");
+                            (None, None, false)
+                        }
+                    }
+                },
+            )
+        } else {
+            (None, None, false)
+        };
     info!(
         "Loaded runtime config: dedup_factor={:.2}",
         runtime_config.dedup_factor
@@ -9029,8 +9470,13 @@ async fn main() {
             info!("Field model calibration enabled — room should be empty during startup");
             FieldModel::new(field_bridge::single_link_config()).ok()
         } else {
-            None
+            bootstrap_field_model
         },
+        installation_id: args.installation_id.clone(),
+        bootstrap_baseline: bootstrap_metadata,
+        bootstrap_baseline_active,
+        calibration_model_id: args.calibrate.then(opaque_calibration_model_id),
+        calibration_source_node_ids: std::collections::BTreeSet::new(),
         // ADR-044 §5.2: rolling-P95 over ~30 s at 20 Hz; warm-up after 60 samples.
         p95_variance: RollingP95::new(600, 60),
         p95_motion_band_power: RollingP95::new(600, 60),
@@ -9326,7 +9772,13 @@ async fn main() {
         // Field model calibration (eigenvalue-based person counting)
         .route("/api/v1/calibration/start", post(calibration_start))
         .route("/api/v1/calibration/stop", post(calibration_stop))
+        .route(
+            "/api/v1/calibration/bootstrap/promote",
+            post(calibration_promote_bootstrap),
+        )
+        .route("/api/v1/calibration/cancel", post(calibration_cancel))
         .route("/api/v1/calibration/status", get(calibration_status))
+        .route("/api/v1/calibration/reset", post(calibration_reset))
         // ADR-044 §5.3: runtime-configurable dedup factor
         .route(
             "/api/v1/config/dedup-factor",

--- a/v2/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
+++ b/v2/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
@@ -23,6 +23,7 @@ use ndarray::Array2;
 use ndarray_linalg::Eigh;
 #[cfg(feature = "eigenvalue")]
 use ndarray_linalg::UPLO;
+use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
 // Calibration window constants
@@ -41,6 +42,11 @@ pub const CALIBRATION_DURATION_S: f64 = 600.0;
 /// Assumed per-node CSI rate (Hz) used to relate the frame target to
 /// [`CALIBRATION_DURATION_S`] ("10 min at 20 Hz").
 pub const ASSUMED_CALIBRATION_RATE_HZ: f64 = 20.0;
+
+/// A recent window whose mean remains within this residual energy of the
+/// empty room manifold is treated as background before eigenvalue counting.
+#[cfg(feature = "eigenvalue")]
+const EMPTY_ROOM_RESIDUAL_ENERGY_MAX: f64 = 1.0;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -261,7 +267,8 @@ impl LinkBaselineStats {
 // ---------------------------------------------------------------------------
 
 /// Configuration for field model calibration and runtime.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct FieldModelConfig {
     /// Number of links in the mesh.
     pub n_links: usize,
@@ -304,7 +311,8 @@ impl Default for FieldModelConfig {
 /// Learned from SVD on the covariance of CSI amplitudes during
 /// empty-room calibration. The top-K modes capture environmental
 /// variation (temperature, humidity, time-of-day effects).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct FieldNormalMode {
     /// Per-link baseline mean: `[n_links][n_subcarriers]`.
     pub baseline: Vec<Vec<f64>>,
@@ -360,6 +368,18 @@ pub enum CalibrationStatus {
     Stale,
     /// Calibration has expired.
     Expired,
+}
+
+/// Privacy reduced restart image for a completed field model.
+///
+/// This contains only aggregate baseline statistics and environmental modes.
+/// It excludes raw CSI frames, device addresses, room names, credentials, and
+/// calibration authority. A restored image is only a bootstrap prior.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct FieldModelSnapshotV1 {
+    pub config: FieldModelConfig,
+    pub modes: FieldNormalMode,
 }
 
 /// The persistent field model for a single room.
@@ -481,6 +501,96 @@ impl FieldModel {
     /// Access the computed field normal modes, if available.
     pub fn modes(&self) -> Option<&FieldNormalMode> {
         self.modes.as_ref()
+    }
+
+    /// Export aggregate model state suitable for local restart persistence.
+    /// Raw calibration observations and Welford accumulators are not exported.
+    pub fn export_snapshot(&self) -> Result<FieldModelSnapshotV1, FieldModelError> {
+        let modes = self.modes.clone().ok_or(FieldModelError::NotCalibrated)?;
+        Ok(FieldModelSnapshotV1 {
+            config: self.config.clone(),
+            modes,
+        })
+    }
+
+    /// Restore a bounded, validated aggregate snapshot.
+    pub fn from_snapshot(
+        snapshot: FieldModelSnapshotV1,
+        current_us: u64,
+    ) -> Result<Self, FieldModelError> {
+        let config = &snapshot.config;
+        if config.n_links > 16 || config.n_subcarriers > 2_048 {
+            return Err(FieldModelError::InvalidConfig(
+                "snapshot dimensions exceed bounded limits".into(),
+            ));
+        }
+        if !config.min_calibration_duration_s.is_finite()
+            || config.min_calibration_duration_s < 0.0
+            || !config.baseline_expiry_s.is_finite()
+            || config.baseline_expiry_s <= 0.0
+            || config.baseline_expiry_s > 604_800.0
+        {
+            return Err(FieldModelError::InvalidConfig(
+                "snapshot timing values are invalid".into(),
+            ));
+        }
+
+        let modes = &snapshot.modes;
+        let baseline_shape_valid = modes.baseline.len() == config.n_links
+            && modes
+                .baseline
+                .iter()
+                .all(|link| link.len() == config.n_subcarriers);
+        let mode_shape_valid = modes.environmental_modes.len() == modes.mode_energies.len()
+            && modes.environmental_modes.len() <= config.n_modes
+            && modes
+                .environmental_modes
+                .iter()
+                .all(|mode| mode.len() == config.n_subcarriers);
+        let values_valid = modes
+            .baseline
+            .iter()
+            .flatten()
+            .chain(modes.environmental_modes.iter().flatten())
+            .all(|value| value.is_finite())
+            && modes
+                .mode_energies
+                .iter()
+                .all(|value| value.is_finite() && *value >= 0.0)
+            && modes.variance_explained.is_finite()
+            && (0.0..=10.0).contains(&modes.variance_explained)
+            && modes.baseline_noise_var.is_finite()
+            && modes.baseline_noise_var >= 0.0
+            && modes.baseline_eigenvalue_count <= config.n_subcarriers;
+        if !baseline_shape_valid || !mode_shape_valid || !values_valid {
+            return Err(FieldModelError::InvalidConfig(
+                "snapshot modes are malformed or non finite".into(),
+            ));
+        }
+        if modes.calibrated_at_us == 0
+            || modes.calibrated_at_us > current_us.saturating_add(300_000_000)
+        {
+            return Err(FieldModelError::InvalidConfig(
+                "snapshot calibration time is invalid".into(),
+            ));
+        }
+        let elapsed_s = current_us.saturating_sub(modes.calibrated_at_us) as f64 / 1_000_000.0;
+        if elapsed_s > config.baseline_expiry_s {
+            return Err(FieldModelError::BaselineExpired {
+                elapsed_s,
+                max_s: config.baseline_expiry_s,
+            });
+        }
+
+        let mut model = Self::new(snapshot.config)?;
+        model.status = if elapsed_s > model.config.baseline_expiry_s * 0.5 {
+            CalibrationStatus::Stale
+        } else {
+            CalibrationStatus::Fresh
+        };
+        model.last_calibration_us = modes.calibrated_at_us;
+        model.modes = Some(snapshot.modes);
+        Ok(model)
     }
 
     /// Number of calibration frames collected so far.
@@ -881,6 +991,17 @@ impl FieldModel {
         }
         for m in &mut mean {
             *m /= count as f64;
+        }
+
+        // Rank alone is not person evidence. A continuation window can expose
+        // more significant eigenvalues while its mean remains on the learned
+        // empty room manifold. Fail toward empty only inside the same
+        // conservative residual energy boundary used by the server fallback.
+        if self
+            .extract_perturbation(&[mean.clone()])
+            .is_ok_and(|perturbation| perturbation.total_energy <= EMPTY_ROOM_RESIDUAL_ENERGY_MAX)
+        {
+            return Ok(0);
         }
 
         let mut cov = Array2::<f64>::zeros((n, n));
@@ -1536,6 +1657,48 @@ mod tests {
             modes.baseline_eigenvalue_count <= 8,
             "baseline_eigenvalue_count should be <= n_subcarriers"
         );
+    }
+
+    #[test]
+    fn snapshot_round_trip_preserves_aggregate_modes_without_raw_frames() {
+        let config = make_config(1, 4, 10);
+        let mut model = FieldModel::new(config).unwrap();
+        for i in 0..10 {
+            model
+                .feed_calibration(&[vec![1.0 + i as f64 * 0.01, 2.0, 3.0, 4.0]])
+                .unwrap();
+        }
+        model.finalize_calibration(1_000_000, 0xCA1).unwrap();
+
+        let snapshot = model.export_snapshot().unwrap();
+        let restored = FieldModel::from_snapshot(snapshot.clone(), 2_000_000).unwrap();
+
+        assert_eq!(restored.status(), CalibrationStatus::Fresh);
+        assert_eq!(restored.calibration_frame_count(), 0);
+        assert_eq!(restored.export_snapshot().unwrap(), snapshot);
+    }
+
+    #[test]
+    fn snapshot_restore_rejects_expired_and_malformed_images() {
+        let config = make_config(1, 4, 10);
+        let mut model = FieldModel::new(config).unwrap();
+        for _ in 0..10 {
+            model.feed_calibration(&[vec![1.0, 2.0, 3.0, 4.0]]).unwrap();
+        }
+        model.finalize_calibration(1_000_000, 0).unwrap();
+        let snapshot = model.export_snapshot().unwrap();
+
+        assert!(matches!(
+            FieldModel::from_snapshot(snapshot.clone(), 90_000_000_000),
+            Err(FieldModelError::BaselineExpired { .. })
+        ));
+
+        let mut malformed = snapshot;
+        malformed.modes.baseline[0].pop();
+        assert!(matches!(
+            FieldModel::from_snapshot(malformed, 2_000_000),
+            Err(FieldModelError::InvalidConfig(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

* add bounded aggregate FieldModel snapshot export and strict restore validation
* add installation bound local baseline persistence with digest, expiry, private atomic writes, and symlink rejection
* add a server measured 12 sample held out promotion gate plus cancel and administrator reset routes
* keep restored baselines at bootstrap only authority and fail closed for numeric vital publication
* document the operator flow and architecture in ADR 355

## Privacy and authority

No household baseline artifact, raw CSI, waveform, device address, room name, pose, identity, credential, or positive human label is included in this pull request. A restored baseline can help suppress startup background false positives, but cannot authorize calibrated evidence or numeric heart and breathing rates.

## Validation

* cargo test --workspace --no-default-features
* cargo test -p wifi-densepose-sensing-server --no-default-features
* cargo test -p wifi-densepose-signal --features eigenvalue
* cargo test -p wifi-densepose-calibration -p wifi-densepose-train --no-default-features
* cargo test -p ruview-unified --no-default-features
* cargo test -p wifi-densepose-sensing-server --no-default-features scope_gate_polarity_tests
* git diff --check

All completed locally with zero failures. Existing compiler warnings remain unchanged.

## Measurement boundary

This is an implementation and safety change. It does not claim accuracy improvement. Cross installation occupied and empty holdouts are still required before making a measured accuracy claim.
