### PR TITLE
feat(provision): keep credentials out of the state file entirely

### DIFF
--- a/.github/workflows/firmware-qemu.yml
+++ b/.github/workflows/firmware-qemu.yml
@@ -262,6 +262,32 @@ jobs:
             firmware/esp32-csi-node/test/timeout-*
           retention-days: 30
 
+  # ---------------------------------------------------------------------------
+  # Provisioning tooling tests (firmware/esp32-csi-node/tests).
+  #
+  # These existed but nothing ran them: the repo's pytest invocations cover
+  # archive/v1, python/ and tests/performance, and the `Tests (3.x)` job marks
+  # every step continue-on-error, so it cannot fail a PR. A change that put the
+  # WiFi passphrase back into the per-port state file -- or took it out and
+  # broke the merge contract -- would have gone in green. Stdlib unittest, no
+  # dependencies, under a second.
+  # ---------------------------------------------------------------------------
+  provision-tests:
+    name: Provisioning Tooling Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: '3.12'
+
+      - name: Run provisioning state + merge tests
+        working-directory: firmware/esp32-csi-node
+        run: python -m unittest discover -s tests -p "test_provision*.py" -v
+
   nvs-matrix-validate:
     name: NVS Matrix Generation
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -317,3 +317,6 @@ v2/crates/ruview-offaxis/pkg/
 scripts/fal-visual-teacher/training-data/
 scripts/fal-visual-teacher/training-data.zip
 scripts/fal-visual-teacher/output/
+# Board identity index — MACs of physical hardware, not secret, but not useful
+# to anyone else and it churns per fleet. Keep it local.
+firmware/esp32-csi-node/board_index.json

--- a/.gitignore
+++ b/.gitignore
@@ -320,3 +320,8 @@ scripts/fal-visual-teacher/output/
 # Board identity index — MACs of physical hardware, not secret, but not useful
 # to anyone else and it churns per fleet. Keep it local.
 firmware/esp32-csi-node/board_index.json
+
+# Provisioning profile: holds an SSID and the PATH to a credential file, never
+# a credential. Created by provision_node.py on first run; site-specific, so it
+# should not be committed.
+firmware/esp32-csi-node/provision_conf.json

--- a/.gitignore
+++ b/.gitignore
@@ -317,11 +317,3 @@ v2/crates/ruview-offaxis/pkg/
 scripts/fal-visual-teacher/training-data/
 scripts/fal-visual-teacher/training-data.zip
 scripts/fal-visual-teacher/output/
-# Board identity index — MACs of physical hardware, not secret, but not useful
-# to anyone else and it churns per fleet. Keep it local.
-firmware/esp32-csi-node/board_index.json
-
-# Provisioning profiles: hold an SSID and the PATH to a credential file, never
-# a credential. Globbed because --net <name> reads provision_conf_<name>.json,
-# so a new profile must not become committable simply by being created.
-firmware/esp32-csi-node/provision_conf*.json

--- a/.gitignore
+++ b/.gitignore
@@ -321,7 +321,7 @@ scripts/fal-visual-teacher/output/
 # to anyone else and it churns per fleet. Keep it local.
 firmware/esp32-csi-node/board_index.json
 
-# Provisioning profile: holds an SSID and the PATH to a credential file, never
-# a credential. Created by provision_node.py on first run; site-specific, so it
-# should not be committed.
-firmware/esp32-csi-node/provision_conf.json
+# Provisioning profiles: hold an SSID and the PATH to a credential file, never
+# a credential. Globbed because --net <name> reads provision_conf_<name>.json,
+# so a new profile must not become committable simply by being created.
+firmware/esp32-csi-node/provision_conf*.json

--- a/firmware/esp32-csi-node/board_index.py
+++ b/firmware/esp32-csi-node/board_index.py
@@ -82,9 +82,15 @@ def mac_via_esptool(port, chip="esp32c6"):
         except Exception:
             continue
         if r.returncode == 0:
-            # Prefer the "MAC: xx:.." line; fall back to any MAC in the output.
+            # BASE MAC is the authoritative one; take nothing else if it is
+            # present, because the other lines are derived forms.
             for line in r.stdout.splitlines():
-                if "MAC" in line.upper():
+                if "BASE MAC" in line.upper():
+                    m = MAC_RE.search(line)
+                    if m:
+                        return m.group(1).lower()
+            for line in r.stdout.splitlines():
+                if "MAC" in line.upper() and "EXT" not in line.upper():
                     m = MAC_RE.search(line)
                     if m:
                         return m.group(1).lower()

--- a/firmware/esp32-csi-node/board_index.py
+++ b/firmware/esp32-csi-node/board_index.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Identify ESP32 boards by MAC, not by serial port.
+
+Why this exists
+---------------
+`provision.py` keys its state files by **serial port**: COM3.json, COM5.json.
+A port is a property of which USB socket you happened to use, not of the board
+plugged into it. Cycling six boards through three ports makes a duplicate
+node_id near-certain, and nothing errors -- the second board silently takes the
+first one's identity, and you find out later when two nodes claim to be node 2
+and the link table quietly merges them.
+
+A MAC address is burned into the silicon. Keying on it means a board keeps its
+identity no matter which socket it lands in, in what order, on which machine.
+
+    python board_index.py                 # what is plugged in, and who is it
+    python board_index.py --assign        # give any unrecognised board an id
+    python board_index.py --watch         # sit and report boards as they mount
+
+The index is `board_index.json` next to this script. It only ever *adds*:
+an existing MAC's node_id is never rewritten, because that is the exact
+accident this tool exists to prevent.
+
+Reading the MAC resets the board into its bootloader, which is harmless when
+you are about to flash it and disruptive when you are not -- use --passive to
+sniff the boot log over serial instead, without touching the board.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+INDEX = os.path.join(HERE, "board_index.json")
+
+# Espressif OUIs seen on this fleet, plus the locally-administered forms the
+# ESP32 derives for its secondary interfaces.
+MAC_RE = re.compile(r"\b([0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5})\b")
+
+
+def load_index():
+    try:
+        with open(INDEX, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return {"boards": {}}
+
+
+def save_index(idx):
+    with open(INDEX, "w", encoding="utf-8") as fh:
+        json.dump(idx, fh, indent=2, sort_keys=True)
+
+
+def ports():
+    try:
+        from serial.tools import list_ports
+    except ImportError:
+        sys.exit("pyserial not installed:  pip install pyserial")
+    out = []
+    for p in list_ports.comports():
+        # Skip obvious non-boards (bluetooth bridges, virtual pairs) but do not
+        # be clever about it -- a board on an unrecognised adapter still counts,
+        # so only exclude what is definitely not a USB serial device.
+        if p.vid is None and p.pid is None:
+            continue
+        out.append((p.device, (p.description or "").strip()))
+    return sorted(out)
+
+
+def mac_via_esptool(port, chip="esp32c6"):
+    """Authoritative, but resets the board into the bootloader."""
+    for form in ("read_mac", "read-mac"):     # esptool 4.x vs 5.x spelling
+        try:
+            r = subprocess.run(
+                [sys.executable, "-m", "esptool", "--port", port,
+                 "--chip", chip, form],
+                capture_output=True, text=True, timeout=30)
+        except Exception:
+            continue
+        if r.returncode == 0:
+            # Prefer the "MAC: xx:.." line; fall back to any MAC in the output.
+            for line in r.stdout.splitlines():
+                if "MAC" in line.upper():
+                    m = MAC_RE.search(line)
+                    if m:
+                        return m.group(1).lower()
+            m = MAC_RE.search(r.stdout)
+            if m:
+                return m.group(1).lower()
+    return None
+
+
+def mac_via_log(port, seconds=12, baud=115200):
+    """Passive: watch the boot log. Needs the board to say its MAC, which it
+    does on the `mode : sta (..)` line shortly after boot -- so it only works
+    if the board reboots inside the window, or logs it periodically."""
+    try:
+        import serial
+    except ImportError:
+        return None
+    try:
+        with serial.Serial(port, baud, timeout=0.5) as ser:
+            end = time.time() + seconds
+            buf = ""
+            while time.time() < end:
+                try:
+                    buf += ser.read(512).decode("utf-8", "replace")
+                except Exception:
+                    break
+                m = MAC_RE.search(buf)
+                if m:
+                    return m.group(1).lower()
+    except Exception:
+        return None
+    return None
+
+
+def next_free_id(idx):
+    used = {b["node_id"] for b in idx["boards"].values()}
+    n = 0
+    while n in used:
+        n += 1
+    return n
+
+
+def identify(port, passive, chip):
+    return mac_via_log(port) if passive else mac_via_esptool(port, chip)
+
+
+def report(idx, assign, passive, chip):
+    found = ports()
+    if not found:
+        print("no serial boards mounted")
+        return []
+
+    rows = []
+    for port, desc in found:
+        mac = identify(port, passive, chip)
+        if not mac:
+            rows.append((port, desc, None, None, "unreadable"))
+            continue
+        entry = idx["boards"].get(mac)
+        if entry:
+            entry["last_port"] = port
+            entry["last_seen"] = time.strftime("%Y-%m-%d %H:%M:%S")
+            rows.append((port, desc, mac, entry["node_id"], "known"))
+        elif assign:
+            nid = next_free_id(idx)
+            idx["boards"][mac] = {
+                "node_id": nid,
+                "label": "",
+                "first_seen": time.strftime("%Y-%m-%d %H:%M:%S"),
+                "last_seen": time.strftime("%Y-%m-%d %H:%M:%S"),
+                "last_port": port,
+            }
+            rows.append((port, desc, mac, nid, "ASSIGNED"))
+        else:
+            rows.append((port, desc, mac, None, "NEW (run --assign)"))
+
+    print("%-8s %-18s %-11s %-9s %s" % ("port", "mac", "node_id", "state", "adapter"))
+    for port, desc, mac, nid, state in rows:
+        print("%-8s %-18s %-11s %-9s %s" % (
+            port, mac or "-", "-" if nid is None else str(nid), state, desc[:34]))
+
+    # A duplicate node_id in the index is the failure this tool exists to
+    # prevent, so say so loudly rather than printing a tidy table over it.
+    seen = {}
+    for mac, b in idx["boards"].items():
+        seen.setdefault(b["node_id"], []).append(mac)
+    dupes = {k: v for k, v in seen.items() if len(v) > 1}
+    if dupes:
+        print("\n*** DUPLICATE node_id IN INDEX ***")
+        for nid, macs in sorted(dupes.items()):
+            print("    node_id %d claimed by: %s" % (nid, ", ".join(macs)))
+        print("    Fix board_index.json before provisioning anything.")
+
+    if rows:
+        print("\nprovision a known board with, e.g.:")
+        for port, _, mac, nid, state in rows:
+            if nid is not None:
+                print("    python provision.py --port %s --chip %s --node-id %d "
+                      "--tdm-slot %d --tdm-total 9 \\\n"
+                      "        --ssid <SSID> --password <PSK> --target-ip <SERVER>"
+                      % (port, "esp32c6", nid, nid))
+                break
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--assign", action="store_true",
+                    help="give any unrecognised board the lowest free node_id")
+    ap.add_argument("--passive", action="store_true",
+                    help="read the boot log instead of resetting the board")
+    ap.add_argument("--watch", action="store_true",
+                    help="poll and report each board as it is mounted")
+    ap.add_argument("--chip", default="esp32c6")
+    ap.add_argument("--label", nargs=2, metavar=("MAC", "TEXT"),
+                    help="attach a human label to a MAC, e.g. --label aa:bb:.. kitchen")
+    args = ap.parse_args()
+
+    idx = load_index()
+
+    if args.label:
+        mac = args.label[0].lower()
+        if mac not in idx["boards"]:
+            sys.exit("unknown MAC %s -- mount it and run --assign first" % mac)
+        idx["boards"][mac]["label"] = args.label[1]
+        save_index(idx)
+        print("labelled %s -> %s" % (mac, args.label[1]))
+        return
+
+    if args.watch:
+        print("watching for boards -- Ctrl-C to stop")
+        known_ports = set()
+        try:
+            while True:
+                now = {p for p, _ in ports()}
+                if now != known_ports:
+                    new = now - known_ports
+                    if new:
+                        print("\n[%s] mounted: %s" %
+                              (time.strftime("%H:%M:%S"), ", ".join(sorted(new))))
+                        report(idx, args.assign, args.passive, args.chip)
+                        save_index(idx)
+                    known_ports = now
+                time.sleep(2)
+        except KeyboardInterrupt:
+            print("\nstopped")
+        return
+
+    report(idx, args.assign, args.passive, args.chip)
+    save_index(idx)
+
+
+if __name__ == "__main__":
+    main()

--- a/firmware/esp32-csi-node/bringup.py
+++ b/firmware/esp32-csi-node/bringup.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Take every board currently plugged in from factory state to wall-ready.
+
+Bringing up nine boards by hand is six commands each with an ordering that is
+easy to get wrong in ways that do not announce themselves:
+
+  * flashing without `0xf000 ota_data_initial.bin` leaves otadata pointing at
+    the other OTA slot, so the board silently boots the PREVIOUS image and the
+    flash looks like it did nothing (cost me a wasted cycle on 2026-08-30);
+  * provisioning without --tdm-total leaves the ESP-NOW beacon period sized for
+    the wrong fleet, and a single mismatched node took the whole mesh to zero
+    delivery for five minutes;
+  * a board provisioned without an OTA PSK is USB-update-only forever, which is
+    only discovered later, from a ladder.
+
+So this does the whole sequence and then VERIFIES it off the boot log rather
+than trusting that each step worked. A board that does not print the expected
+lines is reported as not ready.
+
+    python bringup.py --net home --tdm-total 9
+    python bringup.py --net home --tdm-total 9 --port COM7   # just one
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD = os.path.join(HERE, "build")
+
+FLASH_REGIONS = [
+    ("0x0",     "bootloader/bootloader.bin"),
+    ("0x8000",  "partition_table/partition-table.bin"),
+    ("0xf000",  "ota_data_initial.bin"),          # never omit: see docstring
+    ("0x20000", "esp32-csi-node.bin"),
+]
+
+
+def run(cmd, timeout=600):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def ports():
+    from serial.tools import list_ports
+    return sorted(p.device for p in list_ports.comports() if p.vid or p.pid)
+
+
+def flash(port):
+    cmd = [sys.executable, "-m", "esptool", "--chip", "esp32c6", "--port", port,
+           "--baud", "460800", "--before", "default-reset", "--after",
+           "hard-reset", "write-flash", "--flash-mode", "dio",
+           "--flash-size", "16MB", "--flash-freq", "80m"]
+    for off, rel in FLASH_REGIONS:
+        cmd += [off, os.path.join(BUILD, rel)]
+    r = run(cmd)
+    ok = r.stdout.lower().count("hash of data verified") == len(FLASH_REGIONS)
+    return ok, (r.stderr or r.stdout)[-300:]
+
+
+def provision(port, net, total):
+    cmd = [sys.executable, os.path.join(HERE, "provision_node.py"),
+           "--port", port, "--tdm-total", str(total)]
+    if net:
+        cmd += ["--net", net]
+    r = run(cmd)
+    return ("ok -- NVS written" in r.stdout), (r.stderr or r.stdout)[-300:]
+
+
+def verify(port, expect_ssid, expect_fleet, seconds=22):
+    """Read the boot log and confirm the four things that silently go wrong."""
+    try:
+        import serial
+    except ImportError:
+        return None, "pyserial missing"
+    try:
+        with serial.Serial(port, 115200, timeout=0.3) as ser:
+            ser.setDTR(False); ser.setRTS(True); time.sleep(0.15)
+            ser.setRTS(False); ser.reset_input_buffer()
+            end = time.time() + seconds
+            buf = b""
+            while time.time() < end:
+                buf += ser.read(4096)
+    except Exception as e:
+        return None, str(e)
+    t = buf.decode("utf-8", "replace")
+    checks = {
+        "ssid":  ("ssid=%s" % expect_ssid) in t,
+        "fleet": ("fleet=%d" % expect_fleet) in t,
+        "psk":   "OTA PSK loaded from NVS" in t,
+        "ip":    "Got IP:" in t,
+    }
+    ip = re.search(r"Got IP: ([0-9.]+)", t)
+    return checks, (ip.group(1) if ip else "?")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--net", help="network profile (provision_conf_<net>.json)")
+    ap.add_argument("--tdm-total", type=int, required=True)
+    ap.add_argument("--port", help="only this port; default is every board plugged in")
+    a = ap.parse_args()
+
+    if not os.path.exists(os.path.join(BUILD, "esp32-csi-node.bin")):
+        sys.exit("no build at %s -- run idf.py build first" % BUILD)
+
+    targets = [a.port] if a.port else ports()
+    if not targets:
+        sys.exit("no serial boards plugged in")
+
+    # MAC-keyed identity first, so a board keeps its node_id regardless of which
+    # USB socket it landed in. --assign only ever adds.
+    idx = run([sys.executable, os.path.join(HERE, "board_index.py"), "--assign"])
+    print(idx.stdout.strip().split("provision a known board")[0].strip())
+    print()
+
+    ssid = "?"
+    conf = os.path.join(HERE, "provision_conf_%s.json" % a.net if a.net
+                        else "provision_conf.json")
+    if os.path.exists(conf):
+        import json
+        ssid = json.load(open(conf)).get("ssid", "?")
+
+    ready, failed = [], []
+    for port in targets:
+        print("=" * 58)
+        print("%s" % port)
+        ok, msg = flash(port)
+        print("  flash      %s" % ("ok" if ok else "FAILED: " + msg))
+        if not ok:
+            failed.append(port); continue
+        ok, msg = provision(port, a.net, a.tdm_total)
+        print("  provision  %s" % ("ok" if ok else "FAILED: " + msg))
+        if not ok:
+            failed.append(port); continue
+        checks, ip = verify(port, ssid, a.tdm_total)
+        if checks is None:
+            print("  verify     could not read console (%s)" % ip)
+            failed.append(port); continue
+        print("  verify     ssid=%s fleet=%s psk=%s ip=%s (%s)"
+              % (checks["ssid"], checks["fleet"], checks["psk"],
+                 checks["ip"], ip))
+        (ready if all(checks.values()) else failed).append(port)
+
+    print("\n" + "=" * 58)
+    print("READY:  %s" % (", ".join(ready) or "none"))
+    if failed:
+        print("FAILED: %s  <- do not mount these" % ", ".join(failed))
+
+
+if __name__ == "__main__":
+    main()

--- a/firmware/esp32-csi-node/provision.py
+++ b/firmware/esp32-csi-node/provision.py
@@ -79,6 +79,7 @@ CONFIG_VALUE_CHECKS = [
     ("zone", lambda value: value is not None),
     ("swarm_hb", lambda value: value is not None),
     ("swarm_ingest", lambda value: value is not None),
+    ("ota_psk", lambda value: value is not None),
 ]
 
 
@@ -100,14 +101,24 @@ def has_config_value(args):
 
 # argparse attribute names that participate in the merge. Order doesn't
 # matter; this is just the surface area to round-trip.
+#
+# SECRETS ARE DELIBERATELY EXCLUDED. "password" and "seed_token" used to be in
+# this list, which meant every successful run wrote the WiFi passphrase in
+# cleartext to a JSON file under the user's config dir -- defeating the point
+# of keeping credentials in a file outside the repo, and leaving stale copies
+# of retired passwords lying around after an SSID change. The cost of leaving
+# them out is that a secret must be supplied on every run rather than merged
+# from prior state; provision_node.py already does exactly that, reading them
+# from files, and a direct provision.py call now fails loudly instead of
+# silently reusing an old credential. Do not add them back.
 MERGEABLE_ATTRS = [
-    "ssid", "password", "target_ip", "target_port", "node_id",
+    "ssid", "target_ip", "target_port", "node_id",
     "tdm_slot", "tdm_total",
     "edge_tier", "pres_thresh", "fall_thresh",
     "vital_win", "vital_int", "subk_count",
     "channel", "filter_mac",
     "hop_channels", "hop_dwell",
-    "seed_url", "seed_token", "zone", "swarm_hb", "swarm_ingest",
+    "seed_url", "zone", "swarm_hb", "swarm_ingest",
 ]
 
 
@@ -144,10 +155,17 @@ def load_state(port: str, state_dir: str) -> dict:
     return {}
 
 
+SECRET_ATTRS = ("password", "seed_token", "ota_psk")
+
+
 def save_state(port: str, state_dir: str, state: dict) -> str:
     """Write `state` to the per-port file, creating dirs as needed. Returns path."""
     os.makedirs(state_dir, exist_ok=True)
     path = _state_path_for(port, state_dir)
+    # Enforced here rather than relying on MERGEABLE_ATTRS alone, so a secret
+    # cannot reach the disk by a route someone adds later. This file is a
+    # convenience cache; it is never worth a credential.
+    state = {k: v for k, v in state.items() if k not in SECRET_ATTRS}
     # Sort keys for deterministic on-disk content (easier to diff).
     tmp = path + ".tmp"
     with open(tmp, "w", encoding="utf-8") as f:
@@ -234,6 +252,18 @@ def build_nvs_csv(args):
         writer.writerow(["swarm_hb", "data", "u16", str(args.swarm_hb)])
     if args.swarm_ingest is not None:
         writer.writerow(["swarm_ingest", "data", "u16", str(args.swarm_ingest)])
+    # ADR-050: OTA pre-shared key. Separate NVS namespace ("security"), which
+    # is what ota_update.c's ota_load_psk_from_nvs() opens. Must come after
+    # every csi_cfg row -- in an NVS CSV a `namespace` row starts a section and
+    # everything below it belongs to that namespace until the next one.
+    #
+    # Deliberately NOT in MERGEABLE_ATTRS: that would round-trip the key in
+    # cleartext through the per-port JSON state file, which is how the WiFi
+    # password is already handled and is not a habit worth spreading. The cost
+    # is that the key must be supplied on every run -- see the warning below.
+    if getattr(args, "ota_psk", None):
+        writer.writerow(["security", "namespace", "", ""])
+        writer.writerow(["ota_psk", "data", "string", args.ota_psk])
     return buf.getvalue()
 
 
@@ -354,6 +384,12 @@ def main():
     parser.add_argument("--zone", type=str, help="Zone name for this node (e.g. lobby, hallway)")
     parser.add_argument("--swarm-hb", type=int, help="Swarm heartbeat interval in seconds (default 30)")
     parser.add_argument("--swarm-ingest", type=int, help="Swarm vector ingest interval in seconds (default 5)")
+    parser.add_argument("--ota-psk", type=str,
+                        help="OTA pre-shared key (hex). Without it the node's "
+                             "OTA upload endpoint rejects everything, so the "
+                             "board can only ever be updated over USB. Prefer "
+                             "provision_node.py, which reads this from a file "
+                             "instead of a command line.")
     parser.add_argument("--dry-run", action="store_true", help="Generate NVS binary but don't flash")
     parser.add_argument("--force-partial", action="store_true",
                         help="[deprecated since #391/#574] Suppress the missing-WiFi-trio "
@@ -439,6 +475,20 @@ def main():
                     raise ValueError
         except ValueError:
             parser.error(f"--filter-mac contains invalid hex bytes: '{args.filter_mac}'")
+
+    # Flashing NVS rewrites the whole partition, so a namespace that is absent
+    # from this run's CSV is erased from the board. Omitting --ota-psk on a
+    # reprovision therefore silently revokes the node's OTA key and drops it
+    # back to USB-only updates -- and because ota_check_auth() fails closed,
+    # nothing about the node's behaviour announces it. Say so out loud.
+    if not getattr(args, "ota_psk", None):
+        print(
+            "WARNING: no --ota-psk on this run. The 'security' NVS namespace "
+            "will be absent, so this board will REJECT every OTA upload and "
+            "can only be updated over USB. Use provision_node.py to supply the "
+            "key from a file.",
+            file=sys.stderr,
+        )
 
     print("Building NVS configuration:")
     if args.ssid:

--- a/firmware/esp32-csi-node/provision.py
+++ b/firmware/esp32-csi-node/provision.py
@@ -140,8 +140,18 @@ def _state_path_for(port: str, state_dir: str) -> str:
     return os.path.join(state_dir, f"{safe}.json")
 
 
+SECRET_ATTRS = ("password", "seed_token", "ota_psk")
+
+
 def load_state(port: str, state_dir: str) -> dict:
-    """Return the merged-state dict for `port`, or `{}` if absent / unreadable."""
+    """Return the merged-state dict for `port`, or `{}` if absent / unreadable.
+
+    A state file written before secrets were excluded still holds the WiFi
+    passphrase in cleartext. Reading one is the only moment we are certain
+    such a file exists, so scrub it here and rewrite it immediately rather
+    than waiting for the next successful run to overwrite it -- a run that
+    may never happen on a board that has been retired or moved.
+    """
     path = _state_path_for(port, state_dir)
     if not os.path.isfile(path):
         return {}
@@ -149,13 +159,28 @@ def load_state(port: str, state_dir: str) -> dict:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         if isinstance(data, dict):
+            stale = [k for k in SECRET_ATTRS if k in data]
+            if stale:
+                data = {k: v for k, v in data.items() if k not in SECRET_ATTRS}
+                print(
+                    f"NOTE: removed {', '.join(stale)} from the state file "
+                    f"{path}. Credentials are no longer cached there; supply "
+                    f"them on this run (provision_node.py reads them from "
+                    f"files).",
+                    file=sys.stderr,
+                )
+                try:
+                    save_state(port, state_dir, data)
+                except OSError as exc:
+                    print(
+                        f"WARNING: could not rewrite {path} without the "
+                        f"credential: {exc}",
+                        file=sys.stderr,
+                    )
             return data
     except (OSError, json.JSONDecodeError) as exc:
         print(f"WARNING: could not read state file {path}: {exc}", file=sys.stderr)
     return {}
-
-
-SECRET_ATTRS = ("password", "seed_token", "ota_psk")
 
 
 def save_state(port: str, state_dir: str, state: dict) -> str:
@@ -439,13 +464,25 @@ def main():
         ] if val is None or val == ""
     ]
     if wifi_trio_missing and not args.force_partial:
+        state_path = _state_path_for(args.port, args.state_dir)
+        # Distinguish the two ways to land here. "No state file" was the only
+        # cause until secrets stopped being cached; saying it when the file is
+        # sitting right there sends the operator looking for the wrong problem.
+        if os.path.isfile(state_path):
+            why = (f"  The state file {state_path} exists but does not carry\n"
+                   f"  credentials -- they are no longer cached there -- and the\n"
+                   f"  CLI didn't include them.\n")
+        else:
+            why = (f"  No per-port state file at {state_path}\n"
+                   f"  and the CLI didn't include them.\n")
         parser.error(
             f"Missing required WiFi credentials after merging prior state: "
             f"{', '.join(wifi_trio_missing)}.\n"
             f"\n"
-            f"  No per-port state file at {_state_path_for(args.port, args.state_dir)}\n"
-            f"  and the CLI didn't include them. Either pass --ssid + --password + --target-ip\n"
-            f"  on this run, or add --force-partial to flash without WiFi.\n"
+            f"{why}"
+            f"  Either pass --ssid + --password + --target-ip on this run\n"
+            f"  (provision_node.py reads them from files), or add\n"
+            f"  --force-partial to flash without WiFi.\n"
         )
     if args.force_partial and wifi_trio_missing:
         print(

--- a/firmware/esp32-csi-node/provision_node.py
+++ b/firmware/esp32-csi-node/provision_node.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Provision a node without putting the WiFi password on a command line.
+
+`provision.py` takes --password as an argument, so every invocation leaves the
+credential in shell history, process listings, terminal scrollback and any
+transcript of the session. That is a poor place for it and an easy thing to
+forget you did.
+
+This reads the password from a file, passes it to provision.py as a subprocess
+argument (unavoidable -- that is provision.py's only interface), and never
+prints or echoes it. The password still appears briefly in the child process's
+argv, so this is not protection against a local attacker; it is protection
+against the credential being permanently recorded somewhere it does not belong.
+
+It also fills in the two things that are easy to get wrong by hand:
+
+  * node_id comes from board_index.py's MAC index, so a board keeps its
+    identity regardless of which USB socket it lands in.
+  * --tdm-total is required, not optional. The firmware derives its ESP-NOW
+    beacon period from it (c6_sync_espnow_period_ms), and a node provisioned
+    without it reports `fleet=1` and falls back to the 80 ms default -- which
+    is correct for three nodes and silently overruns the 50 Hz receive gate at
+    nine. Measured on 2026-08-28: an over-fast beacon discarded 60-90% of peer
+    frames at random and wedged a transmit queue.
+
+    python provision_node.py --port COM3 --tdm-total 9
+    python provision_node.py --all --tdm-total 9      # every mounted board
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CONF = os.path.join(HERE, "provision_conf.json")
+
+
+def load_conf():
+    if not os.path.exists(CONF):
+        sys.exit(
+            "no %s.\n\nCreate it with:\n"
+            '  {\n'
+            '    "ssid": "SilverESP",\n'
+            '    "password_file": "D:\\\\path\\\\to\\\\SilverESP.txt",\n'
+            '    "target_ip": "192.168.1.66",\n'
+            '    "chip": "esp32c6",\n'
+            '    "edge_tier": 2\n'
+            '  }\n\n'
+            "password_file holds the passphrase and nothing else. Keep it "
+            "outside this repo." % CONF)
+    with open(CONF, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def read_password(path):
+    try:
+        with open(path, encoding="utf-8-sig") as fh:
+            pw = fh.read().strip()
+    except Exception as e:
+        sys.exit("cannot read password file: %s" % e)
+    if not pw:
+        sys.exit("password file is empty")
+    if len(pw) < 8:
+        sys.exit("password is %d chars; WPA needs at least 8 -- is the file "
+                 "holding something else?" % len(pw))
+    return pw
+
+
+def node_id_for(port):
+    """Ask board_index.py who this board is, so identity follows the MAC."""
+    idx_path = os.path.join(HERE, "board_index.json")
+    try:
+        with open(idx_path, encoding="utf-8") as fh:
+            idx = json.load(fh)
+    except Exception:
+        return None
+    for mac, b in idx.get("boards", {}).items():
+        if b.get("last_port") == port:
+            return b["node_id"], mac
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--port", help="serial port; omit with --all")
+    ap.add_argument("--all", action="store_true",
+                    help="provision every board currently in the index")
+    ap.add_argument("--tdm-total", type=int, required=True,
+                    help="TOTAL nodes in the fleet. Required: the firmware "
+                         "derives its beacon period from this and gets it "
+                         "wrong, silently, if left unset.")
+    ap.add_argument("--node-id", type=int,
+                    help="override the id from board_index.json")
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args()
+
+    conf = load_conf()
+    pw = read_password(conf["password_file"])
+
+    targets = []
+    if a.all:
+        idx_path = os.path.join(HERE, "board_index.json")
+        with open(idx_path, encoding="utf-8") as fh:
+            idx = json.load(fh)
+        for mac, b in sorted(idx["boards"].items(), key=lambda kv: kv[1]["node_id"]):
+            if b.get("last_port"):
+                targets.append((b["last_port"], b["node_id"], mac))
+    else:
+        if not a.port:
+            sys.exit("--port or --all required")
+        nid = a.node_id
+        mac = "?"
+        found = node_id_for(a.port)
+        if found and nid is None:
+            nid, mac = found
+        if nid is None:
+            sys.exit("no node_id for %s -- run board_index.py --assign first, "
+                     "or pass --node-id" % a.port)
+        targets.append((a.port, nid, mac))
+
+    if a.tdm_total < len(targets):
+        sys.exit("--tdm-total %d is smaller than the %d boards being "
+                 "provisioned" % (a.tdm_total, len(targets)))
+
+    for port, nid, mac in targets:
+        cmd = [sys.executable, os.path.join(HERE, "provision.py"),
+               "--port", port,
+               "--chip", conf.get("chip", "esp32c6"),
+               "--ssid", conf["ssid"],
+               "--password", pw,
+               "--target-ip", conf["target_ip"],
+               "--node-id", str(nid),
+               "--tdm-slot", str(nid),
+               "--tdm-total", str(a.tdm_total),
+               "--edge-tier", str(conf.get("edge_tier", 2))]
+        shown = [c if c != pw else "<password>" for c in cmd]
+        print("\n%s  node %d  (%s)" % (port, nid, mac))
+        print("  " + " ".join(shown[1:]))
+        if a.dry_run:
+            continue
+        r = subprocess.run(cmd)
+        if r.returncode != 0:
+            print("  FAILED rc=%d" % r.returncode)
+        else:
+            print("  ok -- confirm the boot log says fleet=%d" % a.tdm_total)
+
+
+if __name__ == "__main__":
+    main()

--- a/firmware/esp32-csi-node/provision_node.py
+++ b/firmware/esp32-csi-node/provision_node.py
@@ -223,6 +223,11 @@ def main():
         print("  " + " ".join(shown[1:]))
         if a.dry_run:
             continue
+        # nosemgrep: dangerous-subprocess-use-audit
+        # List form, no shell=True: argv goes straight to execve, so there is no
+        # shell to inject into. The elements are a fixed flag sequence plus values
+        # from a local operator-owned config file; a hostile value can only become
+        # one bad argument to provision.py, not a second command.
         r = subprocess.run(cmd, capture_output=True, text=True)
         # provision.py cannot build the NVS image without ESP-IDF on PATH, so
         # on a bare Windows host it writes nvs_config.csv and stops. Finish the
@@ -252,6 +257,8 @@ def main():
             if a.no_auto_reset:
                 esp += ["--before", "no-reset"]
             esp += ["write_flash", NVS_OFFSET, binp]
+            # nosemgrep: dangerous-subprocess-use-audit
+            # Same reasoning as above: list form, no shell.
             f = subprocess.run(esp, capture_output=True, text=True)
             if "verified" in f.stdout or f.returncode == 0:
                 print("  ok -- NVS written at %s. Confirm the boot log says "

--- a/firmware/esp32-csi-node/provision_node.py
+++ b/firmware/esp32-csi-node/provision_node.py
@@ -266,16 +266,21 @@ def main():
         print("  " + " ".join(shown[1:]))
         if a.dry_run:
             continue
-        # List form with no shell=True: argv goes straight to execve, so there
-        # is no shell to inject into and a hostile value can only ever become
-        # one bad argument to provision.py, never a second command. Every
-        # element that is not a literal is range-checked above.
+        # Semgrep reports dangerous-subprocess-use-tainted-env-args here and
+        # suggests shlex.quote(). Do not apply it: quoting is for building a
+        # shell string, and this is the list form with no shell=True, so argv
+        # goes straight to execve. shlex.quote would hand provision.py a port
+        # named "'COM7'", quotes included, and break provisioning to satisfy a
+        # scanner. There is no shell to inject into; a hostile value can only
+        # ever become one bad argument, never a second command, and `port` is
+        # range-checked above.
         #
-        # An earlier attempt named the rule `dangerous-subprocess-use-audit`,
-        # which is a different rule and suppressed nothing. Both spellings of
-        # the id that actually fires are listed because the registry reports
-        # the fully-qualified form and local runs report the short one.
-        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args, dangerous-subprocess-use-tainted-env-args
+        # The finding is left visible rather than suppressed. The suppression
+        # pragma does not take effect in this workflow -- it was tried on the
+        # line above the call and on the reported line itself, and the finding
+        # survived both -- and the SAST job is `continue-on-error: true` by
+        # design, so it does not gate the PR. The pragma is not even spelled
+        # out here: on its own in a comment it is blanket-suppression syntax.
         r = subprocess.run(cmd, capture_output=True, text=True)
         # provision.py cannot build the NVS image without ESP-IDF on PATH, so
         # on a bare Windows host it writes nvs_config.csv and stops. Finish the
@@ -305,9 +310,9 @@ def main():
             if a.no_auto_reset:
                 esp += ["--before", "no-reset"]
             esp += ["write_flash", NVS_OFFSET, binp]
-            # Same reasoning as the provision.py call above: list form, no
-            # shell, and `chip` and `port` are the only non-literals.
-            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args, dangerous-subprocess-use-tainted-env-args
+            # Same finding and same reasoning as the provision.py call above:
+            # list form, no shell, shlex.quote inapplicable, and `chip` and
+            # `port` are the only non-literals.
             f = subprocess.run(esp, capture_output=True, text=True)
             if "verified" in f.stdout or f.returncode == 0:
                 print("  ok -- NVS written at %s. Confirm the boot log says "

--- a/firmware/esp32-csi-node/provision_node.py
+++ b/firmware/esp32-csi-node/provision_node.py
@@ -238,6 +238,16 @@ def main():
     if edge_tier not in (0, 1, 2):
         sys.exit("edge_tier must be 0, 1 or 2 (got %d)" % edge_tier)
 
+    # Ports arrive from --port or from board_index.json, so they are the one
+    # remaining non-literal in the esptool argv. Real device nodes are
+    # COM7, /dev/ttyUSB0, /dev/cu.usbserial-1420 -- none of which need a
+    # character outside this set.
+    for port, _nid, _mac in targets:
+        if not port or len(port) > 64 or not all(
+                c.isalnum() or c in "/\\.-_:" for c in port):
+            sys.exit("refusing to use %r as a serial port: expected something "
+                     "like COM7 or /dev/ttyUSB0" % port)
+
     for port, nid, mac in targets:
         cmd = [sys.executable, os.path.join(HERE, "provision.py"),
                "--port", port,
@@ -256,6 +266,16 @@ def main():
         print("  " + " ".join(shown[1:]))
         if a.dry_run:
             continue
+        # List form with no shell=True: argv goes straight to execve, so there
+        # is no shell to inject into and a hostile value can only ever become
+        # one bad argument to provision.py, never a second command. Every
+        # element that is not a literal is range-checked above.
+        #
+        # An earlier attempt named the rule `dangerous-subprocess-use-audit`,
+        # which is a different rule and suppressed nothing. Both spellings of
+        # the id that actually fires are listed because the registry reports
+        # the fully-qualified form and local runs report the short one.
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args, dangerous-subprocess-use-tainted-env-args
         r = subprocess.run(cmd, capture_output=True, text=True)
         # provision.py cannot build the NVS image without ESP-IDF on PATH, so
         # on a bare Windows host it writes nvs_config.csv and stops. Finish the
@@ -285,6 +305,9 @@ def main():
             if a.no_auto_reset:
                 esp += ["--before", "no-reset"]
             esp += ["write_flash", NVS_OFFSET, binp]
+            # Same reasoning as the provision.py call above: list form, no
+            # shell, and `chip` and `port` are the only non-literals.
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args, dangerous-subprocess-use-tainted-env-args
             f = subprocess.run(esp, capture_output=True, text=True)
             if "verified" in f.stdout or f.returncode == 0:
                 print("  ok -- NVS written at %s. Confirm the boot log says "

--- a/firmware/esp32-csi-node/provision_node.py
+++ b/firmware/esp32-csi-node/provision_node.py
@@ -37,6 +37,7 @@ It also fills in the two things that are easy to get wrong by hand:
 
 import argparse
 import json
+import ipaddress
 import os
 import secrets
 import stat
@@ -205,17 +206,49 @@ def main():
         sys.exit("--tdm-total %d is smaller than the %d boards being "
                  "provisioned" % (a.tdm_total, len(targets)))
 
+    # Validate everything that reaches an argv list before it gets there.
+    #
+    # These values come from a JSON config and CLI flags, which a scanner
+    # rightly treats as untrusted. subprocess is called in list form with no
+    # shell, so this is not a command-injection path -- but "no shell" is a
+    # property of THIS call site, and the values also end up in esptool
+    # arguments and a flash offset. Constraining them here means the safety
+    # does not depend on remembering that, and a typo fails loudly at the top
+    # instead of surfacing as a confusing esptool error nine boards in.
+    CHIPS = {"esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c5", "esp32c6", "esp32h2"}
+    chip = str(conf.get("chip", "esp32c6"))
+    if chip not in CHIPS:
+        sys.exit("unsupported chip %r in config (expected one of %s)"
+                 % (chip, ", ".join(sorted(CHIPS))))
+
+    ssid = str(conf["ssid"])
+    if not ssid or len(ssid) > 32:
+        sys.exit("ssid must be 1-32 characters (802.11 limit)")
+
+    target_ip = str(conf["target_ip"])
+    try:
+        ipaddress.ip_address(target_ip)
+    except ValueError:
+        sys.exit("target_ip %r is not a valid IP address" % target_ip)
+
+    try:
+        edge_tier = int(conf.get("edge_tier", 2))
+    except (TypeError, ValueError):
+        sys.exit("edge_tier must be an integer")
+    if edge_tier not in (0, 1, 2):
+        sys.exit("edge_tier must be 0, 1 or 2 (got %d)" % edge_tier)
+
     for port, nid, mac in targets:
         cmd = [sys.executable, os.path.join(HERE, "provision.py"),
                "--port", port,
-               "--chip", conf.get("chip", "esp32c6"),
-               "--ssid", conf["ssid"],
+               "--chip", chip,
+               "--ssid", ssid,
                "--password", pw,
-               "--target-ip", conf["target_ip"],
+               "--target-ip", target_ip,
                "--node-id", str(nid),
                "--tdm-slot", str(nid),
                "--tdm-total", str(a.tdm_total),
-               "--edge-tier", str(conf.get("edge_tier", 2)),
+               "--edge-tier", str(edge_tier),
                "--ota-psk", psk]
         redact = {pw: "<password>", psk: "<ota-psk>"}
         shown = [redact.get(c, c) for c in cmd]
@@ -223,11 +256,6 @@ def main():
         print("  " + " ".join(shown[1:]))
         if a.dry_run:
             continue
-        # nosemgrep: dangerous-subprocess-use-audit
-        # List form, no shell=True: argv goes straight to execve, so there is no
-        # shell to inject into. The elements are a fixed flag sequence plus values
-        # from a local operator-owned config file; a hostile value can only become
-        # one bad argument to provision.py, not a second command.
         r = subprocess.run(cmd, capture_output=True, text=True)
         # provision.py cannot build the NVS image without ESP-IDF on PATH, so
         # on a bare Windows host it writes nvs_config.csv and stops. Finish the
@@ -252,13 +280,11 @@ def main():
                 print("  " + (g.stderr or g.stdout).strip()[-300:])
                 continue
             esp = [sys.executable, "-m", "esptool", "--chip",
-                   conf.get("chip", "esp32c6"), "--port", port,
+                   chip, "--port", port,
                    "--baud", "460800"]
             if a.no_auto_reset:
                 esp += ["--before", "no-reset"]
             esp += ["write_flash", NVS_OFFSET, binp]
-            # nosemgrep: dangerous-subprocess-use-audit
-            # Same reasoning as above: list form, no shell.
             f = subprocess.run(esp, capture_output=True, text=True)
             if "verified" in f.stdout or f.returncode == 0:
                 print("  ok -- NVS written at %s. Confirm the boot log says "

--- a/firmware/esp32-csi-node/provision_node.py
+++ b/firmware/esp32-csi-node/provision_node.py
@@ -23,6 +23,14 @@ It also fills in the two things that are easy to get wrong by hand:
     nine. Measured on 2026-08-28: an over-fast beacon discarded 60-90% of peer
     frames at random and wedged a transmit queue.
 
+  * --ota-psk is supplied from a file, generating one on first use. Without a
+    provisioned key the node's OTA endpoint fails closed and the board can only
+    ever be updated over USB -- which, once nine boards are screwed to walls,
+    turns every firmware fix into a ladder job. Flashing NVS rewrites the whole
+    partition, so the key has to be present on EVERY provisioning run or it is
+    erased; that is exactly why it lives in a file this script always reads
+    rather than a flag someone has to remember.
+
     python provision_node.py --port COM3 --tdm-total 9
     python provision_node.py --all --tdm-total 9      # every mounted board
 """
@@ -30,21 +38,34 @@ It also fills in the two things that are easy to get wrong by hand:
 import argparse
 import json
 import os
+import secrets
+import stat
 import subprocess
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 CONF = os.path.join(HERE, "provision_conf.json")
+# Alternate network profiles live beside it as provision_conf_<name>.json,
+# selected with --net <name>. Reverting a fleet to a known-good SSID is a
+# diagnostic move that wants to be one flag, not an edit-and-remember-to-
+# put-it-back on a file that also holds the path to a credential.
+# NVS partition offset from partitions_4mb.csv. Nothing else is written, so a
+# firmware image already on the board is untouched by provisioning.
+NVS_OFFSET = "0x9000"
 
 
-def load_conf():
+def load_conf(net=None):
+    global CONF
+    if net:
+        CONF = os.path.join(HERE, "provision_conf_%s.json" % net)
     if not os.path.exists(CONF):
         sys.exit(
             "no %s.\n\nCreate it with:\n"
             '  {\n'
-            '    "ssid": "SilverESP",\n'
-            '    "password_file": "D:\\\\path\\\\to\\\\SilverESP.txt",\n'
-            '    "target_ip": "192.168.1.66",\n'
+            '    "ssid": "thisismyssid",\n'
+            '    "password_file": "D:\\\\path\\\\to\\\\thisismyssid.txt",\n'
+            '    "target_ip": "192.168.1.10",\n'
+            '    "ota_psk_file": "D:\\\\path\\\\to\\\\ota_psk.txt",\n'
             '    "chip": "esp32c6",\n'
             '    "edge_tier": 2\n'
             '  }\n\n'
@@ -66,6 +87,54 @@ def read_password(path):
         sys.exit("password is %d chars; WPA needs at least 8 -- is the file "
                  "holding something else?" % len(pw))
     return pw
+
+
+def read_or_create_psk(conf):
+    """Return the fleet's OTA pre-shared key, creating it on first use.
+
+    One key for the whole fleet rather than one per node: the point of OTA here
+    is pushing a build to every board at once, and per-node keys would mean
+    tracking nine secrets to do it. The blast radius is the same as the WiFi
+    passphrase, which any host on this VLAN already needs.
+
+    Kept outside the repo for the same reason the passphrase is, and refused if
+    it is not -- a secret inside a git worktree is one `git add -A` from being
+    committed.
+    """
+    path = conf.get("ota_psk_file")
+    if not path:
+        # Default alongside the passphrase, which is already outside the repo.
+        path = os.path.join(os.path.dirname(conf["password_file"]), "ota_psk.txt")
+
+    real = os.path.realpath(path)
+    if real.startswith(os.path.realpath(HERE) + os.sep):
+        sys.exit("ota_psk_file is inside the repository (%s). Move it outside "
+                 "the worktree; secrets there are one 'git add -A' from being "
+                 "committed." % real)
+
+    if os.path.exists(path):
+        try:
+            with open(path, encoding="utf-8-sig") as fh:
+                psk = fh.read().strip()
+        except Exception as e:
+            sys.exit("cannot read ota_psk_file: %s" % e)
+        if psk:
+            # ota_update.c caps the key at 65 bytes including the NUL.
+            if len(psk) > 64:
+                sys.exit("OTA PSK is %d chars; the firmware accepts at most 64"
+                         % len(psk))
+            return psk
+
+    psk = secrets.token_hex(32)          # 64 hex chars
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(psk + "\n")
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    except Exception as e:
+        sys.exit("cannot create ota_psk_file at %s: %s" % (path, e))
+    print("generated a new fleet OTA key at %s -- back this up; without it you "
+          "cannot push firmware to these boards over the network." % path)
+    return psk
 
 
 def node_id_for(port):
@@ -94,11 +163,22 @@ def main():
                          "wrong, silently, if left unset.")
     ap.add_argument("--node-id", type=int,
                     help="override the id from board_index.json")
+    ap.add_argument("--net",
+                    help="network profile name; reads provision_conf_<name>.json "
+                         "instead of provision_conf.json (e.g. --net home)")
+    ap.add_argument("--no-auto-reset", action="store_true",
+                    help="board is ALREADY in the bootloader (BOOT held, "
+                         "RESET tapped). Some units have a non-functional "
+                         "auto-reset circuit: the CH343 enumerates and the "
+                         "chip runs fine, but it never hears DTR/RTS, so "
+                         "esptool reports 'No serial data received'. Skips "
+                         "the reset so one button press covers the flash.")
     ap.add_argument("--dry-run", action="store_true")
     a = ap.parse_args()
 
-    conf = load_conf()
+    conf = load_conf(a.net)
     pw = read_password(conf["password_file"])
+    psk = read_or_create_psk(conf)
 
     targets = []
     if a.all:
@@ -135,17 +215,56 @@ def main():
                "--node-id", str(nid),
                "--tdm-slot", str(nid),
                "--tdm-total", str(a.tdm_total),
-               "--edge-tier", str(conf.get("edge_tier", 2))]
-        shown = [c if c != pw else "<password>" for c in cmd]
+               "--edge-tier", str(conf.get("edge_tier", 2)),
+               "--ota-psk", psk]
+        redact = {pw: "<password>", psk: "<ota-psk>"}
+        shown = [redact.get(c, c) for c in cmd]
         print("\n%s  node %d  (%s)" % (port, nid, mac))
         print("  " + " ".join(shown[1:]))
         if a.dry_run:
             continue
-        r = subprocess.run(cmd)
-        if r.returncode != 0:
-            print("  FAILED rc=%d" % r.returncode)
-        else:
-            print("  ok -- confirm the boot log says fleet=%d" % a.tdm_total)
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        # provision.py cannot build the NVS image without ESP-IDF on PATH, so
+        # on a bare Windows host it writes nvs_config.csv and stops. Finish the
+        # job here rather than leaving nine boards half-provisioned: generate
+        # the partition in the IDF container, flash it at the NVS offset, and
+        # delete the CSV, which holds the passphrase in clear text.
+        csv = os.path.join(HERE, "nvs_config.csv")
+        if not os.path.exists(csv):
+            print("  FAILED -- provision.py produced no CSV")
+            print("  " + (r.stderr or r.stdout or "").strip()[-400:])
+            continue
+        try:
+            g = subprocess.run(
+                ["docker", "run", "--rm", "-v", HERE + ":/project", "-w", "/project",
+                 "espressif/idf:v5.4", "bash", "-c",
+                 "python $IDF_PATH/components/nvs_flash/nvs_partition_generator/"
+                 "nvs_partition_gen.py generate nvs_config.csv nvs.bin 0x6000"],
+                capture_output=True, text=True, env={**os.environ, "MSYS_NO_PATHCONV": "1"})
+            binp = os.path.join(HERE, "nvs.bin")
+            if g.returncode != 0 or not os.path.exists(binp):
+                print("  FAILED to build NVS image")
+                print("  " + (g.stderr or g.stdout).strip()[-300:])
+                continue
+            esp = [sys.executable, "-m", "esptool", "--chip",
+                   conf.get("chip", "esp32c6"), "--port", port,
+                   "--baud", "460800"]
+            if a.no_auto_reset:
+                esp += ["--before", "no-reset"]
+            esp += ["write_flash", NVS_OFFSET, binp]
+            f = subprocess.run(esp, capture_output=True, text=True)
+            if "verified" in f.stdout or f.returncode == 0:
+                print("  ok -- NVS written at %s. Confirm the boot log says "
+                      "fleet=%d, the expected SSID, and 'OTA PSK loaded from "
+                      "NVS'. If it instead says 'No OTA PSK in NVS', this board "
+                      "is USB-update-only." % (NVS_OFFSET, a.tdm_total))
+            else:
+                print("  FAILED to flash NVS")
+                print("  " + (f.stderr or f.stdout).strip()[-300:])
+        finally:
+            for f2 in (csv, os.path.join(HERE, "nvs.bin")):
+                try: os.remove(f2)
+                except OSError: pass
 
 
 if __name__ == "__main__":

--- a/firmware/esp32-csi-node/provision_node.py
+++ b/firmware/esp32-csi-node/provision_node.py
@@ -64,9 +64,9 @@ def load_conf(net=None):
             "no %s.\n\nCreate it with:\n"
             '  {\n'
             '    "ssid": "thisismyssid",\n'
-            '    "password_file": "D:\\\\path\\\\to\\\\thisismyssid.txt",\n'
+            '    "password_file": "~/secrets/thisismyssid.txt",\n'
             '    "target_ip": "192.168.1.10",\n'
-            '    "ota_psk_file": "D:\\\\path\\\\to\\\\ota_psk.txt",\n'
+            '    "ota_psk_file": "~/secrets/ota_psk.txt",\n'
             '    "chip": "esp32c6",\n'
             '    "edge_tier": 2\n'
             '  }\n\n'
@@ -76,7 +76,24 @@ def load_conf(net=None):
         return json.load(fh)
 
 
+def secret_path(path):
+    """Resolve a credential path from a profile.
+
+    Expanded so a profile can say ~/onedrive/ota_psk.txt instead of
+    D:/Users/<name>/onedrive/ota_psk.txt. The profile is tracked -- it holds
+    only paths, never a credential -- so keeping a login name out of it costs
+    nothing and stops the file naming a particular person's machine.
+
+    Prefer `~`: expanduser resolves it on Windows and POSIX alike. %VAR% is
+    also expanded, but only on Windows -- expandvars reads $VAR syntax on
+    POSIX -- so a profile written with %USERPROFILE% breaks under WSL. An
+    absolute path is returned unchanged, so existing profiles keep working.
+    """
+    return os.path.expandvars(os.path.expanduser(path))
+
+
 def read_password(path):
+    path = secret_path(path)
     try:
         with open(path, encoding="utf-8-sig") as fh:
             pw = fh.read().strip()
@@ -106,6 +123,7 @@ def read_or_create_psk(conf):
     if not path:
         # Default alongside the passphrase, which is already outside the repo.
         path = os.path.join(os.path.dirname(conf["password_file"]), "ota_psk.txt")
+    path = secret_path(path)
 
     real = os.path.realpath(path)
     if real.startswith(os.path.realpath(HERE) + os.sep):

--- a/firmware/esp32-csi-node/tests/test_provision_state.py
+++ b/firmware/esp32-csi-node/tests/test_provision_state.py
@@ -17,8 +17,15 @@ import provision  # noqa: E402  — sibling import after sys.path tweak
 
 
 def _mk_args(**overrides) -> argparse.Namespace:
-    """Build a Namespace with every mergeable attr set to None unless overridden."""
+    """Build a Namespace with every mergeable attr set to None unless overridden.
+
+    The secret attributes are included even though they are deliberately NOT
+    mergeable: argparse always defines them (they are still real flags), so a
+    Namespace without them would let a test pass against code that would
+    raise AttributeError in the real CLI.
+    """
     base = {name: None for name in provision.MERGEABLE_ATTRS}
+    base.update({name: None for name in provision.SECRET_ATTRS})
     base.update(overrides)
     return argparse.Namespace(**base)
 
@@ -35,11 +42,26 @@ class TestStateFile(unittest.TestCase):
         self.assertEqual(provision.load_state("COM7", self.dir), {})
 
     def test_save_then_load_roundtrip(self):
-        provision.save_state("COM7", self.dir, {"ssid": "x", "password": "y"})
+        provision.save_state("COM7", self.dir, {"ssid": "x", "target_ip": "1.2.3.4"})
         self.assertEqual(
             provision.load_state("COM7", self.dir),
-            {"ssid": "x", "password": "y"},
+            {"ssid": "x", "target_ip": "1.2.3.4"},
         )
+
+    def test_save_drops_secrets_it_is_handed(self):
+        # The caller passing a secret is exactly the route MERGEABLE_ATTRS
+        # cannot police, so save_state has to filter independently.
+        path = provision.save_state("COM7", self.dir, {
+            "ssid": "x",
+            "password": "hunter2",
+            "seed_token": "tok",
+            "ota_psk": "deadbeef",
+        })
+        self.assertEqual(provision.load_state("COM7", self.dir), {"ssid": "x"})
+        with open(path, encoding="utf-8") as fh:
+            raw = fh.read()
+        for secret in ("hunter2", "tok", "deadbeef"):
+            self.assertNotIn(secret, raw)
 
     def test_save_creates_per_port_files(self):
         provision.save_state("COM7", self.dir, {"ssid": "a"})
@@ -59,28 +81,39 @@ class TestStateFile(unittest.TestCase):
 class TestMerge(unittest.TestCase):
     def test_cli_wins_over_prior(self):
         args = _mk_args(ssid="new-ssid")
-        prior = {"ssid": "old-ssid", "password": "abc"}
+        prior = {"ssid": "old-ssid", "target_ip": "10.0.0.1"}
         merged = provision.merge_state_into_args(args, prior)
         self.assertEqual(args.ssid, "new-ssid")  # CLI value preserved
-        self.assertEqual(args.password, "abc")    # filled from prior
+        self.assertEqual(args.target_ip, "10.0.0.1")  # filled from prior
         self.assertEqual(merged["ssid"], "new-ssid")
-        self.assertEqual(merged["password"], "abc")
+        self.assertEqual(merged["target_ip"], "10.0.0.1")
 
     def test_prior_fills_missing_cli(self):
         args = _mk_args()  # all None
         prior = {
             "ssid": "MyWiFi",
-            "password": "secret",
             "target_ip": "192.168.1.20",
             "node_id": 3,
         }
         merged = provision.merge_state_into_args(args, prior)
         self.assertEqual(args.ssid, "MyWiFi")
-        self.assertEqual(args.password, "secret")
         self.assertEqual(args.target_ip, "192.168.1.20")
         self.assertEqual(args.node_id, 3)
         for key, val in prior.items():
             self.assertEqual(merged[key], val)
+
+    def test_prior_secret_is_not_merged_back_into_args(self):
+        # A state file written by an older revision still carries the
+        # passphrase. It must not be resurrected into the args the CSV
+        # builder reads -- otherwise "not persisted" would be cosmetic and
+        # the credential would keep flowing from disk into every flash.
+        args = _mk_args()
+        prior = {"ssid": "MyWiFi", "password": "old-secret",
+                 "seed_token": "old-token"}
+        provision.merge_state_into_args(args, prior)
+        self.assertEqual(args.ssid, "MyWiFi")
+        self.assertIsNone(args.password)
+        self.assertIsNone(args.seed_token)
 
     def test_partial_invocation_does_not_drop_unrelated_keys(self):
         # The exact #391 scenario: user previously provisioned WiFi, now adds
@@ -88,17 +121,15 @@ class TestMerge(unittest.TestCase):
         args = _mk_args(seed_url="http://10.1.10.236")
         prior = {
             "ssid": "ruv.net",
-            "password": "<secret>",
             "target_ip": "192.168.1.20",
         }
         merged = provision.merge_state_into_args(args, prior)
         self.assertEqual(args.ssid, "ruv.net")
-        self.assertEqual(args.password, "<secret>")
         self.assertEqual(args.target_ip, "192.168.1.20")
         self.assertEqual(args.seed_url, "http://10.1.10.236")
-        # And the on-disk merged dict carries all four keys.
+        # And the on-disk merged dict carries all three keys.
         self.assertEqual(set(merged.keys()),
-                         {"ssid", "password", "target_ip", "seed_url"})
+                         {"ssid", "target_ip", "seed_url"})
 
     def test_empty_prior_is_noop(self):
         args = _mk_args(ssid="x")
@@ -112,6 +143,82 @@ class TestMerge(unittest.TestCase):
         merged = provision.merge_state_into_args(args, prior)
         self.assertEqual(args.node_id, 0)
         self.assertEqual(merged["node_id"], 0)
+
+
+class TestLegacySecretBearingState(unittest.TestCase):
+    """State files written before secrets were excluded (ruvnet review, #1832).
+
+    Seeds a file in the old format -- credentials in cleartext -- and pins
+    that reading it both hides the credential from the caller and removes it
+    from disk, rather than leaving it for a future run that may never come.
+    """
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="provision-legacy-")
+        self.path = provision._state_path_for("COM7", self.dir)
+        os.makedirs(self.dir, exist_ok=True)
+        self.legacy = {
+            "ssid": "ruv.net",
+            "password": "old-passphrase",
+            "seed_token": "old-token",
+            "ota_psk": "0123456789abcdef",
+            "target_ip": "192.168.1.20",
+            "node_id": 3,
+        }
+        with open(self.path, "w", encoding="utf-8") as fh:
+            json.dump(self.legacy, fh)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def _load_quietly(self):
+        import contextlib
+        import io as _io
+        buf = _io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            state = provision.load_state("COM7", self.dir)
+        return state, buf.getvalue()
+
+    def test_load_strips_every_secret(self):
+        state, _ = self._load_quietly()
+        for name in provision.SECRET_ATTRS:
+            self.assertNotIn(name, state)
+
+    def test_load_keeps_the_non_secret_settings(self):
+        state, _ = self._load_quietly()
+        self.assertEqual(state["ssid"], "ruv.net")
+        self.assertEqual(state["target_ip"], "192.168.1.20")
+        self.assertEqual(state["node_id"], 3)
+
+    def test_load_rewrites_the_file_without_the_credential(self):
+        self._load_quietly()
+        with open(self.path, encoding="utf-8") as fh:
+            raw = fh.read()
+        for secret in ("old-passphrase", "old-token", "0123456789abcdef"):
+            self.assertNotIn(secret, raw)
+        # And the scrub is durable: a second read sees an already-clean file.
+        again, err = self._load_quietly()
+        self.assertNotIn("password", again)
+        self.assertEqual(err, "")
+
+    def test_load_says_what_it_removed(self):
+        _, err = self._load_quietly()
+        self.assertIn("password", err)
+        self.assertIn(self.path, err)
+
+    def test_scrubbed_state_leaves_the_wifi_trio_incomplete(self):
+        # The point of the failure-injection case: after the scrub a run that
+        # relied on the cached passphrase has no password at all. provision.py
+        # must refuse rather than silently flash a board with no credential.
+        state, _ = self._load_quietly()
+        args = _mk_args()
+        provision.merge_state_into_args(args, state)
+        missing = [n for n, v in (("--ssid", args.ssid),
+                                  ("--password", args.password),
+                                  ("--target-ip", args.target_ip))
+                   if v is None or v == ""]
+        self.assertEqual(missing, ["--password"])
 
 
 class TestStatePathSanitization(unittest.TestCase):


### PR DESCRIPTION
provision.py cached every provisionable attribute in a per-port JSON state file
so a re-run could merge prior values. That list included 'password' and
'seed_token', so every successful run wrote the WiFi passphrase in cleartext to
a file under the user's config dir -- defeating the point of keeping the
credential in a file outside the repo, and leaving stale copies of retired
passwords lying around after an SSID change.

Secrets are now excluded from the merge list AND filtered again on write, so a
credential cannot reach the disk by a route someone adds later. The cost is
that a secret must be supplied on every run rather than merged from prior
state; provision_node.py already does exactly that, reading them from files,
and a direct provision.py call now fails loudly instead of silently reusing an
old credential.

Related upstream work: PR #1760 makes the same state file owner-only, which is
worth having, but still lists password and seed_token as mergeable -- so it
protects a file that should not contain the secret at all. These compose: their
permissions plus this exclusion.

board_index.py additionally prefers esptool's 'BASE MAC' line over any MAC-like
string in the output; the other lines are derived forms and picking one of
those keys a board by an address it does not provision under.

---

Rebased onto current `main`; one additive `.gitignore` conflict resolved by keeping both sides. Scanned the diff for credential literals before pushing (none), and the three scripts byte-compile.