### PR TITLE
feat(firmware): opt-in CSI census and AP survey diagnostics

### DIFF
--- a/firmware/esp32-csi-node/main/csi_collector.c
+++ b/firmware/esp32-csi-node/main/csi_collector.c
@@ -272,9 +272,114 @@ size_t csi_serialize_frame(const wifi_csi_info_t *info, uint8_t *buf, size_t buf
 /**
  * WiFi CSI callback — invoked by ESP-IDF when CSI data is available.
  */
+/* ---- DIAGNOSTIC: census of every transmitter the CSI engine produces for ----
+ *
+ * OFF BY DEFAULT. Build with -DRUVIEW_DIAG_CENSUS to enable. It logs heavily
+ * over serial and is only meaningful on a board you are watching, so it must
+ * never reach the fleet through an OTA.
+ */
+#ifdef RUVIEW_DIAG_CENSUS
+/*
+ *
+ * Recorded at the TOP of the callback, before filter_mac and before the rate
+ * gate, so it reports what the radio actually generated CSI for rather than
+ * what survived our own filtering. That distinction is the entire question:
+ * measured 2026-08-31, an access point at -62 dBm on the same channel yielded
+ * zero frames while the associated AP at -68 dBm yielded everything, which
+ * points at the 802.11 BSSID receive filter rather than at signal strength.
+ *
+ * A per-frame log would be ~40 lines/second and would not fit the serial link,
+ * so this aggregates into a small table and dumps it periodically.
+ */
+#define DIAG_CENSUS_MAX 24
+struct diag_census_entry {
+    uint8_t  mac[6];
+    uint32_t count;
+    int8_t   last_rssi;
+    uint16_t last_len;    /* info->len: CSI payload bytes. 0 => empty
+                           * amplitudes => LinkTable::observe drops it. */
+    uint16_t min_len;
+};
+struct diag_census {
+    struct diag_census_entry e[DIAG_CENSUS_MAX];
+    uint8_t  used;
+    uint32_t seen;
+    uint32_t over;      /* distinct MACs beyond the table */
+};
+
+/* Three censuses at three stages of the SAME callback, so the survival of each
+ * transmitter can be read straight off:
+ *
+ *   RX   — what the radio's CSI engine actually produced (before every filter)
+ *   GATE — what survived the 20 ms mesh-aligned bucket gate
+ *   SEND — what was actually put on the wire to the server
+ *
+ * MEASURED 2026-08-31: foreign transmitters DO appear at RX while associated
+ * (the 1st floor AP at n=391, -68 dBm), yet never reach the server's link
+ * table. These three tables localise that loss to a specific stage instead of
+ * leaving it to inference, which has been wrong repeatedly on this question.
+ */
+static struct diag_census s_cen_rx;
+static struct diag_census s_cen_gate;
+static struct diag_census s_cen_send;
+
+static void diag_census_record(struct diag_census *c, const uint8_t *mac,
+                               int8_t rssi, uint16_t len)
+{
+    c->seen++;
+    for (uint8_t i = 0; i < c->used; i++) {
+        if (memcmp(c->e[i].mac, mac, 6) == 0) {
+            c->e[i].count++;
+            c->e[i].last_rssi = rssi;
+            c->e[i].last_len = len;
+            if (len < c->e[i].min_len) c->e[i].min_len = len;
+            return;
+        }
+    }
+    if (c->used >= DIAG_CENSUS_MAX) { c->over++; return; }
+    memcpy(c->e[c->used].mac, mac, 6);
+    c->e[c->used].count = 1;
+    c->e[c->used].last_rssi = rssi;
+    c->e[c->used].last_len = len;
+    c->e[c->used].min_len = len;
+    c->used++;
+}
+
+static void diag_census_dump_one(const char *label, const struct diag_census *c)
+{
+    ESP_LOGW(TAG, "CENSUS-%s: %u frames, %u MAC(s), %u over table",
+             label, (unsigned)c->seen, (unsigned)c->used, (unsigned)c->over);
+    for (uint8_t i = 0; i < c->used; i++) {
+        ESP_LOGW(TAG, "CENSUS-%s %02x:%02x:%02x:%02x:%02x:%02x n=%-6u rssi=%-4d len=%u min=%u",
+                 label,
+                 c->e[i].mac[0], c->e[i].mac[1], c->e[i].mac[2],
+                 c->e[i].mac[3], c->e[i].mac[4], c->e[i].mac[5],
+                 (unsigned)c->e[i].count, (int)c->e[i].last_rssi,
+                 (unsigned)c->e[i].last_len, (unsigned)c->e[i].min_len);
+    }
+}
+
+static void diag_census_dump(void)
+{
+    diag_census_dump_one("RX  ", &s_cen_rx);
+    diag_census_dump_one("GATE", &s_cen_gate);
+    diag_census_dump_one("SEND", &s_cen_send);
+}
+#else
+#define diag_census_record(c, mac, rssi, len) ((void)0)
+#define diag_census_dump()                    ((void)0)
+static struct { uint32_t seen; } s_cen_rx;   /* seen stays readable when off */
+#endif
+
 static void wifi_csi_callback(void *ctx, wifi_csi_info_t *info)
 {
     (void)ctx;
+
+    /* DIAGNOSTIC BUILD ONLY — before every filter, including our own. */
+    diag_census_record(&s_cen_rx, info->mac, (int8_t)info->rx_ctrl.rssi, (uint16_t)info->len);
+    if ((s_cen_rx.seen % 1000u) == 0u) {
+        diag_census_dump();
+    }
 
     /* Early rate gate: drop excess callbacks to ~50 Hz to prevent
      * SPI flash cache crash in WiFi ISR (wDev_ProcessFiq). */
@@ -293,6 +398,9 @@ static void wifi_csi_callback(void *ctx, wifi_csi_info_t *info)
             return;  /* Source MAC doesn't match filter — skip frame. */
         }
     }
+
+    /* DIAGNOSTIC BUILD ONLY -- survived the rate gate. */
+    diag_census_record(&s_cen_gate, info->mac, (int8_t)info->rx_ctrl.rssi, (uint16_t)info->len);
 
     s_cb_count++;
 
@@ -315,6 +423,8 @@ static void wifi_csi_callback(void *ctx, wifi_csi_info_t *info)
             if (ret > 0) {
                 s_send_ok++;
                 s_last_send_us = now;
+                /* DIAGNOSTIC BUILD ONLY — actually on the wire to the server. */
+                diag_census_record(&s_cen_send, info->mac, (int8_t)info->rx_ctrl.rssi, (uint16_t)info->len);
             } else {
                 s_send_fail++;
                 if (s_send_fail <= 5) {

--- a/firmware/esp32-csi-node/main/main.c
+++ b/firmware/esp32-csi-node/main/main.c
@@ -107,13 +107,27 @@ static void wifi_reconnect_cb(void *arg)
     esp_wifi_connect();
 }
 
+/* DIAGNOSTIC BUILD ONLY: when set, the node deliberately holds NO association,
+ * so the reconnect machinery below must stand down. Without this guard the
+ * disconnect handler immediately reconnects and the sniffer experiment
+ * measures ordinary associated behaviour while appearing to work. */
+static volatile bool s_sniffer_mode = false;
+
 static void event_handler(void *arg, esp_event_base_t event_base,
                           int32_t event_id, void *event_data)
 {
     if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        if (s_sniffer_mode) {
+            return;
+        }
         esp_wifi_connect();
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
         wifi_event_sta_disconnected_t *disc = (wifi_event_sta_disconnected_t *)event_data;
+        if (s_sniffer_mode) {
+            ESP_LOGW(TAG, "SNIFFER: disconnected (reason=%d) — staying unassociated",
+                     disc->reason);
+            return;
+        }
         ESP_LOGW(TAG, "WiFi disconnected, reason=%d rssi=%d", disc->reason, disc->rssi);
         s_retry_num++;
         /* Release the boot wait once, so a node that comes up while the AP is
@@ -301,6 +315,71 @@ static void led_gamma_40hz_cb(void *arg)
     led_strip_refresh(s_viz_led);
 }
 #endif /* CONFIG_LED_GAMMA_VIZ */
+
+/* ---- DIAGNOSTIC: one-shot survey of every AP this node can actually hear ----
+ *
+ * OFF BY DEFAULT. Build with -DRUVIEW_DIAG_SCAN to enable. A scan takes the
+ * radio off its operating channel, so it is a CSI outage and a chance to drop
+ * the association — never ship it to the fleet.
+ */
+#ifdef RUVIEW_DIAG_SCAN
+/*
+ *
+ * Answers a question no server-side metric can: what does THIS radio, behind
+ * THIS PCB trace antenna, at THIS mounting position, actually receive? A scan
+ * from a laptop or from an access point answers for a different antenna in a
+ * different place with a different LNA — measured 2026-08-31, a Powerwall
+ * gateway read -54 dBm at a U7 Pro XG while being entirely absent from every
+ * node's link table, and no amount of server-side inference could separate
+ * "out of range" from "received but discarded".
+ *
+ * ONE-SHOT, and deliberately so: esp_wifi_scan_start takes the radio off its
+ * operating channel, so every scan is a CSI outage and a chance to drop the
+ * association. Run it once, log it, never again. Do not put this on a timer.
+ */
+static wifi_ap_record_t s_diag_scan_recs[40];   /* static: too large for stack */
+
+static void diag_survey_visible_aps(void)
+{
+    wifi_scan_config_t cfg = {
+        .ssid = NULL,
+        .bssid = NULL,
+        .channel = 0,              /* every channel, not just ours */
+        .show_hidden = true,
+        .scan_type = WIFI_SCAN_TYPE_ACTIVE,
+        .scan_time = { .active = { .min = 120, .max = 300 } },
+    };
+
+    ESP_LOGW(TAG, "DIAG-SCAN: starting survey — CSI pauses for a few seconds");
+    esp_err_t err = esp_wifi_scan_start(&cfg, true /* block until done */);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "DIAG-SCAN: failed: %s", esp_err_to_name(err));
+        return;
+    }
+
+    uint16_t found = 0;
+    esp_wifi_scan_get_ap_num(&found);
+    uint16_t want = (found > 40u) ? 40u : found;
+    if (want == 0) {
+        ESP_LOGW(TAG, "DIAG-SCAN: 0 APs visible — that is itself the answer");
+        return;
+    }
+    esp_wifi_scan_get_ap_records(&want, s_diag_scan_recs);
+
+    ESP_LOGW(TAG, "DIAG-SCAN: %u of %u AP(s) visible to node %u",
+             (unsigned)want, (unsigned)found, (unsigned)g_nvs_config.node_id);
+    for (uint16_t i = 0; i < want; i++) {
+        const wifi_ap_record_t *r = &s_diag_scan_recs[i];
+        ESP_LOGW(TAG,
+                 "DIAG-SCAN %02u ch=%2u rssi=%4d %02x:%02x:%02x:%02x:%02x:%02x \"%s\"",
+                 (unsigned)i, (unsigned)r->primary, (int)r->rssi,
+                 r->bssid[0], r->bssid[1], r->bssid[2],
+                 r->bssid[3], r->bssid[4], r->bssid[5],
+                 (const char *)r->ssid);
+    }
+    ESP_LOGW(TAG, "DIAG-SCAN: complete — CSI resumes");
+}
+#endif /* RUVIEW_DIAG_SCAN */
 
 void app_main(void)
 {
@@ -644,6 +723,27 @@ void app_main(void)
              (adapt_ret == ESP_OK) ? "on" : "off");
 
     /* Main loop — keep alive, and supervise the uplink. */
+    /* DIAGNOSTIC BUILD ONLY — see diag_survey_visible_aps(). Delayed so the
+     * association and the first CSI frames settle first, otherwise the scan
+     * competes with connection setup and the RSSI figures are not
+     * representative of steady state. */
+#ifdef RUVIEW_DIAG_SCAN
+    vTaskDelay(pdMS_TO_TICKS(10000));
+    diag_survey_visible_aps();
+#endif
+
+    /* The sniffer experiment ran on 2026-08-31 and ANSWERED ITS QUESTION: going
+     * unassociated changed nothing. Foreign transmitters already produce CSI
+     * while fully associated (the 1st floor AP at n=391, -68 dBm; TEG's radio
+     * at -90), so there is no BSSID receive filter to escape. The node now
+     * stays associated deliberately — the SEND census is meaningless without an
+     * uplink, and that census is what localises where those frames are lost.
+     * `s_sniffer_mode` is retained, unused, so the experiment is one line to
+     * re-run rather than a rebuild. */
+
+    /* Main loop — keep alive, and supervise the uplink. */
+
+    /* Main loop — keep alive */
     while (1) {
         vTaskDelay(pdMS_TO_TICKS(10000));
 #ifdef CONFIG_UPLINK_WATCHDOG


### PR DESCRIPTION
Two questions come up whenever a node underperforms and neither can be
answered from the outside: what is this node actually hearing, and what does
the RF around it look like. Both are answerable on the node and were not.

The census counts frames per transmitter at three points -- as received, after
the rate gate, and as sent -- so the drop between stages is attributable. "The
node is only sending 6 fps" has very different causes depending on whether it
heard 6 or heard 400 and discarded the rest.

The AP survey performs one scan and logs every visible BSSID with its channel
and RSSI, which answers whether a weak node is weak because of distance or
because it associated with the wrong AP.

Both are behind compile flags (RUVIEW_DIAG_CENSUS, RUVIEW_DIAG_SCAN) and off
by default. Neither belongs in a soak or a production flash: the census logs
continuously, and the scan takes the radio off its operating channel, which is
a CSI outage and a chance to lose the association. The survey is additionally
delayed 10 s after boot so it measures steady state rather than competing with
connection setup.

---

Rebased onto current `main`. One conflict in `main.c`, additive on both sides and resolved by keeping both. Firmware builds clean for esp32c6 on ESP-IDF v5.4.