### PR TITLE
feat(emitters): four-state triage for the transmitters a fleet can hear

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -5,6 +5,7 @@ import { DashboardTab } from './components/DashboardTab.js';
 import { HardwareTab } from './components/HardwareTab.js';
 import { LiveDemoTab } from './components/LiveDemoTab.js';
 import { SensingTab } from './components/SensingTab.js';
+import { RoomBuilderTab } from './components/RoomBuilderTab.js';
 import { apiService } from './services/api.service.js';
 import { wsService } from './services/websocket.service.js';
 import { healthService } from './services/health.service.js';
@@ -159,6 +160,15 @@ class WiFiDensePoseApp {
     const sensingContainer = document.getElementById('sensing');
     if (sensingContainer) {
       this.components.sensing = new SensingTab(sensingContainer);
+    }
+
+    // Room Builder tab
+    const roomBuilderContainer = document.getElementById('roombuilder');
+    if (roomBuilderContainer) {
+      this.components.roomBuilder = new RoomBuilderTab(roomBuilderContainer);
+      this.components.roomBuilder.init().catch(error => {
+        console.error('Failed to initialize room builder:', error);
+      });
     }
 
     // Training tab - lazy load to avoid breaking other tabs if import fails
@@ -344,6 +354,14 @@ class WiFiDensePoseApp {
         }
         if (this.components.modelPanel && typeof this.components.modelPanel.refresh === 'function') {
           this.components.modelPanel.refresh();
+        }
+        break;
+
+      case 'roombuilder':
+        // Re-fetch the live config each time the tab is opened, in case it
+        // changed elsewhere (another browser tab's save, a server restart).
+        if (this.components.roomBuilder) {
+          this.components.roomBuilder._load();
         }
         break;
     }

--- a/ui/components/RoomBuilderTab.js
+++ b/ui/components/RoomBuilderTab.js
@@ -45,10 +45,18 @@ export class RoomBuilderTab {
     // node with the wall below it -- which is the whole point of stacking
     // storeys on a shared origin.
     this._activeFloor = 1;
-    // 'select' drags nodes and the AP; 'wall' draws segments.
+    // 'select' drags nodes and the AP; 'wall' draws segments; 'footprint'
+    // clicks out the building's outline vertex by vertex.
     this._mode = 'select';
     this._wallStart = null;
     this._wallPreview = null;
+    // The outline being traced right now, as {x, y} in room coordinates. It
+    // is not part of `config` until closed: a half-traced ring is not a shape,
+    // and the server rejects one with fewer than three vertices.
+    this._ringDraft = null;
+    // Where the pointer is, so the segment about to be committed is visible
+    // before the click that commits it.
+    this._ringHover = null;
     this._loaded = false;
     // Live tracked-position overlay, fed by sensingService (/ws/sensing).
     // `_liveDot` is only ever set from a "bistatic_velocity", "doppler_centroid",
@@ -312,6 +320,48 @@ export class RoomBuilderTab {
             <div id="rbWallList"></div>
           </div>
           <div class="rb-card">
+            <div class="rb-card-title">Building Outline</div>
+            <p class="rb-hint" style="margin-top:0;">
+              The width and depth above are a <strong>bounding box</strong>. Trace the
+              storey's real outline here and the position search stops scoring cells
+              that are not part of the house — the notch of an L-shaped plan is the
+              garden, not a place a person can stand. Leave it empty and the whole
+              box is searched, exactly as before.
+            </p>
+            <p class="rb-hint" style="margin-top:0;">
+              A wing <strong>west or north</strong> of the north-west corner has
+              <strong>negative</strong> coordinates. That is expected: the origin is
+              pinned to the block your nodes were measured against, so it never moves
+              under them. The canvas widens to show whatever you trace.
+            </p>
+            <div class="rb-actions" style="margin-top:10px;">
+              <button class="rb-btn secondary" id="rbFootprintMode">Trace Outline</button>
+              <button class="rb-btn secondary" id="rbCloseRing" style="display:none;">Close Outline</button>
+              <button class="rb-btn secondary" id="rbUndoPoint" style="display:none;">Undo Point</button>
+            </div>
+            <div class="rb-wall-entry" style="grid-template-columns:1fr 1fr auto;">
+              <label><span>Corner &middot; east &rarr;</span><input type="number" id="rbRingX" step="0.5" placeholder="—" title="Distance east of the north-west corner. Negative for a wing west of it."></label>
+              <label><span>Corner &middot; south &darr;</span><input type="number" id="rbRingY" step="0.5" placeholder="—" title="Distance south of the north-west corner. Negative for a wing north of it."></label>
+              <button class="rb-btn secondary" id="rbAddCorner">Add Corner</button>
+            </div>
+            <p class="rb-hint" style="margin:4px 2px 8px;">
+              Type a corner when clicking cannot reach it or is not precise enough.
+              A wing <strong>west</strong> of the north-west corner has a
+              <strong>negative</strong> east value — a 12&nbsp;ft wing runs
+              <strong>&minus;12&nbsp;&rarr;&nbsp;0</strong>, not 0&nbsp;&rarr;&nbsp;12.
+              Clicking can only reach about 2.6&nbsp;ft west of the corner, so anything
+              further out has to be typed.
+            </p>
+            <p class="rb-hint" id="rbFootprintHint" style="margin-bottom:6px;">
+              <strong>Walk the perimeter</strong>, clicking each corner in turn, then Close
+              Outline. You do not cut a notch out — you route around it: a rectangle is
+              4 clicks, an L-shaped plan is 6. Several outlines may share a storey — a
+              wing or a detached garage is its own shape, and a person is indoors if
+              they are inside any of them.
+            </p>
+            <div id="rbFootprintList"></div>
+          </div>
+          <div class="rb-card">
             <div class="rb-card-title">Access Point</div>
             <p class="rb-hint" style="margin-top:0;">
               Optional — needed for Doppler-based position geometry. One AP,
@@ -478,9 +528,14 @@ export class RoomBuilderTab {
     this.container.querySelector('#rbWallMode').addEventListener('click', (e) => {
       this._mode = this._mode === 'wall' ? 'select' : 'wall';
       // Abandon a half-drawn segment rather than leaving it to commit on the
-      // next unrelated click.
+      // next unrelated click. The same goes for a half-traced outline: the
+      // two drawing modes are exclusive, so entering one must not leave the
+      // other's unfinished shape armed.
       this._wallStart = null;
       this._wallPreview = null;
+      this._ringDraft = null;
+      this._ringHover = null;
+      this._renderFootprintControls();
       e.target.textContent = this._mode === 'wall' ? 'Done Drawing' : 'Draw Walls';
       const canvas = this.container.querySelector('#rbCanvas');
       if (canvas) canvas.style.cursor = this._mode === 'wall' ? 'crosshair' : 'default';
@@ -490,6 +545,57 @@ export class RoomBuilderTab {
           ? 'Drag on the canvas to draw a wall on the selected storey. Dragging no longer moves nodes.'
           : 'In wall mode, drag on the canvas to draw a segment on the selected storey. Other storeys stay visible, faintly, so you can line one up with the floor below.';
       }
+      this._render();
+    });
+    this.container.querySelector('#rbFootprintMode').addEventListener('click', () => {
+      if (this._mode === 'footprint') {
+        // Leaving the mode abandons a half-traced ring rather than leaving it
+        // to be closed by some later, unrelated click.
+        this._ringDraft = null;
+        this._ringHover = null;
+        this._mode = 'select';
+      } else {
+        this._mode = 'footprint';
+        this._ringDraft = [];
+        // A wall being dragged out would otherwise commit on the next mouseup.
+        this._wallStart = null;
+        this._wallPreview = null;
+      }
+      this._renderFootprintControls();
+      this._render();
+    });
+    this.container.querySelector('#rbCloseRing').addEventListener('click', () => {
+      this._closeRing();
+    });
+    this.container.querySelector('#rbAddCorner').addEventListener('click', () => {
+      const num = (id) => parseFloat(this.container.querySelector(`#${id}`).value);
+      const [dx, dy] = [num('rbRingX'), num('rbRingY')];
+      if (!Number.isFinite(dx) || !Number.isFinite(dy)) {
+        toastManager.error('Fill in both corner coordinates before adding.');
+        return;
+      }
+      // Typing a corner IS tracing, so switch into the mode rather than
+      // silently dropping the point because a button was not pressed first.
+      if (this._mode !== 'footprint') {
+        this._mode = 'footprint';
+        this._wallStart = null;
+        this._wallPreview = null;
+      }
+      if (!Array.isArray(this._ringDraft)) this._ringDraft = [];
+      const r = (v) => Math.round(v * 10000) / 10000;
+      this._ringDraft.push({ x: r(this._fromDisplay(dx)), y: r(this._fromDisplay(dy)) });
+      // Clear rather than chain: unlike a wall, whose next segment starts
+      // where the last ended, the next corner of an outline shares no
+      // coordinate with the previous one, so leaving the numbers in place
+      // would only stage a duplicate point.
+      this.container.querySelector('#rbRingX').value = '';
+      this.container.querySelector('#rbRingY').value = '';
+      this._renderFootprintControls();
+      this._render();
+    });
+    this.container.querySelector('#rbUndoPoint').addEventListener('click', () => {
+      if (this._ringDraft && this._ringDraft.length) this._ringDraft.pop();
+      this._renderFootprintControls();
       this._render();
     });
     this.container.querySelector('#rbRemoveAp').addEventListener('click', () => {
@@ -619,6 +725,7 @@ export class RoomBuilderTab {
           ap_position: Array.isArray(data.ap_position) ? data.ap_position : null,
           floors: Array.isArray(data.floors) ? data.floors : [],
           walls: Array.isArray(data.walls) ? data.walls : [],
+          footprint: Array.isArray(data.footprint) ? data.footprint : [],
         };
       }
     } catch (e) {
@@ -637,6 +744,7 @@ export class RoomBuilderTab {
   _renderStoreyPanels() {
     this._renderFloorControls();
     this._renderWallList();
+    this._renderFootprintControls();
   }
 
   _refreshUnitDisplay() {
@@ -868,28 +976,64 @@ export class RoomBuilderTab {
 
   // ---- Canvas -----------------------------------------------------------------
 
-  /** Room-space (x,y) meters -> canvas pixel coordinates. */
-  _toPixel(x, y) {
-    const scale = Math.min(
-      (CANVAS_W - 2 * MARGIN) / this.config.width_m,
-      (CANVAS_H - 2 * MARGIN) / this.config.depth_m
-    );
-    return { px: MARGIN + x * scale, py: MARGIN + y * scale, scale };
+  /** The extent the canvas must show, in room coordinates.
+   *
+   * Deliberately not just `0..width_m x 0..depth_m`. The origin is pinned to
+   * the north-west corner of the building's MAIN BLOCK, because that is what
+   * every node position was measured against — so a wing to the west or north
+   * of it has negative coordinates. A viewport that always started at (0, 0)
+   * would render that wing off the canvas entirely: invisible, undraggable,
+   * and impossible to trace an outline around.
+   *
+   * The room rectangle is always included even when a footprint extends past
+   * it, so the box the nodes were placed in never scrolls out of view.
+   */
+  _view() {
+    let minX = 0;
+    let minY = 0;
+    let maxX = this.config.width_m;
+    let maxY = this.config.depth_m;
+    const consider = (x, y) => {
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    };
+    (this.config.footprint || []).forEach((ring) => {
+      (ring.points || []).forEach((p) => consider(p[0], p[1]));
+    });
+    (this._ringDraft || []).forEach((p) => consider(p.x, p.y));
+
+    const spanX = maxX - minX;
+    const spanY = maxY - minY;
+    // A zero or non-finite span would make every coordinate NaN and blank the
+    // canvas. Fall back to a scale of 1 px/m, which draws something wrong
+    // rather than nothing at all.
+    const scale =
+      spanX > 0 && spanY > 0
+        ? Math.min((CANVAS_W - 2 * MARGIN) / spanX, (CANVAS_H - 2 * MARGIN) / spanY)
+        : 1;
+    return { minX, minY, maxX, maxY, scale };
   }
 
-  /** Canvas pixel coordinates -> room-space (x,y) meters. Clamped to the room
-   * by default (sensor nodes always live inside it); pass `clamp: false` for
-   * the AP marker, which is legitimately often outside the room. */
+  /** Room-space (x,y) meters -> canvas pixel coordinates. */
+  _toPixel(x, y) {
+    const { minX, minY, scale } = this._view();
+    return { px: MARGIN + (x - minX) * scale, py: MARGIN + (y - minY) * scale, scale };
+  }
+
+  /** Canvas pixel coordinates -> room-space (x,y) meters. Clamped to the
+   * visible extent by default (sensor nodes always live inside the building);
+   * pass `clamp: false` for the AP marker, which is legitimately often outside
+   * it, and for footprint and wall vertices, which trace its boundary. */
   _toRoom(px, py, { clamp = true } = {}) {
-    const scale = Math.min(
-      (CANVAS_W - 2 * MARGIN) / this.config.width_m,
-      (CANVAS_H - 2 * MARGIN) / this.config.depth_m
-    );
-    let x = (px - MARGIN) / scale;
-    let y = (py - MARGIN) / scale;
+    const { minX, minY, maxX, maxY, scale } = this._view();
+    let x = minX + (px - MARGIN) / scale;
+    let y = minY + (py - MARGIN) / scale;
     if (clamp) {
-      x = Math.min(this.config.width_m, Math.max(0, x));
-      y = Math.min(this.config.depth_m, Math.max(0, y));
+      x = Math.min(maxX, Math.max(minX, x));
+      y = Math.min(maxY, Math.max(minY, y));
     }
     return { x, y };
   }
@@ -906,6 +1050,27 @@ export class RoomBuilderTab {
   _onCanvasDown(e) {
     const pos = this._canvasPos(e);
 
+    if (this._mode === 'footprint') {
+      // Not clamped: the outline traces the building's boundary, and a wing
+      // west of the origin is legitimately at negative x.
+      const room = this._toRoom(pos.x, pos.y, { clamp: false });
+      if (!this._ringDraft) this._ringDraft = [];
+      const pt = { x: Math.round(room.x * 100) / 100, y: Math.round(room.y * 100) / 100 };
+      // Clicking the first vertex again is the usual way to close a polygon,
+      // so honour it rather than adding a duplicate point on top of it.
+      const first = this._ringDraft[0];
+      if (first && this._ringDraft.length >= 3) {
+        const { scale } = this._view();
+        if (Math.hypot((pt.x - first.x) * scale, (pt.y - first.y) * scale) <= WALL_HIT_PX) {
+          this._closeRing();
+          return;
+        }
+      }
+      this._ringDraft.push(pt);
+      this._renderFootprintControls();
+      this._render();
+      return;
+    }
     if (this._mode === 'wall') {
       // Walls are not clamped to the room rectangle. width_m/depth_m describe
       // the sensed area, and an exterior wall is legitimately on or slightly
@@ -931,6 +1096,13 @@ export class RoomBuilderTab {
   }
 
   _onCanvasMove(e) {
+    if (this._mode === 'footprint') {
+      if (!this._ringDraft || !this._ringDraft.length) return;
+      const pos = this._canvasPos(e);
+      this._ringHover = { x: pos.x, y: pos.y };
+      this._render();
+      return;
+    }
     if (this._mode === 'wall' && this._wallStart) {
       const pos = this._canvasPos(e);
       this._wallPreview = { x: pos.x, y: pos.y };
@@ -1124,6 +1296,117 @@ export class RoomBuilderTab {
     this._render();
   }
 
+  // ---- Footprint --------------------------------------------------------------
+
+  /** Commit the traced outline to the active storey.
+   *
+   * Refuses anything under three vertices. Two points are a line and one is a
+   * dot; neither encloses anything, and the server's point-in-polygon test
+   * reports every cell OUTSIDE such a ring — so saving one would mask the
+   * whole search grid away and stop position output with no error anywhere.
+   * The server rejects it too; failing here means the user finds out while
+   * they are still looking at the shape.
+   */
+  _closeRing() {
+    const draft = this._ringDraft || [];
+    if (draft.length < 3) {
+      toastManager.error('An outline needs at least three corners before it can be closed.');
+      return;
+    }
+    if (!Array.isArray(this.config.footprint)) this.config.footprint = [];
+    this.config.footprint.push({
+      level: this._activeFloor,
+      points: draft.map((p) => [p.x, p.y]),
+    });
+    // Stay in the mode: a house with a wing needs a second outline, and
+    // dropping out after every ring would make that needlessly fiddly.
+    this._ringDraft = [];
+    this._ringHover = null;
+    this._renderFootprintControls();
+    this._render();
+  }
+
+  /** Button labels and the per-storey outline list. */
+  _renderFootprintControls() {
+    const tracing = this._mode === 'footprint';
+    const draft = this._ringDraft || [];
+    const modeBtn = this.container.querySelector('#rbFootprintMode');
+    if (modeBtn) modeBtn.textContent = tracing ? 'Done Tracing' : 'Trace Outline';
+    const closeBtn = this.container.querySelector('#rbCloseRing');
+    if (closeBtn) {
+      closeBtn.style.display = tracing ? '' : 'none';
+      closeBtn.disabled = draft.length < 3;
+    }
+    const undoBtn = this.container.querySelector('#rbUndoPoint');
+    if (undoBtn) {
+      undoBtn.style.display = tracing ? '' : 'none';
+      undoBtn.disabled = draft.length === 0;
+    }
+    const canvas = this.container.querySelector('#rbCanvas');
+    if (canvas && tracing) canvas.style.cursor = 'crosshair';
+    else if (canvas && this._mode === 'select') canvas.style.cursor = 'default';
+
+    const hint = this.container.querySelector('#rbFootprintHint');
+    if (hint) {
+      hint.textContent = tracing
+        ? `Tracing on ${this._floorName(this._activeFloor)} — ${draft.length} corner(s) placed. `
+          + 'Click the first corner again, or Close Outline, to finish.'
+        : 'Click each corner in turn, then Close Outline. Several outlines may share '
+          + 'a storey — a wing or a detached garage is its own shape, and a person is '
+          + 'indoors if they are inside any of them.';
+    }
+    this._renderFootprintList();
+  }
+
+  _floorName(level) {
+    const f = this._floors().find((x) => x.level === level);
+    return (f && f.name) || `Floor ${level}`;
+  }
+
+  _renderFootprintList() {
+    const host = this.container.querySelector('#rbFootprintList');
+    if (!host) return;
+    const rings = this.config.footprint || [];
+    const draft = this._ringDraft || [];
+
+    // The corners placed so far, with their numbers. A traced shape that is
+    // 12 ft off reads as obviously wrong here long before it does on a canvas
+    // where the whole plan simply rescales to fit whatever was drawn.
+    const u = this._unitLabel();
+    const draftHtml = draft.length
+      ? `<p class="rb-hint" style="margin:6px 2px 2px;">Corners so far (${u}):</p>
+         <p class="rb-hint" style="margin:0 2px 6px; color:#ffd166;">`
+        + draft
+          .map((p, i) => `${i + 1}: ${this._toDisplay(p.x).toFixed(1)}, ${this._toDisplay(p.y).toFixed(1)}`)
+          .join(' &nbsp;·&nbsp; ')
+        + '</p>'
+      : '';
+
+    if (!rings.length) {
+      host.innerHTML = draftHtml
+        + '<p class="rb-hint" style="margin:6px 2px 0;">No outline saved yet — until one '
+        + 'is closed, the whole width &times; depth box counts as building.</p>';
+      return;
+    }
+    host.innerHTML = draftHtml + rings
+      .map((ring, idx) => {
+        const active = ring.level === this._activeFloor;
+        const pts = (ring.points || []).length;
+        return `<div class="rb-wall-entry" style="grid-template-columns:1fr auto; opacity:${active ? 1 : 0.55};">
+            <span style="font-size:12px;">${this._floorName(ring.level)} — ${pts} corner(s)${active ? '' : ' (other storey)'}</span>
+            <button class="rb-btn secondary rb-ring-remove" data-index="${idx}">Remove</button>
+          </div>`;
+      })
+      .join('');
+    host.querySelectorAll('.rb-ring-remove').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        this.config.footprint.splice(Number(btn.dataset.index), 1);
+        this._renderFootprintControls();
+        this._render();
+      });
+    });
+  }
+
   /** Add a storey above the highest one. */
   _addFloor() {
     const floors = this._floors();
@@ -1164,15 +1447,21 @@ export class RoomBuilderTab {
     const doomed = floors[floors.length - 1].level;
     const nodes = this.config.nodes.filter((n) => this._floorOf(n) === doomed).length;
     const walls = (this.config.walls || []).filter((w) => w.level === doomed).length;
-    if (nodes || walls) {
+    const rings = (this.config.footprint || []).filter((r) => r.level === doomed).length;
+    if (nodes || walls || rings) {
       const ok = window.confirm(
-        `Remove floor ${doomed}? This also deletes ${nodes} node(s) and ${walls} wall(s) on it.`
+        `Remove floor ${doomed}? This also deletes ${nodes} node(s), ${walls} wall(s) `
+        + `and ${rings} outline(s) on it.`
       );
       if (!ok) return;
     }
     this.config.floors = floors.filter((f) => f.level !== doomed);
     this.config.nodes = this.config.nodes.filter((n) => this._floorOf(n) !== doomed);
     this.config.walls = (this.config.walls || []).filter((w) => w.level !== doomed);
+    // An outline left behind on a deleted storey makes the server reject every
+    // subsequent save with "footprint N is on undefined floor" — an error
+    // naming a storey the user can no longer see.
+    this.config.footprint = (this.config.footprint || []).filter((r) => r.level !== doomed);
     if (this.config.floors.length <= 1) this.config.floors = [];
     this._activeFloor = 1;
     this._renderFloorControls();
@@ -1211,6 +1500,65 @@ export class RoomBuilderTab {
       ctx.moveTo(topLeft.px, py);
       ctx.lineTo(bottomRight.px, py);
       ctx.stroke();
+    }
+
+    // Building outline. Drawn first, filled, so it reads as ground the rest of
+    // the plan stands on. The active storey's outline is solid; other storeys
+    // show as a faint line, because lining a wing up with the floor below it
+    // is exactly what a shared origin is for.
+    (this.config.footprint || []).forEach((ring) => {
+      const pts = ring.points || [];
+      if (pts.length < 3) return;
+      const active = ring.level === this._activeFloor;
+      ctx.beginPath();
+      pts.forEach((p, i) => {
+        const { px, py } = this._toPixel(p[0], p[1]);
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      });
+      ctx.closePath();
+      ctx.fillStyle = active ? 'rgba(50,184,198,0.10)' : 'rgba(50,184,198,0.04)';
+      ctx.fill();
+      ctx.strokeStyle = active ? 'rgba(50,184,198,0.85)' : 'rgba(50,184,198,0.22)';
+      ctx.lineWidth = active ? 2 : 1;
+      ctx.stroke();
+    });
+
+    // The outline being traced right now: committed segments solid, the one
+    // that would follow the next click dashed back to the pointer.
+    if (this._ringDraft && this._ringDraft.length) {
+      const draft = this._ringDraft;
+      ctx.strokeStyle = '#ffd166';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      draft.forEach((p, i) => {
+        const { px, py } = this._toPixel(p.x, p.y);
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      });
+      ctx.stroke();
+
+      if (this._ringHover) {
+        const last = this._toPixel(draft[draft.length - 1].x, draft[draft.length - 1].y);
+        const first = this._toPixel(draft[0].x, draft[0].y);
+        ctx.setLineDash([6, 4]);
+        ctx.beginPath();
+        ctx.moveTo(last.px, last.py);
+        ctx.lineTo(this._ringHover.x, this._ringHover.y);
+        // Show the closing edge too, so the shape being committed is the shape
+        // on screen rather than one the user has to imagine.
+        if (draft.length >= 2) ctx.lineTo(first.px, first.py);
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+
+      draft.forEach((p, i) => {
+        const { px, py } = this._toPixel(p.x, p.y);
+        ctx.beginPath();
+        ctx.arc(px, py, i === 0 ? 5 : 3, 0, Math.PI * 2);
+        ctx.fillStyle = i === 0 ? '#ffd166' : '#e6e9ef';
+        ctx.fill();
+      });
     }
 
     // Walls. Drawn before nodes so a node marker is never hidden behind one.

--- a/ui/components/RoomBuilderTab.js
+++ b/ui/components/RoomBuilderTab.js
@@ -1,0 +1,468 @@
+/**
+ * RoomBuilderTab — define room geometry and sensor node positions
+ *
+ * A 2D top-down floor-plan editor: set room width/depth, add sensor nodes,
+ * drag them into place (or type exact coordinates), and save. Saving both
+ * applies the positions live (no restart needed) and persists them to
+ * <data_dir>/room_config.json, which is loaded automatically on the next
+ * server launch — replacing the --node-positions CLI-only workflow.
+ */
+
+import { apiService } from '../services/api.service.js';
+import { toastManager } from '../utils/toast.js';
+
+const ENDPOINT = '/api/v1/config/room';
+const CANVAS_W = 640;
+const CANVAS_H = 480;
+const MARGIN = 32;
+const NODE_RADIUS = 9;
+const METERS_PER_FOOT = 0.3048;
+const UNITS_STORAGE_KEY = 'roombuilder-units';
+
+export class RoomBuilderTab {
+  /** @param {HTMLElement} container - the #roombuilder section element */
+  constructor(container) {
+    this.container = container;
+    this.config = { width_m: 5, depth_m: 4, nodes: [] };
+    this._dragIndex = null;
+    this._loaded = false;
+    // Display-only - this.config always stays in meters (that's what the
+    // server/API/saved file use); only input values and labels convert.
+    this._units = 'metric';
+    try {
+      const saved = localStorage.getItem(UNITS_STORAGE_KEY);
+      if (saved === 'metric' || saved === 'imperial') this._units = saved;
+    } catch (e) { /* storage unavailable - default to metric */ }
+  }
+
+  /** Convert a length in meters to the currently-selected display unit. */
+  _toDisplay(meters) {
+    return this._units === 'imperial' ? meters / METERS_PER_FOOT : meters;
+  }
+
+  /** Convert a length from the currently-selected display unit back to meters. */
+  _fromDisplay(value) {
+    return this._units === 'imperial' ? value * METERS_PER_FOOT : value;
+  }
+
+  _unitLabel() {
+    return this._units === 'imperial' ? 'ft' : 'm';
+  }
+
+  async init() {
+    this._buildDOM();
+    this._wireEvents();
+    await this._load();
+  }
+
+  // ---- DOM ----------------------------------------------------------------
+
+  _buildDOM() {
+    this.container.innerHTML = `
+      <style>
+        .rb-layout { display: flex; gap: 20px; flex-wrap: wrap; }
+        .rb-canvas-wrap { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 8px; padding: 12px; }
+        .rb-canvas-wrap canvas { display: block; cursor: default; border-radius: 4px; }
+        .rb-panel { flex: 1; min-width: 280px; display: flex; flex-direction: column; gap: 16px; }
+        .rb-card { background: #12161f; border: 1px solid #2a2f3a; border-radius: 8px; padding: 14px; }
+        .rb-card-title { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: #8b93a7; margin-bottom: 10px; }
+        .rb-room-dims { display: flex; gap: 12px; }
+        .rb-room-dims label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: #8b93a7; }
+        .rb-room-dims input, .rb-node-row input { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 7px; font-size: 13px; box-sizing: border-box; }
+        .rb-room-dims input { width: 72px; }
+        .rb-room-dims select { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 7px; font-size: 13px; }
+        .rb-node-row { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 1fr 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
+        .rb-node-row input { width: 100%; }
+        .rb-node-row .rb-id { color: #32b8c6; font-weight: 600; font-size: 13px; }
+        /* Number inputs' native up/down spinner eats most of the width in
+           narrow columns (esp. the 42px ID field) - hide it. Nobody needs
+           spinner arrows to type a node ID or a coordinate. */
+        .rb-node-row input[type="number"]::-webkit-outer-spin-button,
+        .rb-node-row input[type="number"]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+        .rb-node-row input[type="number"] { -moz-appearance: textfield; appearance: textfield; }
+        .rb-remove-btn { background: none; border: none; color: #e05561; cursor: pointer; font-size: 15px; line-height: 1; }
+        .rb-btn { background: #32b8c6; color: #06222a; border: none; border-radius: 6px; padding: 8px 16px; font-weight: 600; cursor: pointer; font-size: 13px; }
+        .rb-btn.secondary { background: transparent; color: #32b8c6; border: 1px solid #32b8c6; }
+        .rb-actions { display: flex; gap: 10px; margin-top: 8px; }
+        .rb-hint { color: #6b7280; font-size: 12px; margin-top: 8px; line-height: 1.5; }
+        .rb-col-headers { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 1fr 24px; gap: 6px; font-size: 11px; color: #6b7280; margin-bottom: 6px; }
+      </style>
+      <h2>Room Builder</h2>
+      <p class="rb-hint" style="margin-bottom:16px;">
+        Define your room and place sensor nodes. Node <strong>ID</strong> must match
+        each board's provisioned <code>--node-id</code>. Saving applies immediately
+        (no restart) and is what future launches load automatically.
+      </p>
+      <div class="rb-layout">
+        <div class="rb-canvas-wrap">
+          <canvas id="rbCanvas" width="${CANVAS_W}" height="${CANVAS_H}"></canvas>
+        </div>
+        <div class="rb-panel">
+          <div class="rb-card">
+            <div class="rb-card-title">Room Dimensions</div>
+            <div class="rb-room-dims">
+              <label><span>Width (<span class="rb-unit-label">${this._unitLabel()}</span>)</span> <input type="number" id="rbWidth" min="0.1" step="0.1" value="${this._toDisplay(this.config.width_m).toFixed(2)}"></label>
+              <label><span>Depth (<span class="rb-unit-label">${this._unitLabel()}</span>)</span> <input type="number" id="rbDepth" min="0.1" step="0.1" value="${this._toDisplay(this.config.depth_m).toFixed(2)}"></label>
+              <label><span>Units</span>
+                <select id="rbUnits">
+                  <option value="metric" ${this._units === 'metric' ? 'selected' : ''}>Metric (m)</option>
+                  <option value="imperial" ${this._units === 'imperial' ? 'selected' : ''}>Imperial (ft)</option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div class="rb-card">
+            <div class="rb-card-title">Sensor Nodes</div>
+            <div class="rb-col-headers">
+              <span>ID</span><span>Label</span><span>X (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Y (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Z (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span></span><span></span>
+            </div>
+            <div id="rbNodeList"></div>
+            <div class="rb-actions">
+              <button class="rb-btn secondary" id="rbAddNode">+ Add Node</button>
+            </div>
+          </div>
+          <div class="rb-actions">
+            <button class="rb-btn" id="rbSave">Save</button>
+          </div>
+          <p class="rb-hint">
+            Drag a node on the canvas to reposition it (X/Y only — set height
+            with the Z field). Coordinates are in the same room-space meters
+            used by <code>--node-positions</code>.
+          </p>
+          <p class="rb-hint">
+            <strong>(0, 0)</strong> is the room's <strong>Northwest</strong> corner
+            (the <strong>N</strong> arrow on the canvas points that way) — X increases
+            going <strong>East</strong>, Y increases going <strong>South</strong>. Face
+            the room's actual north wall and match it up when you place nodes.
+          </p>
+        </div>
+      </div>
+    `;
+  }
+
+  _wireEvents() {
+    const widthEl = this.container.querySelector('#rbWidth');
+    const depthEl = this.container.querySelector('#rbDepth');
+    widthEl.addEventListener('input', () => {
+      this.config.width_m = Math.max(0.1, this._fromDisplay(parseFloat(widthEl.value) || 0));
+      this._render();
+    });
+    depthEl.addEventListener('input', () => {
+      this.config.depth_m = Math.max(0.1, this._fromDisplay(parseFloat(depthEl.value) || 0));
+      this._render();
+    });
+
+    this.container.querySelector('#rbUnits').addEventListener('change', (e) => {
+      this._units = e.target.value;
+      try { localStorage.setItem(UNITS_STORAGE_KEY, this._units); } catch (err) { /* ignore */ }
+      this._refreshUnitDisplay();
+    });
+
+    this.container.querySelector('#rbAddNode').addEventListener('click', () => {
+      this._addNode();
+    });
+    this.container.querySelector('#rbSave').addEventListener('click', () => {
+      this._save();
+    });
+
+    const canvas = this.container.querySelector('#rbCanvas');
+    canvas.addEventListener('mousedown', (e) => this._onCanvasDown(e));
+    canvas.addEventListener('mousemove', (e) => this._onCanvasMove(e));
+    window.addEventListener('mouseup', () => { this._dragIndex = null; });
+  }
+
+  // ---- Data -----------------------------------------------------------------
+
+  async _load() {
+    try {
+      const data = await apiService.get(ENDPOINT);
+      if (data && typeof data === 'object') {
+        this.config = {
+          width_m: data.width_m > 0 ? data.width_m : 5,
+          depth_m: data.depth_m > 0 ? data.depth_m : 4,
+          nodes: Array.isArray(data.nodes) ? data.nodes : [],
+        };
+      }
+    } catch (e) {
+      console.warn('[RoomBuilder] Failed to load room config, using defaults:', e.message);
+    }
+    this._loaded = true;
+    this._refreshUnitDisplay();
+  }
+
+  /** Re-render everything that shows a unit-dependent value, using the
+   * current `this._units` - called on load and whenever the unit toggle
+   * changes. `this.config` itself never changes here; only what's displayed. */
+  _refreshUnitDisplay() {
+    const label = this._unitLabel();
+    this.container.querySelectorAll('.rb-unit-label').forEach((el) => {
+      el.textContent = label;
+    });
+    this.container.querySelector('#rbWidth').value = this._toDisplay(this.config.width_m).toFixed(2);
+    this.container.querySelector('#rbDepth').value = this._toDisplay(this.config.depth_m).toFixed(2);
+    this._renderNodeList();
+    this._render();
+  }
+
+  async _save() {
+    // Pull the latest values out of the node-row inputs before sending -
+    // numeric fields don't write back into this.config until blur/save.
+    this._syncNodesFromInputs();
+    const ids = this.config.nodes.map((n) => n.id);
+    if (new Set(ids).size !== ids.length) {
+      toastManager.error('Cannot save: two or more nodes have the same ID. Give each a unique ID first.');
+      return;
+    }
+    try {
+      // The server validates width/depth/duplicate-ids and responds 200 OK
+      // with an {"error": ...} body rather than a non-2xx status, so a
+      // rejected save must be checked for explicitly - it won't throw.
+      const result = await apiService.post(ENDPOINT, this.config);
+      if (result && result.error) {
+        toastManager.error(`Save rejected: ${result.error}`);
+        return;
+      }
+      toastManager.success('Room config saved — applied immediately, and will load automatically on next launch.');
+    } catch (e) {
+      toastManager.error(`Failed to save room config: ${e.message}`);
+    }
+  }
+
+  _nextFreeId() {
+    const used = new Set(this.config.nodes.map((n) => n.id));
+    let id = 0;
+    while (used.has(id)) id++;
+    return id;
+  }
+
+  _addNode() {
+    this.config.nodes.push({
+      id: this._nextFreeId(),
+      x: this.config.width_m / 2,
+      y: this.config.depth_m / 2,
+      z: 0.4,
+      label: '',
+    });
+    this._renderNodeList();
+    this._render();
+  }
+
+  _removeNode(index) {
+    this.config.nodes.splice(index, 1);
+    this._renderNodeList();
+    this._render();
+  }
+
+  /** Pull edited values out of the node-row inputs back into this.config.nodes.
+   *
+   * Rows are matched to nodes by array index (`row.dataset.index`), NOT by
+   * `id` - id is one of the fields being edited, so using it as the lookup
+   * key meant renaming a node to an ID that collided with another node's ID
+   * broke the row<->node link: both rows' edits would then read/write
+   * whichever node .find() happened to return first, which looked like one
+   * node "jumping" onto or stacking with another. Array index never changes
+   * just because a field's value changes, so it can't have that problem. */
+  _syncNodesFromInputs() {
+    const rows = this.container.querySelectorAll('.rb-node-row');
+    rows.forEach((row) => {
+      const idx = parseInt(row.dataset.index, 10);
+      const node = this.config.nodes[idx];
+      if (!node) return;
+      const idInput = row.querySelector('.rb-id-input');
+      const newId = parseInt(idInput.value, 10);
+      if (!Number.isNaN(newId)) node.id = newId;
+      node.label = row.querySelector('.rb-label').value;
+      node.x = this._fromDisplay(parseFloat(row.querySelector('.rb-x').value) || 0);
+      node.y = this._fromDisplay(parseFloat(row.querySelector('.rb-y').value) || 0);
+      node.z = this._fromDisplay(parseFloat(row.querySelector('.rb-z').value) || 0);
+    });
+    this._warnOnDuplicateIds();
+  }
+
+  _warnOnDuplicateIds() {
+    const seen = new Set();
+    for (const node of this.config.nodes) {
+      if (seen.has(node.id)) {
+        toastManager.warning(`Duplicate node ID ${node.id} — IDs must be unique before saving.`);
+        return;
+      }
+      seen.add(node.id);
+    }
+  }
+
+  // ---- Node list (form rows) -------------------------------------------------
+
+  _renderNodeList() {
+    const list = this.container.querySelector('#rbNodeList');
+    list.innerHTML = '';
+    // A bad value here (non-finite x/y/z, or an id survey away turning up
+    // NaN) used to throw out of .toFixed() partway through the loop,
+    // silently aborting the render for every node after it - one bad node
+    // could make a later, perfectly fine node vanish from both the list and
+    // the canvas with no visible error. Coerce defensively instead.
+    const safe = (v, fallback = 0) => (Number.isFinite(v) ? v : fallback);
+    this.config.nodes.forEach((node, idx) => {
+      if (!Number.isFinite(node.x) || !Number.isFinite(node.y) || !Number.isFinite(node.z)) {
+        console.warn('[RoomBuilder] Node has non-finite coordinate(s), coercing to 0:', node);
+      }
+      const row = document.createElement('div');
+      row.className = 'rb-node-row';
+      row.dataset.index = idx;
+      row.innerHTML = `
+        <input class="rb-id-input" type="number" min="0" value="${safe(node.id)}" title="Node ID (must match --node-id)">
+        <input class="rb-label" type="text" value="${node.label || ''}" placeholder="e.g. front-right">
+        <input class="rb-x" type="number" step="0.05" value="${this._toDisplay(safe(node.x)).toFixed(2)}">
+        <input class="rb-y" type="number" step="0.05" value="${this._toDisplay(safe(node.y)).toFixed(2)}">
+        <input class="rb-z" type="number" step="0.05" value="${this._toDisplay(safe(node.z)).toFixed(2)}">
+        <span></span>
+        <button class="rb-remove-btn" title="Remove node">&times;</button>
+      `;
+      row.querySelectorAll('input').forEach((inp) => {
+        inp.addEventListener('input', () => {
+          this._syncNodesFromInputs();
+          this._render();
+        });
+      });
+      row.querySelector('.rb-remove-btn').addEventListener('click', () => this._removeNode(idx));
+      list.appendChild(row);
+    });
+  }
+
+  // ---- Canvas -----------------------------------------------------------------
+
+  /** Room-space (x,y) meters -> canvas pixel coordinates. */
+  _toPixel(x, y) {
+    const scale = Math.min(
+      (CANVAS_W - 2 * MARGIN) / this.config.width_m,
+      (CANVAS_H - 2 * MARGIN) / this.config.depth_m
+    );
+    return { px: MARGIN + x * scale, py: MARGIN + y * scale, scale };
+  }
+
+  /** Canvas pixel coordinates -> room-space (x,y) meters, clamped to the room. */
+  _toRoom(px, py) {
+    const scale = Math.min(
+      (CANVAS_W - 2 * MARGIN) / this.config.width_m,
+      (CANVAS_H - 2 * MARGIN) / this.config.depth_m
+    );
+    const x = Math.min(this.config.width_m, Math.max(0, (px - MARGIN) / scale));
+    const y = Math.min(this.config.depth_m, Math.max(0, (py - MARGIN) / scale));
+    return { x, y };
+  }
+
+  _canvasPos(e) {
+    const canvas = this.container.querySelector('#rbCanvas');
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: ((e.clientX - rect.left) / rect.width) * CANVAS_W,
+      y: ((e.clientY - rect.top) / rect.height) * CANVAS_H,
+    };
+  }
+
+  _onCanvasDown(e) {
+    const pos = this._canvasPos(e);
+    this.config.nodes.forEach((node, idx) => {
+      const { px, py } = this._toPixel(node.x, node.y);
+      if (this._dragIndex == null && Math.hypot(px - pos.x, py - pos.y) <= NODE_RADIUS + 4) {
+        this._dragIndex = idx;
+      }
+    });
+  }
+
+  _onCanvasMove(e) {
+    if (this._dragIndex == null) return;
+    const node = this.config.nodes[this._dragIndex];
+    if (!node) return;
+    const pos = this._canvasPos(e);
+    const room = this._toRoom(pos.x, pos.y);
+    node.x = Math.round(room.x * 100) / 100;
+    node.y = Math.round(room.y * 100) / 100;
+    this._renderNodeList();
+    this._render();
+  }
+
+  _render() {
+    const canvas = this.container.querySelector('#rbCanvas');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+
+    // Room rectangle.
+    const topLeft = this._toPixel(0, 0);
+    const bottomRight = this._toPixel(this.config.width_m, this.config.depth_m);
+    ctx.strokeStyle = '#32b8c6';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(topLeft.px, topLeft.py, bottomRight.px - topLeft.px, bottomRight.py - topLeft.py);
+
+    // Faint grid every meter, for scale reference.
+    ctx.strokeStyle = 'rgba(50,184,198,0.15)';
+    ctx.lineWidth = 1;
+    for (let gx = 1; gx < this.config.width_m; gx++) {
+      const { px } = this._toPixel(gx, 0);
+      ctx.beginPath();
+      ctx.moveTo(px, topLeft.py);
+      ctx.lineTo(px, bottomRight.py);
+      ctx.stroke();
+    }
+    for (let gy = 1; gy < this.config.depth_m; gy++) {
+      const { py } = this._toPixel(0, gy);
+      ctx.beginPath();
+      ctx.moveTo(topLeft.px, py);
+      ctx.lineTo(bottomRight.px, py);
+      ctx.stroke();
+    }
+
+    // Nodes.
+    this.config.nodes.forEach((node, idx) => {
+      const { px, py } = this._toPixel(node.x, node.y);
+      if (!Number.isFinite(px) || !Number.isFinite(py)) {
+        console.warn('[RoomBuilder] Skipping node with non-finite position:', node);
+        return;
+      }
+      ctx.beginPath();
+      ctx.arc(px, py, NODE_RADIUS, 0, Math.PI * 2);
+      ctx.fillStyle = idx === this._dragIndex ? '#ffd166' : '#e05561';
+      ctx.fill();
+      ctx.strokeStyle = '#0d1117';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+
+      ctx.fillStyle = '#e6e9ef';
+      ctx.font = '12px monospace';
+      ctx.textAlign = 'center';
+      const label = node.label ? `${node.id}:${node.label}` : `${node.id}`;
+      ctx.fillText(label, px, py - NODE_RADIUS - 6);
+    });
+
+    this._drawCompass(ctx);
+  }
+
+  /** (0,0,0) is the room's Northwest corner by convention - X increases
+   * going East, Y increases going South. That's already how _toPixel maps
+   * room space onto the canvas (x -> right, y -> down); this just draws a
+   * fixed compass badge in the corner so it reads as "North" instead of
+   * an arbitrary direction, so a person can orient the room to reality. */
+  _drawCompass(ctx) {
+    const cx = 20;
+    const cy = 20;
+    const len = 10;
+    ctx.save();
+    ctx.strokeStyle = '#e6e9ef';
+    ctx.fillStyle = '#e6e9ef';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy + len);
+    ctx.lineTo(cx, cy - len);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - len);
+    ctx.lineTo(cx - 4, cy - len + 6);
+    ctx.lineTo(cx + 4, cy - len + 6);
+    ctx.closePath();
+    ctx.fill();
+    ctx.font = 'bold 11px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText('N', cx, cy + len + 13);
+    ctx.restore();
+  }
+}

--- a/ui/components/RoomBuilderTab.js
+++ b/ui/components/RoomBuilderTab.js
@@ -123,6 +123,7 @@ export class RoomBuilderTab {
           </div>
           <div class="rb-actions">
             <button class="rb-btn" id="rbSave">Save</button>
+            <button class="rb-btn secondary" id="rbReload" title="Discard unsaved changes and reload the last saved config">Reload from Saved</button>
           </div>
           <p class="rb-hint">
             Drag a node on the canvas to reposition it (X/Y only — set height
@@ -163,6 +164,10 @@ export class RoomBuilderTab {
     });
     this.container.querySelector('#rbSave').addEventListener('click', () => {
       this._save();
+    });
+    this.container.querySelector('#rbReload').addEventListener('click', async () => {
+      await this._load();
+      toastManager.info('Reloaded from the last saved config — unsaved changes discarded.');
     });
 
     const canvas = this.container.querySelector('#rbCanvas');

--- a/ui/components/RoomBuilderTab.js
+++ b/ui/components/RoomBuilderTab.js
@@ -10,25 +10,62 @@
 
 import { apiService } from '../services/api.service.js';
 import { toastManager } from '../utils/toast.js';
+import { sensingService } from '../services/sensing.service.js';
 
 const ENDPOINT = '/api/v1/config/room';
 const CANVAS_W = 640;
 const CANVAS_H = 480;
 const MARGIN = 32;
 const NODE_RADIUS = 9;
+const AP_RADIUS = 8;
+const LIVE_DOT_RADIUS = 8;
 const METERS_PER_FOOT = 0.3048;
+const METERS_PER_INCH = 0.0254;
+// Typical residential defaults, used when a storey is first added.
+const DEFAULT_CEILING_IN = 96;    // 8 ft
+const DEFAULT_SUBFLOOR_IN = 16;   // joists + subfloor between storeys
 const UNITS_STORAGE_KEY = 'roombuilder-units';
+// Derived from the inch figures above so there is one source of truth for a
+// default storey; a second one in metres drifted from it the moment ceiling
+// height became an input rather than a constant.
+const DEFAULT_CEILING_M = DEFAULT_CEILING_IN * METERS_PER_INCH;
+const DEFAULT_SUBFLOOR_M = DEFAULT_SUBFLOOR_IN * METERS_PER_INCH;
+// Click within this many pixels of a wall endpoint to grab it.
+const WALL_HIT_PX = 7;
 
 export class RoomBuilderTab {
   /** @param {HTMLElement} container - the #roombuilder section element */
   constructor(container) {
     this.container = container;
-    this.config = { width_m: 5, depth_m: 4, nodes: [] };
+    this.config = { width_m: 5, depth_m: 4, nodes: [], ap_position: null };
     this._dragIndex = null;
+    this._draggingAp = false;
+    // Which storey the canvas is editing. Nodes and walls on other storeys
+    // are drawn faintly rather than hidden, so you can line up a second-floor
+    // node with the wall below it -- which is the whole point of stacking
+    // storeys on a shared origin.
+    this._activeFloor = 1;
+    // 'select' drags nodes and the AP; 'wall' draws segments.
+    this._mode = 'select';
+    this._wallStart = null;
+    this._wallPreview = null;
     this._loaded = false;
+    // Live tracked-position overlay, fed by sensingService (/ws/sensing).
+    // `_liveDot` is only ever set from a "bistatic_velocity", "doppler_centroid",
+    // or "motion_centroid" position_source (real room-space meters, same
+    // convention as this.config.nodes) — a "field_peak" fix lives in the Observatory's own
+    // grid-centered coordinate frame (unrelated to this room's actual
+    // width_m/depth_m), so plotting it here would be a fabricated-looking
+    // position. `_liveStatus` explains why no dot is showing when that's the
+    // case. `_liveDotSource` records which tier produced the current dot, so
+    // the canvas label can say which one is actually driving it.
+    this._liveDot = null;
+    this._liveDotSource = null;
+    this._liveStatus = 'Waiting for live sensing data…';
+    this._unsubSensingData = null;
     // Display-only - this.config always stays in meters (that's what the
     // server/API/saved file use); only input values and labels convert.
-    this._units = 'metric';
+    this._units = 'imperial';
     try {
       const saved = localStorage.getItem(UNITS_STORAGE_KEY);
       if (saved === 'metric' || saved === 'imperial') this._units = saved;
@@ -49,10 +86,133 @@ export class RoomBuilderTab {
     return this._units === 'imperial' ? 'ft' : 'm';
   }
 
+  /** Heights are entered in INCHES when imperial, not feet.
+   *
+   * A person siting a node measures "the outlet is 20 inches" and "the
+   * ceiling is 8 foot". Forcing one unit on both means every height becomes a
+   * conversion done by hand, and a conversion done nine times is one done
+   * wrong at least once. Plan distances stay in feet, where feet are natural.
+   */
+  _toHeight(meters) {
+    return this._units === 'imperial' ? meters / METERS_PER_INCH : meters;
+  }
+
+  _fromHeight(value) {
+    return this._units === 'imperial' ? value * METERS_PER_INCH : value;
+  }
+
+  _heightLabel() {
+    return this._units === 'imperial' ? 'in' : 'm';
+  }
+
+  /** Derived elevation of a storey's floor surface above the origin.
+   *
+   * Not measured, and not editable: nobody can put a tape on the height of a
+   * second floor above a first. It is the running sum of the ceiling height
+   * and subfloor thickness of every storey below, both of which a person can
+   * actually measure or look up.
+   */
+  _derivedElevation(level) {
+    const floors = this._floors();
+    let z = 0;
+    for (const f of floors) {
+      if (f.level >= level) break;
+      z += (f.ceiling_m || 0) + (f.subfloor_m || 0);
+    }
+    return Math.round(z * 10000) / 10000;
+  }
+
+  /** Recompute every storey's elevation from ceiling + subfloor, and carry
+   * anything standing on those storeys along with them.
+   *
+   * A node's stored z is absolute (height above the ground floor), but the
+   * height a person entered was relative to its own storey. If floor 1's
+   * ceiling changes, floor 2 moves, and a node 20 inches above floor 2 must
+   * stay 20 inches above floor 2 rather than staying at an absolute height
+   * that is now inside the ceiling below.
+   */
+  _reflowElevations() {
+    // Read every measured height BEFORE the elevations move, then write them
+    // back after. Preserving the measurement is the intent; shifting z by a
+    // delta was the mechanism, and it double-applied whenever another writer
+    // had already accounted for the same elevation.
+    const heights = this.config.nodes.map((n) => this._nodeHeight(n));
+    const apLevel = Number.isFinite(this.config.ap_floor) ? this.config.ap_floor : 1;
+    const apHeight = Array.isArray(this.config.ap_position)
+      ? this.config.ap_position[2] - this._elevationOf(apLevel)
+      : null;
+
+    const floors = this._floors();
+    floors.forEach((f) => { f.elevation_m = this._derivedElevation(f.level); });
+    this.config.floors = floors;
+
+    this.config.nodes.forEach((n, i) => this._setNodeHeight(n, heights[i]));
+    if (apHeight !== null) {
+      this.config.ap_position[2] =
+        Math.round((apHeight + this._elevationOf(apLevel)) * 10000) / 10000;
+    }
+  }
+
   async init() {
     this._buildDOM();
     this._wireEvents();
     await this._load();
+    // sensingService is a singleton started once globally (app.js); we just
+    // subscribe here, same pattern as DashboardTab's live-data subscription.
+    this._unsubSensingData = sensingService.onData((data) => this._onSensingData(data));
+  }
+
+  // ---- Live position overlay ---------------------------------------------
+
+  _onSensingData(data) {
+    const persons = Array.isArray(data.persons) ? data.persons : [];
+    if (persons.length === 0) {
+      this._liveDot = null;
+      this._liveDotSource = null;
+      this._liveStatus = 'No person currently detected.';
+      const idleStatusEl = this.container.querySelector('#rbLiveStatus');
+      if (idleStatusEl) idleStatusEl.textContent = this._liveStatus;
+      this._render();
+      return;
+    }
+
+    // With today's centroid methods, all persons share the one estimate
+    // (single-target only for now) — show just the first to avoid clutter
+    // from the tracker's occasional duplicate/ghost detections.
+    const p = persons[0];
+    const nodeCount = Array.isArray(data.nodes) ? data.nodes.length : 0;
+    const ROOM_SPACE_SOURCES = {
+      bistatic_velocity: 'Live bistatic-geometry estimate — real AP/node Doppler-ellipse math, '
+        + 'still an unvalidated first cut (see position_uncertainty_m).',
+      doppler_centroid: 'Live Doppler-weighted centroid — a heuristic estimate, not a calibrated fix.',
+      motion_centroid: 'Live motion-weighted centroid — a heuristic estimate, not a calibrated fix.',
+    };
+
+    if (ROOM_SPACE_SOURCES[p.position_source] && Array.isArray(p.position)) {
+      const [x, y] = p.position;
+      if (Number.isFinite(x) && Number.isFinite(y)) {
+        this._liveDot = { x, y };
+        this._liveDotSource = p.position_source;
+        this._liveStatus = ROOM_SPACE_SOURCES[p.position_source];
+      } else {
+        this._liveDot = null;
+        this._liveDotSource = null;
+        this._liveStatus = `${p.position_source} reported non-finite coordinates — not plotted.`;
+      }
+    } else {
+      // field_peak positions live in the Observatory's own grid-centered
+      // coordinate frame, not this room's meters/NW-origin frame — plotting
+      // them here would be misleading, so we explain instead of drawing.
+      this._liveDot = null;
+      this._liveDotSource = null;
+      this._liveStatus = `No room-space estimate yet — only ${nodeCount} node(s) reporting, `
+        + `or not enough measured motion right now (need >= 2 positioned nodes with real `
+        + `disturbance). Showing the Observatory's field-peak fallback instead, which isn't `
+        + `in this room's coordinates.`;
+    }
+    const statusEl = this.container.querySelector('#rbLiveStatus');
+    if (statusEl) statusEl.textContent = this._liveStatus;
+    this._render();
   }
 
   // ---- DOM ----------------------------------------------------------------
@@ -69,9 +229,13 @@ export class RoomBuilderTab {
         .rb-room-dims { display: flex; gap: 12px; }
         .rb-room-dims label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: #8b93a7; }
         .rb-room-dims input, .rb-node-row input { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 7px; font-size: 13px; box-sizing: border-box; }
+        .rb-wall-entry { display: grid; grid-template-columns: repeat(4, 1fr) auto; gap: 6px; align-items: end; margin-top: 8px; }
+        .rb-wall-entry label { display: flex; flex-direction: column; gap: 3px; font-size: 11px; color: #6b7280; }
+        .rb-wall-entry input { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 6px; font-size: 13px; width: 100%; box-sizing: border-box; }
+        .rb-node-row select { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 4px; font-size: 13px; width: 100%; box-sizing: border-box; }
         .rb-room-dims input { width: 72px; }
         .rb-room-dims select { background: #0d1117; border: 1px solid #2a2f3a; border-radius: 4px; color: #e6e9ef; padding: 5px 7px; font-size: 13px; }
-        .rb-node-row { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 1fr 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
+        .rb-node-row { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 52px 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
         .rb-node-row input { width: 100%; }
         .rb-node-row .rb-id { color: #32b8c6; font-weight: 600; font-size: 13px; }
         /* Number inputs' native up/down spinner eats most of the width in
@@ -85,7 +249,7 @@ export class RoomBuilderTab {
         .rb-btn.secondary { background: transparent; color: #32b8c6; border: 1px solid #32b8c6; }
         .rb-actions { display: flex; gap: 10px; margin-top: 8px; }
         .rb-hint { color: #6b7280; font-size: 12px; margin-top: 8px; line-height: 1.5; }
-        .rb-col-headers { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 1fr 24px; gap: 6px; font-size: 11px; color: #6b7280; margin-bottom: 6px; }
+        .rb-col-headers { display: grid; grid-template-columns: 42px 1fr 60px 60px 60px 52px 24px; gap: 6px; font-size: 11px; color: #6b7280; margin-bottom: 6px; }
       </style>
       <h2>Room Builder</h2>
       <p class="rb-hint" style="margin-bottom:16px;">
@@ -96,6 +260,7 @@ export class RoomBuilderTab {
       <div class="rb-layout">
         <div class="rb-canvas-wrap">
           <canvas id="rbCanvas" width="${CANVAS_W}" height="${CANVAS_H}"></canvas>
+          <p class="rb-hint" id="rbLiveStatus" style="margin:8px 2px 0;">Waiting for live sensing data…</p>
         </div>
         <div class="rb-panel">
           <div class="rb-card">
@@ -112,9 +277,62 @@ export class RoomBuilderTab {
             </div>
           </div>
           <div class="rb-card">
+            <div class="rb-card-title">Storeys &amp; Walls</div>
+            <p class="rb-hint" style="margin-top:0;">
+              The origin (0,&nbsp;0,&nbsp;0) is the <strong>north-west corner of the
+              first floor</strong>, at floor level. Every storey shares it — the
+              second floor is not re-zeroed — so a node's X/Y means the same
+              thing on any storey and Z is height above the ground floor.
+            </p>
+            <div id="rbFloorControls"></div>
+            <div class="rb-actions" style="margin-top:10px;">
+              <button class="rb-btn secondary" id="rbAddFloor">+ Add Storey</button>
+              <button class="rb-btn secondary" id="rbRemoveFloor">Remove Top Storey</button>
+              <button class="rb-btn secondary" id="rbWallMode">Draw Walls</button>
+            </div>
+            <p class="rb-hint" id="rbWallHint" style="margin-bottom:6px;">
+              In wall mode, drag on the canvas to draw a segment on the selected
+              storey. Other storeys stay visible, faintly, so you can line one up
+              with the floor below.
+            </p>
+            <div class="rb-wall-entry">
+              <label><span>Start &middot; east &rarr;</span><input type="number" id="rbWallX1" step="0.25" value="0" title="Distance east from the north-west corner"></label>
+              <label><span>Start &middot; south &darr;</span><input type="number" id="rbWallY1" step="0.25" value="0" title="Distance south from the north-west corner"></label>
+              <label><span>End &middot; east &rarr;</span><input type="number" id="rbWallX2" step="0.25" placeholder="—" title="Distance east from the north-west corner"></label>
+              <label><span>End &middot; south &darr;</span><input type="number" id="rbWallY2" step="0.25" placeholder="—" title="Distance south from the north-west corner"></label>
+              <button class="rb-btn secondary" id="rbAddWall">Add</button>
+            </div>
+            <p class="rb-hint" id="rbWallEntryHint" style="margin:4px 2px 8px;">
+              Both points are measured from the <strong>north-west corner</strong>, in
+              <span class="rb-unit-label">${this._unitLabel()}</span> — east is right,
+              south is down, matching the <strong>N</strong> arrow on the canvas. A wall
+              along the north edge starting at the corner is
+              start&nbsp;0,&nbsp;0 → end&nbsp;12,&nbsp;0.
+            </p>
+            <div id="rbWallList"></div>
+          </div>
+          <div class="rb-card">
+            <div class="rb-card-title">Access Point</div>
+            <p class="rb-hint" style="margin-top:0;">
+              Optional — needed for Doppler-based position geometry. One AP,
+              same room-space meters as the nodes above (it's often outside
+              the room itself — a hallway, another floor — and that's fine).
+            </p>
+            <div class="rb-room-dims" id="rbApFields" style="${this.config.ap_position ? '' : 'display:none;'}">
+              <label><span>X (<span class="rb-unit-label">${this._unitLabel()}</span>)</span> <input type="number" id="rbApX" step="0.05" value="${this._toDisplay(this.config.ap_position?.[0] ?? 0).toFixed(2)}"></label>
+              <label><span>Y (<span class="rb-unit-label">${this._unitLabel()}</span>)</span> <input type="number" id="rbApY" step="0.05" value="${this._toDisplay(this.config.ap_position?.[1] ?? 0).toFixed(2)}"></label>
+              <label><span>Z (<span class="rb-hunit-label">${this._heightLabel()}</span>)</span> <input type="number" id="rbApZ" step="0.5" title="Height above the AP's own floor" value="${this._toHeight(this.config.ap_position?.[2] ?? 0).toFixed(1)}"></label>
+              <label><span>Floor</span> <select id="rbApFloor"></select></label>
+            </div>
+            <div class="rb-actions" style="margin-top:${this.config.ap_position ? '10px' : '0'};">
+              <button class="rb-btn secondary" id="rbAddAp" style="${this.config.ap_position ? 'display:none;' : ''}">+ Set AP Position</button>
+              <button class="rb-btn secondary" id="rbRemoveAp" style="${this.config.ap_position ? '' : 'display:none;'}">Remove AP</button>
+            </div>
+          </div>
+          <div class="rb-card">
             <div class="rb-card-title">Sensor Nodes</div>
             <div class="rb-col-headers">
-              <span>ID</span><span>Label</span><span>X (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Y (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Z (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span></span><span></span>
+              <span>ID</span><span>Label</span><span>X (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Y (<span class="rb-unit-label">${this._unitLabel()}</span>)</span><span>Z (<span class="rb-hunit-label">${this._heightLabel()}</span>)</span><span>Floor</span><span></span>
             </div>
             <div id="rbNodeList"></div>
             <div class="rb-actions">
@@ -122,19 +340,34 @@ export class RoomBuilderTab {
             </div>
           </div>
           <div class="rb-actions">
+            <button class="rb-btn secondary" id="rbCalibrate"
+                    title="Clear every node's ambient floor and re-learn it from the room as it is now">
+              Recalibrate All Nodes
+            </button>
+          </div>
+          <p class="rb-hint">
+            Use after moving boards or rearranging a room. Nodes adapt on their own,
+            but they climb back down to a lower floor slowly on purpose — so a person
+            standing still is never mistaken for the new normal. This skips the wait.
+            <strong>Leave the area first:</strong> each node re-learns from roughly the
+            next 30&nbsp;seconds, so whatever is moving then becomes its idea of quiet.
+          </p>
+          <div class="rb-actions">
             <button class="rb-btn" id="rbSave">Save</button>
             <button class="rb-btn secondary" id="rbReload" title="Discard unsaved changes and reload the last saved config">Reload from Saved</button>
           </div>
           <p class="rb-hint">
-            Drag a node on the canvas to reposition it (X/Y only — set height
-            with the Z field). Coordinates are in the same room-space meters
-            used by <code>--node-positions</code>.
+            Drag a node — or the AP marker (violet diamond), once set — on the
+            canvas to reposition it (X/Y only — set height with the Z field).
+            Coordinates are in the same room-space meters used by
+            <code>--node-positions</code>.
           </p>
           <p class="rb-hint">
             <strong>(0, 0)</strong> is the room's <strong>Northwest</strong> corner
             (the <strong>N</strong> arrow on the canvas points that way) — X increases
             going <strong>East</strong>, Y increases going <strong>South</strong>. Face
-            the room's actual north wall and match it up when you place nodes.
+            the room's actual north wall and match it up when you place nodes
+            and the access point.
           </p>
         </div>
       </div>
@@ -162,6 +395,145 @@ export class RoomBuilderTab {
     this.container.querySelector('#rbAddNode').addEventListener('click', () => {
       this._addNode();
     });
+    this.container.querySelector('#rbAddAp').addEventListener('click', () => {
+      // Default to head height on the storey currently being edited, rather
+      // than an absolute 2.5 m that would be inside the ceiling upstairs.
+      this.config.ap_floor = this._activeFloor;
+      this.config.ap_position = [
+        this.config.width_m / 2,
+        this.config.depth_m / 2,
+        Math.round((this._elevationOf(this._activeFloor) + 2.2) * 10000) / 10000,
+      ];
+      this._renderApFields();
+      this._render();
+    });
+    // Live preview: typing coordinates is only unclear until you can see what
+    // they produce. The dashed line uses the same path as a dragged wall.
+    const wallInputs = ['rbWallX1', 'rbWallY1', 'rbWallX2', 'rbWallY2'];
+    const previewWall = () => {
+      const raw = wallInputs.map((id) => this.container.querySelector(`#${id}`).value);
+      if (raw.some((v) => v === '' || v === null)) {
+        this._wallStart = null;
+        this._wallPreview = null;
+        this._updateWallEntryHint(null);
+        this._render();
+        return;
+      }
+      const [x1, y1, x2, y2] = raw.map((v) => this._fromDisplay(parseFloat(v) || 0));
+      this._wallStart = { x: x1, y: y1 };
+      const end = this._toPixel(x2, y2);
+      this._wallPreview = { x: end.px, y: end.py };
+      this._updateWallEntryHint(Math.hypot(x2 - x1, y2 - y1));
+      this._render();
+    };
+    wallInputs.forEach((id) => {
+      this.container.querySelector(`#${id}`).addEventListener('input', previewWall);
+    });
+
+    this.container.querySelector('#rbAddWall').addEventListener('click', () => {
+      const num = (id) => parseFloat(this.container.querySelector(`#${id}`).value);
+      // An empty end box used to fall through `|| 0` and draw a wall to the
+      // north-west corner, which is a real coordinate and so looked deliberate.
+      const missing = ['rbWallX2', 'rbWallY2'].some(
+        (id) => !Number.isFinite(num(id))
+      );
+      if (missing) {
+        toastManager.error('Fill in both end coordinates before adding the wall.');
+        return;
+      }
+      const x1 = this._fromDisplay(num('rbWallX1') || 0);
+      const y1 = this._fromDisplay(num('rbWallY1') || 0);
+      const x2 = this._fromDisplay(num('rbWallX2'));
+      const y2 = this._fromDisplay(num('rbWallY2'));
+      if (Math.hypot(x2 - x1, y2 - y1) < 0.1) {
+        toastManager.error('Start and end are the same point — a wall needs length.');
+        return;
+      }
+      if (!Array.isArray(this.config.walls)) this.config.walls = [];
+      const r = (v) => Math.round(v * 10000) / 10000;
+      this.config.walls.push({
+        level: this._activeFloor,
+        x1: r(x1), y1: r(y1), x2: r(x2), y2: r(y2),
+      });
+      // Chain from the end point -- walls in a room almost always meet -- but
+      // CLEAR the end. Copying both left all four boxes showing the same
+      // number and staged a zero-length wall, which looked broken.
+      this.container.querySelector('#rbWallX1').value = num('rbWallX2');
+      this.container.querySelector('#rbWallY1').value = num('rbWallY2');
+      this.container.querySelector('#rbWallX2').value = '';
+      this.container.querySelector('#rbWallY2').value = '';
+      this._wallStart = null;
+      this._wallPreview = null;
+      this._updateWallEntryHint(null);
+      this._renderWallList();
+      this._renderFloorControls();
+      this._render();
+    });
+    this.container.querySelector('#rbAddFloor').addEventListener('click', () => {
+      this._addFloor();
+    });
+    this.container.querySelector('#rbRemoveFloor').addEventListener('click', () => {
+      this._removeTopFloor();
+    });
+    this.container.querySelector('#rbWallMode').addEventListener('click', (e) => {
+      this._mode = this._mode === 'wall' ? 'select' : 'wall';
+      // Abandon a half-drawn segment rather than leaving it to commit on the
+      // next unrelated click.
+      this._wallStart = null;
+      this._wallPreview = null;
+      e.target.textContent = this._mode === 'wall' ? 'Done Drawing' : 'Draw Walls';
+      const canvas = this.container.querySelector('#rbCanvas');
+      if (canvas) canvas.style.cursor = this._mode === 'wall' ? 'crosshair' : 'default';
+      const hint = this.container.querySelector('#rbWallHint');
+      if (hint) {
+        hint.textContent = this._mode === 'wall'
+          ? 'Drag on the canvas to draw a wall on the selected storey. Dragging no longer moves nodes.'
+          : 'In wall mode, drag on the canvas to draw a segment on the selected storey. Other storeys stay visible, faintly, so you can line one up with the floor below.';
+      }
+      this._render();
+    });
+    this.container.querySelector('#rbRemoveAp').addEventListener('click', () => {
+      this.config.ap_position = null;
+      this._renderApFields();
+      this._render();
+    });
+    ['rbApX', 'rbApY', 'rbApZ'].forEach((id) => {
+      this.container.querySelector(`#${id}`).addEventListener('input', () => {
+        this._syncApFromInputs();
+        this._render();
+      });
+    });
+    this.container.querySelector('#rbCalibrate').addEventListener('click', async (e) => {
+      const btn = e.target;
+      btn.disabled = true;
+      const was = btn.textContent;
+      btn.textContent = 'Recalibrating…';
+      try {
+        const r = await apiService.post('/api/v1/calibrate', {});
+        if (r && r.error) {
+          toastManager.error(`Recalibrate failed: ${r.error}`);
+        } else {
+          const okList = (r && r.recalibrated) || [];
+          const bad = (r && r.failed) || [];
+          // Name the nodes that did not take it. "Partial success" with no
+          // list means walking the house to work out which board to look at.
+          if (bad.length) {
+            toastManager.error(
+              `Recalibrated ${okList.length}; failed on node(s) ${bad.map((f) => f.node).join(', ')}`
+            );
+          } else {
+            toastManager.success(
+              `Recalibrating ${okList.length} node(s) — they re-learn over about 30 seconds.`
+            );
+          }
+        }
+      } catch (err) {
+        toastManager.error(`Recalibrate failed: ${err.message}`);
+      } finally {
+        btn.disabled = false;
+        btn.textContent = was;
+      }
+    });
     this.container.querySelector('#rbSave').addEventListener('click', () => {
       this._save();
     });
@@ -173,19 +545,80 @@ export class RoomBuilderTab {
     const canvas = this.container.querySelector('#rbCanvas');
     canvas.addEventListener('mousedown', (e) => this._onCanvasDown(e));
     canvas.addEventListener('mousemove', (e) => this._onCanvasMove(e));
-    window.addEventListener('mouseup', () => { this._dragIndex = null; });
+    window.addEventListener('mouseup', (e) => {
+      if (this._mode === 'wall' && this._wallStart) {
+        this._commitWall(e);
+      }
+      this._dragIndex = null;
+      this._draggingAp = false;
+    });
   }
 
   // ---- Data -----------------------------------------------------------------
+
+  /** Storeys, ascending. An empty list means a single implicit ground floor,
+   * which is how every config written before storeys existed behaves. */
+  _floors() {
+    if (!Array.isArray(this.config.floors) || this.config.floors.length === 0) {
+      return [{ level: 1, name: 'First', elevation_m: 0, ceiling_m: DEFAULT_CEILING_M, subfloor_m: DEFAULT_SUBFLOOR_M }];
+    }
+    return [...this.config.floors].sort((a, b) => a.level - b.level);
+  }
+
+  _floorOf(node) {
+    return Number.isFinite(node.floor) ? node.floor : 1;
+  }
+
+  /** A node's height above its OWN storey — the number a person measured. */
+  _nodeHeight(node) {
+    return node.z - this._elevationOf(this._floorOf(node));
+  }
+
+  /** The ONLY place node.z is written.
+   *
+   * z is stored absolute (above the ground floor) because geometry needs one
+   * axis, but every height in this form is entered relative to its own storey.
+   * That conversion used to happen in three places — the input sync, the
+   * storey selector, and the elevation reflow — each adding the storey
+   * elevation independently. Any two firing for one edit added it twice, which
+   * is how nodes ended up at 122 and 246 inches above their own ceilings.
+   *
+   * Now there is one writer and one reader, and both go through the same
+   * elevation lookup, so the round trip is idempotent no matter how many times
+   * it runs. */
+  _setNodeHeight(node, relMeters) {
+    if (!Number.isFinite(relMeters)) return;
+    node.z = Math.round((relMeters + this._elevationOf(this._floorOf(node))) * 10000) / 10000;
+  }
+
+  _elevationOf(level) {
+    const f = this._floors().find((x) => x.level === level);
+    return f ? f.elevation_m : 0;
+  }
 
   async _load() {
     try {
       const data = await apiService.get(ENDPOINT);
       if (data && typeof data === 'object') {
+        // Spread first, then override only the fields that need defaulting.
+        //
+        // This was an explicit allowlist of four fields, which silently
+        // discarded everything the server sent that was not on it — floors,
+        // walls and ap_floor were all dropped on load. The visible symptom was
+        // storeys vanishing from the picker after a refresh, but the real
+        // danger was the next Save: config no longer held them, so it would
+        // POST an empty list and destroy the storeys on disk for real.
+        //
+        // Spreading means a field added to the server is carried through
+        // rather than quietly deleted by a UI that predates it.
         this.config = {
+          ...data,
           width_m: data.width_m > 0 ? data.width_m : 5,
           depth_m: data.depth_m > 0 ? data.depth_m : 4,
           nodes: Array.isArray(data.nodes) ? data.nodes : [],
+          ap_position: Array.isArray(data.ap_position) ? data.ap_position : null,
+          floors: Array.isArray(data.floors) ? data.floors : [],
+          walls: Array.isArray(data.walls) ? data.walls : [],
         };
       }
     } catch (e) {
@@ -198,21 +631,97 @@ export class RoomBuilderTab {
   /** Re-render everything that shows a unit-dependent value, using the
    * current `this._units` - called on load and whenever the unit toggle
    * changes. `this.config` itself never changes here; only what's displayed. */
+  /** Re-render every panel that depends on the loaded config. Called from the
+   * same places as _renderNodeList, so storeys and walls cannot drift out of
+   * sync with what was loaded or saved. */
+  _renderStoreyPanels() {
+    this._renderFloorControls();
+    this._renderWallList();
+  }
+
   _refreshUnitDisplay() {
     const label = this._unitLabel();
     this.container.querySelectorAll('.rb-unit-label').forEach((el) => {
       el.textContent = label;
     });
+    // Heights use their own unit (inches when imperial), so they have their
+    // own label class. Missing this leaves "ft" beside a field holding inches.
+    const hLabel = this._heightLabel();
+    this.container.querySelectorAll('.rb-hunit-label').forEach((el) => {
+      el.textContent = hLabel;
+    });
     this.container.querySelector('#rbWidth').value = this._toDisplay(this.config.width_m).toFixed(2);
     this.container.querySelector('#rbDepth').value = this._toDisplay(this.config.depth_m).toFixed(2);
     this._renderNodeList();
+    this._renderStoreyPanels();
+    this._renderApFields();
     this._render();
   }
 
+  /** Show/hide the AP X/Y/Z fields and Add/Remove buttons based on whether
+   * ap_position is set, and refresh the input values from this.config. */
+  _renderApFields() {
+    const fields = this.container.querySelector('#rbApFields');
+    const addBtn = this.container.querySelector('#rbAddAp');
+    const removeBtn = this.container.querySelector('#rbRemoveAp');
+    const has = Array.isArray(this.config.ap_position);
+    fields.style.display = has ? '' : 'none';
+    addBtn.style.display = has ? 'none' : '';
+    removeBtn.style.display = has ? '' : 'none';
+    if (has) {
+      const [x, y, z] = this.config.ap_position;
+      const lvl = Number.isFinite(this.config.ap_floor) ? this.config.ap_floor : 1;
+      this.container.querySelector('#rbApX').value = this._toDisplay(x).toFixed(2);
+      this.container.querySelector('#rbApY').value = this._toDisplay(y).toFixed(2);
+      // Shown as height above the AP's own storey, like every other height in
+      // this form. Storage stays absolute.
+      this.container.querySelector('#rbApZ').value =
+        this._toHeight(z - this._elevationOf(lvl)).toFixed(1);
+
+      const sel = this.container.querySelector('#rbApFloor');
+      if (sel) {
+        sel.innerHTML = this._floors()
+          .map((f) => `<option value="${f.level}" ${f.level === lvl ? 'selected' : ''}>${f.level}</option>`)
+          .join('');
+        if (!sel.dataset.wired) {
+          sel.dataset.wired = '1';
+          sel.addEventListener('change', () => {
+            // Keep the measured height: moving the AP upstairs moves its
+            // absolute z by the difference in storey elevations.
+            const prev = this._elevationOf(
+              Number.isFinite(this.config.ap_floor) ? this.config.ap_floor : 1
+            );
+            const next = this._elevationOf(Number(sel.value));
+            this.config.ap_floor = Number(sel.value);
+            if (Array.isArray(this.config.ap_position)) {
+              this.config.ap_position[2] =
+                Math.round((this.config.ap_position[2] - prev + next) * 10000) / 10000;
+            }
+            this._renderApFields();
+            this._render();
+          });
+        }
+      }
+    }
+  }
+
+  /** Pull edited values out of the AP X/Y/Z inputs back into
+   * this.config.ap_position, same pattern as _syncNodesFromInputs. */
+  _syncApFromInputs() {
+    if (!Array.isArray(this.config.ap_position)) return;
+    const x = this._fromDisplay(parseFloat(this.container.querySelector('#rbApX').value) || 0);
+    const y = this._fromDisplay(parseFloat(this.container.querySelector('#rbApY').value) || 0);
+    const lvl = Number.isFinite(this.config.ap_floor) ? this.config.ap_floor : 1;
+    const relZ = this._fromHeight(parseFloat(this.container.querySelector('#rbApZ').value) || 0);
+    const z = Math.round((relZ + this._elevationOf(lvl)) * 10000) / 10000;
+    this.config.ap_position = [x, y, z];
+  }
+
   async _save() {
-    // Pull the latest values out of the node-row inputs before sending -
+    // Pull the latest values out of the node-row/AP inputs before sending -
     // numeric fields don't write back into this.config until blur/save.
     this._syncNodesFromInputs();
+    this._syncApFromInputs();
     const ids = this.config.nodes.map((n) => n.id);
     if (new Set(ids).size !== ids.length) {
       toastManager.error('Cannot save: two or more nodes have the same ID. Give each a unique ID first.');
@@ -249,12 +758,14 @@ export class RoomBuilderTab {
       label: '',
     });
     this._renderNodeList();
+    this._renderStoreyPanels();
     this._render();
   }
 
   _removeNode(index) {
     this.config.nodes.splice(index, 1);
     this._renderNodeList();
+    this._renderStoreyPanels();
     this._render();
   }
 
@@ -279,7 +790,9 @@ export class RoomBuilderTab {
       node.label = row.querySelector('.rb-label').value;
       node.x = this._fromDisplay(parseFloat(row.querySelector('.rb-x').value) || 0);
       node.y = this._fromDisplay(parseFloat(row.querySelector('.rb-y').value) || 0);
-      node.z = this._fromDisplay(parseFloat(row.querySelector('.rb-z').value) || 0);
+      // The field holds height above this node's own storey; _setNodeHeight
+      // is the single place that turns that into absolute z.
+      this._setNodeHeight(node, this._fromHeight(parseFloat(row.querySelector('.rb-z').value) || 0));
     });
     this._warnOnDuplicateIds();
   }
@@ -318,10 +831,30 @@ export class RoomBuilderTab {
         <input class="rb-label" type="text" value="${node.label || ''}" placeholder="e.g. front-right">
         <input class="rb-x" type="number" step="0.05" value="${this._toDisplay(safe(node.x)).toFixed(2)}">
         <input class="rb-y" type="number" step="0.05" value="${this._toDisplay(safe(node.y)).toFixed(2)}">
-        <input class="rb-z" type="number" step="0.05" value="${this._toDisplay(safe(node.z)).toFixed(2)}">
-        <span></span>
+        <input class="rb-z" type="number" step="0.5" title="Height above this node's own floor"
+               value="${this._toHeight(safe(node.z) - this._elevationOf(this._floorOf(node))).toFixed(1)}">
+        <select class="rb-floor" title="Which storey this node is mounted on">
+          ${this._floors().map((f) => `<option value="${f.level}" ${this._floorOf(node) === f.level ? 'selected' : ''}>${f.level}</option>`).join('')}
+        </select>
         <button class="rb-remove-btn" title="Remove node">&times;</button>
       `;
+      const floorSel = row.querySelector('.rb-floor');
+      if (floorSel) {
+        floorSel.addEventListener('change', () => {
+          // Store the storey, and lift z onto it so the node does not stay at
+          // ground-floor height after being moved upstairs. z is measured from
+          // the FIRST floor, so moving between storeys has to move z too or the
+          // node silently ends up inside the ceiling below.
+          // Keep the height the person measured: read it against the OLD
+          // storey, change storey, write it back against the NEW one. The
+          // elevation is applied by _setNodeHeight and nowhere else.
+          const rel = this._nodeHeight(node);
+          node.floor = Number(floorSel.value);
+          this._setNodeHeight(node, rel);
+          this._renderNodeList();
+          this._render();
+        });
+      }
       row.querySelectorAll('input').forEach((inp) => {
         inp.addEventListener('input', () => {
           this._syncNodesFromInputs();
@@ -344,14 +877,20 @@ export class RoomBuilderTab {
     return { px: MARGIN + x * scale, py: MARGIN + y * scale, scale };
   }
 
-  /** Canvas pixel coordinates -> room-space (x,y) meters, clamped to the room. */
-  _toRoom(px, py) {
+  /** Canvas pixel coordinates -> room-space (x,y) meters. Clamped to the room
+   * by default (sensor nodes always live inside it); pass `clamp: false` for
+   * the AP marker, which is legitimately often outside the room. */
+  _toRoom(px, py, { clamp = true } = {}) {
     const scale = Math.min(
       (CANVAS_W - 2 * MARGIN) / this.config.width_m,
       (CANVAS_H - 2 * MARGIN) / this.config.depth_m
     );
-    const x = Math.min(this.config.width_m, Math.max(0, (px - MARGIN) / scale));
-    const y = Math.min(this.config.depth_m, Math.max(0, (py - MARGIN) / scale));
+    let x = (px - MARGIN) / scale;
+    let y = (py - MARGIN) / scale;
+    if (clamp) {
+      x = Math.min(this.config.width_m, Math.max(0, x));
+      y = Math.min(this.config.depth_m, Math.max(0, y));
+    }
     return { x, y };
   }
 
@@ -366,6 +905,23 @@ export class RoomBuilderTab {
 
   _onCanvasDown(e) {
     const pos = this._canvasPos(e);
+
+    if (this._mode === 'wall') {
+      // Walls are not clamped to the room rectangle. width_m/depth_m describe
+      // the sensed area, and an exterior wall is legitimately on or slightly
+      // outside that boundary.
+      const room = this._toRoom(pos.x, pos.y, { clamp: false });
+      this._wallStart = { x: room.x, y: room.y };
+      this._wallPreview = { x: pos.x, y: pos.y };
+      return;
+    }
+    if (Array.isArray(this.config.ap_position)) {
+      const { px, py } = this._toPixel(this.config.ap_position[0], this.config.ap_position[1]);
+      if (Math.hypot(px - pos.x, py - pos.y) <= AP_RADIUS + 4) {
+        this._draggingAp = true;
+        return;
+      }
+    }
     this.config.nodes.forEach((node, idx) => {
       const { px, py } = this._toPixel(node.x, node.y);
       if (this._dragIndex == null && Math.hypot(px - pos.x, py - pos.y) <= NODE_RADIUS + 4) {
@@ -375,6 +931,21 @@ export class RoomBuilderTab {
   }
 
   _onCanvasMove(e) {
+    if (this._mode === 'wall' && this._wallStart) {
+      const pos = this._canvasPos(e);
+      this._wallPreview = { x: pos.x, y: pos.y };
+      this._render();
+      return;
+    }
+    if (this._draggingAp) {
+      const pos = this._canvasPos(e);
+      const room = this._toRoom(pos.x, pos.y, { clamp: false });
+      this.config.ap_position[0] = Math.round(room.x * 100) / 100;
+      this.config.ap_position[1] = Math.round(room.y * 100) / 100;
+      this._renderApFields();
+      this._render();
+      return;
+    }
     if (this._dragIndex == null) return;
     const node = this.config.nodes[this._dragIndex];
     if (!node) return;
@@ -383,6 +954,231 @@ export class RoomBuilderTab {
     node.x = Math.round(room.x * 100) / 100;
     node.y = Math.round(room.y * 100) / 100;
     this._renderNodeList();
+    this._renderStoreyPanels();
+    this._render();
+  }
+
+  /** Storey selector, plus the two numbers a person can actually measure.
+   *
+   * Ceiling height and subfloor thickness are the inputs; elevation is
+   * derived from them and shown read-only. Nobody can put a tape measure on
+   * "height of the second floor above the first", but anyone can measure a
+   * ceiling and look up a joist depth -- and deriving it means every height
+   * elsewhere in this form is relative to the floor you are standing on.
+   */
+  _renderFloorControls() {
+    const host = this.container.querySelector('#rbFloorControls');
+    if (!host) return;
+    const floors = this._floors();
+    const active = floors.find((f) => f.level === this._activeFloor) || floors[0];
+    this._activeFloor = active.level;
+    const hu = this._heightLabel();
+
+    const opts = floors
+      .map((f) => {
+        const nodes = this.config.nodes.filter((n) => this._floorOf(n) === f.level).length;
+        const walls = (this.config.walls || []).filter((w) => w.level === f.level).length;
+        const sel = f.level === this._activeFloor ? 'selected' : '';
+        const nm = f.name || `Floor ${f.level}`;
+        return `<option value="${f.level}" ${sel}>${nm} — ${nodes} node(s), ${walls} wall(s)</option>`;
+      })
+      .join('');
+
+    const elev = this._derivedElevation(active.level);
+    host.innerHTML = `
+      <div class="rb-room-dims">
+        <label><span>Editing storey</span>
+          <select id="rbFloorSelect">${opts}</select>
+        </label>
+        <label><span>Floor to ceiling (<span class="rb-hunit-label">${hu}</span>)</span>
+          <input type="number" id="rbFloorCeil" min="1" step="0.5"
+                 value="${this._toHeight(active.ceiling_m).toFixed(1)}"
+                 title="Measured floor surface to ceiling on this storey"></label>
+        <label><span>Subfloor / joists (<span class="rb-hunit-label">${hu}</span>)</span>
+          <input type="number" id="rbFloorSub" min="0" step="0.5"
+                 value="${this._toHeight(active.subfloor_m || 0).toFixed(1)}"
+                 title="Structure between this ceiling and the floor above"></label>
+      </div>
+      <p class="rb-hint" style="margin:6px 2px 0;">
+        This storey's floor sits <strong>${this._toHeight(elev).toFixed(1)} ${hu}</strong>
+        above the ground floor${active.level === 1 ? ' (it defines the origin)' : ''}.
+        Heights you enter below are measured from <em>this</em> floor, so an outlet
+        20&nbsp;${hu} up is just 20.
+      </p>`;
+
+    const sel = host.querySelector('#rbFloorSelect');
+    if (sel) sel.addEventListener('change', () => {
+      this._activeFloor = Number(sel.value);
+      this._renderFloorControls();
+      this._renderNodeList();
+      this._renderWallList();
+      this._render();
+    });
+
+    const commit = () => {
+      const f = this._floors().find((x) => x.level === this._activeFloor);
+      if (!f) return;
+      const c = parseFloat(host.querySelector('#rbFloorCeil').value);
+      const sub = parseFloat(host.querySelector('#rbFloorSub').value);
+      if (Number.isFinite(c) && c > 0) f.ceiling_m = this._fromHeight(c);
+      if (Number.isFinite(sub) && sub >= 0) f.subfloor_m = this._fromHeight(sub);
+      this.config.floors = this._floors();
+      // Changing a ceiling moves every storey above it, and everything on them.
+      this._reflowElevations();
+      this._renderFloorControls();
+      this._renderNodeList();
+      this._renderApFields();
+      this._render();
+    };
+    ['#rbFloorCeil', '#rbFloorSub'].forEach((id) => {
+      const el = host.querySelector(id);
+      if (el) el.addEventListener('change', commit);
+    });
+  }
+
+  /** Show the length of the wall currently being typed, or the how-to text. */
+  _updateWallEntryHint(lengthMeters) {
+    const el = this.container.querySelector('#rbWallEntryHint');
+    if (!el) return;
+    if (lengthMeters == null) {
+      el.innerHTML = `Both points are measured from the <strong>north-west corner</strong>, in
+        <span class="rb-unit-label">${this._unitLabel()}</span> — east is right, south is
+        down, matching the <strong>N</strong> arrow on the canvas. A wall along the north
+        edge starting at the corner is start&nbsp;0,&nbsp;0 → end&nbsp;12,&nbsp;0.`;
+      return;
+    }
+    const u = this._unitLabel();
+    el.innerHTML = lengthMeters < 0.1
+      ? '<span style="color:#e05561;">Start and end are the same point.</span>'
+      : `This wall is <strong>${this._toDisplay(lengthMeters).toFixed(1)} ${u}</strong> long — shown dashed on the canvas.`;
+  }
+
+  /** Walls on the active storey, each removable. */
+  _renderWallList() {
+    const host = this.container.querySelector('#rbWallList');
+    if (!host) return;
+    const walls = this.config.walls || [];
+    const mine = walls
+      .map((w, i) => ({ w, i }))
+      .filter(({ w }) => w.level === this._activeFloor);
+
+    if (mine.length === 0) {
+      host.innerHTML = '<p class="rb-hint" style="margin:4px 2px;">No walls on this storey yet.</p>';
+      return;
+    }
+    const u = this._unitLabel();
+    host.innerHTML = mine
+      .map(({ w, i }) => {
+        const len = Math.hypot(w.x2 - w.x1, w.y2 - w.y1);
+        return `<div class="rb-hint" style="display:flex;align-items:center;gap:8px;margin:3px 2px;">
+          <span style="flex:1;font-family:monospace;">
+            (${this._toDisplay(w.x1).toFixed(1)}, ${this._toDisplay(w.y1).toFixed(1)})
+            → (${this._toDisplay(w.x2).toFixed(1)}, ${this._toDisplay(w.y2).toFixed(1)})
+            · ${this._toDisplay(len).toFixed(1)} ${u}
+          </span>
+          <button class="rb-btn secondary" data-wall="${i}" style="padding:2px 8px;">✕</button>
+        </div>`;
+      })
+      .join('');
+
+    host.querySelectorAll('button[data-wall]').forEach((b) => {
+      b.addEventListener('click', () => {
+        const idx = Number(b.getAttribute('data-wall'));
+        this.config.walls.splice(idx, 1);
+        this._renderWallList();
+        this._renderFloorControls();
+        this._render();
+      });
+    });
+  }
+
+  /** Finish the wall being dragged, if it is long enough to be a wall.
+   *
+   * The server rejects zero-length segments (they make any
+   * line-intersection test degenerate rather than merely wrong), so a stray
+   * click is dropped here rather than sent and bounced. 10 cm is below any
+   * real wall and above any accidental twitch.
+   */
+  _commitWall(e) {
+    const start = this._wallStart;
+    this._wallStart = null;
+    this._wallPreview = null;
+    if (!start) return;
+
+    const pos = this._canvasPos(e);
+    const end = this._toRoom(pos.x, pos.y, { clamp: false });
+    const len = Math.hypot(end.x - start.x, end.y - start.y);
+    if (!Number.isFinite(len) || len < 0.1) {
+      this._render();
+      return;
+    }
+
+    const round = (v) => Math.round(v * 100) / 100;
+    if (!Array.isArray(this.config.walls)) this.config.walls = [];
+    this.config.walls.push({
+      level: this._activeFloor,
+      x1: round(start.x), y1: round(start.y),
+      x2: round(end.x), y2: round(end.y),
+    });
+    this._renderWallList();
+    this._render();
+  }
+
+  /** Add a storey above the highest one. */
+  _addFloor() {
+    const floors = this._floors();
+    const top = floors[floors.length - 1];
+    const next = {
+      level: top.level + 1,
+      name: `Floor ${top.level + 1}`,
+      // Placeholder; _reflowElevations derives the real value from the
+      // ceiling and subfloor of every storey below.
+      elevation_m: 0,
+      ceiling_m: top.ceiling_m || DEFAULT_CEILING_M,
+      subfloor_m: DEFAULT_SUBFLOOR_M,
+    };
+    // Materialise the implicit ground floor too, otherwise saving a second
+    // storey would leave the first undeclared and the server would reject
+    // every node on it as living on an undefined floor.
+    // A storey below with no subfloor recorded would put the new floor
+    // exactly on the old ceiling, which is never true of a real building.
+    const below = floors[floors.length - 1];
+    if (!below.subfloor_m) below.subfloor_m = DEFAULT_SUBFLOOR_M;
+    this.config.floors = [...floors, next];
+    this._activeFloor = next.level;
+    this._reflowElevations();
+    this._renderFloorControls();
+    this._renderNodeList();
+    this._render();
+  }
+
+  /** Remove the top storey, and anything on it.
+   *
+   * Deleting a storey while nodes or walls still reference it would produce a
+   * config the server refuses to save, with an error naming a floor the user
+   * can no longer see. Better to say what will go, and go.
+   */
+  _removeTopFloor() {
+    const floors = this._floors();
+    if (floors.length <= 1) return;
+    const doomed = floors[floors.length - 1].level;
+    const nodes = this.config.nodes.filter((n) => this._floorOf(n) === doomed).length;
+    const walls = (this.config.walls || []).filter((w) => w.level === doomed).length;
+    if (nodes || walls) {
+      const ok = window.confirm(
+        `Remove floor ${doomed}? This also deletes ${nodes} node(s) and ${walls} wall(s) on it.`
+      );
+      if (!ok) return;
+    }
+    this.config.floors = floors.filter((f) => f.level !== doomed);
+    this.config.nodes = this.config.nodes.filter((n) => this._floorOf(n) !== doomed);
+    this.config.walls = (this.config.walls || []).filter((w) => w.level !== doomed);
+    if (this.config.floors.length <= 1) this.config.floors = [];
+    this._activeFloor = 1;
+    this._renderFloorControls();
+    this._renderNodeList();
+    this._renderStoreyPanels();
+    this._renderWallList();
     this._render();
   }
 
@@ -417,6 +1213,36 @@ export class RoomBuilderTab {
       ctx.stroke();
     }
 
+    // Walls. Drawn before nodes so a node marker is never hidden behind one.
+    // Other storeys show faintly: alignment between floors is exactly what a
+    // shared origin is for, and hiding them would make it guesswork.
+    (this.config.walls || []).forEach((w) => {
+      const a = this._toPixel(w.x1, w.y1);
+      const b = this._toPixel(w.x2, w.y2);
+      const active = w.level === this._activeFloor;
+      ctx.strokeStyle = active ? '#e6edf3' : 'rgba(230,237,243,0.18)';
+      ctx.lineWidth = active ? 4 : 2;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(a.px, a.py);
+      ctx.lineTo(b.px, b.py);
+      ctx.stroke();
+    });
+    ctx.lineCap = 'butt';
+
+    // Wall being dragged out right now.
+    if (this._wallStart && this._wallPreview) {
+      const a = this._toPixel(this._wallStart.x, this._wallStart.y);
+      ctx.strokeStyle = '#ffd166';
+      ctx.lineWidth = 4;
+      ctx.setLineDash([6, 4]);
+      ctx.beginPath();
+      ctx.moveTo(a.px, a.py);
+      ctx.lineTo(this._wallPreview.x, this._wallPreview.y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
     // Nodes.
     this.config.nodes.forEach((node, idx) => {
       const { px, py } = this._toPixel(node.x, node.y);
@@ -424,6 +1250,8 @@ export class RoomBuilderTab {
         console.warn('[RoomBuilder] Skipping node with non-finite position:', node);
         return;
       }
+      const onThisFloor = this._floorOf(node) === this._activeFloor;
+      ctx.globalAlpha = onThisFloor ? 1 : 0.28;
       ctx.beginPath();
       ctx.arc(px, py, NODE_RADIUS, 0, Math.PI * 2);
       ctx.fillStyle = idx === this._dragIndex ? '#ffd166' : '#e05561';
@@ -438,8 +1266,79 @@ export class RoomBuilderTab {
       const label = node.label ? `${node.id}:${node.label}` : `${node.id}`;
       ctx.fillText(label, px, py - NODE_RADIUS - 6);
     });
+    // Leaving globalAlpha faded would silently dim the AP, the live dot and
+    // the compass drawn below.
+    ctx.globalAlpha = 1;
 
+    this._drawAp(ctx);
+    this._drawLiveDot(ctx);
     this._drawCompass(ctx);
+  }
+
+  /** Draw the AP marker (a diamond, distinct from the round sensor nodes) —
+   * intentionally NOT clamped/warned about being outside the room rectangle,
+   * since a real AP very often is (see validate_room_config on the server). */
+  _drawAp(ctx) {
+    if (!Array.isArray(this.config.ap_position)) return;
+    const [x, y] = this.config.ap_position;
+    const { px, py } = this._toPixel(x, y);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return;
+
+    ctx.save();
+    ctx.translate(px, py);
+    ctx.rotate(Math.PI / 4);
+    const s = AP_RADIUS;
+    ctx.fillStyle = this._draggingAp ? '#ffd166' : '#a78bfa';
+    ctx.fillRect(-s, -s, s * 2, s * 2);
+    ctx.strokeStyle = '#0d1117';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(-s, -s, s * 2, s * 2);
+    ctx.restore();
+
+    ctx.fillStyle = '#e6e9ef';
+    ctx.font = '12px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText('AP', px, py - AP_RADIUS - 8);
+  }
+
+  /** Draw the live person-position estimate, when one exists. Pulses gently
+   * so it reads as "live" rather than a static marker like the sensor nodes.
+   * Label states which tier produced it (doppler vs motion) so it's never
+   * mistaken for a calibrated fix. */
+  _drawLiveDot(ctx) {
+    if (!this._liveDot) return;
+    const { px, py } = this._toPixel(this._liveDot.x, this._liveDot.y);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return;
+
+    const pulse = 1 + 0.15 * Math.sin(Date.now() / 300);
+    ctx.beginPath();
+    ctx.arc(px, py, LIVE_DOT_RADIUS * pulse, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(255, 209, 102, 0.9)';
+    ctx.fill();
+    ctx.strokeStyle = '#0d1117';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    ctx.fillStyle = '#ffd166';
+    ctx.font = 'bold 12px monospace';
+    ctx.textAlign = 'center';
+    const LIVE_DOT_LABELS = {
+      bistatic_velocity: 'live (bistatic)',
+      doppler_centroid: 'live (doppler)',
+      motion_centroid: 'live (motion)',
+    };
+    const label = LIVE_DOT_LABELS[this._liveDotSource] || 'live (motion)';
+    ctx.fillText(label, px, py - LIVE_DOT_RADIUS - 8);
+
+    // Keep animating the pulse while a fix is present.
+    if (!this._liveDotAnimHandle) {
+      const animate = () => {
+        if (!this._liveDot) { this._liveDotAnimHandle = null; return; }
+        this._render();
+        this._liveDotAnimHandle = requestAnimationFrame(animate);
+      };
+      this._liveDotAnimHandle = requestAnimationFrame(animate);
+    }
   }
 
   /** (0,0,0) is the room's Northwest corner by convention - X increases

--- a/ui/illuminators.html
+++ b/ui/illuminators.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Illuminator Triage</title>
+<!--
+  Every transmitter the fleet can hear, and whether it is worth keeping as an
+  illumination source.
+
+  No dependencies, so it works with the internet down — same as mark.html,
+  mesh.html, mesh3d.html and world3d.html.
+
+  WHY THIS EXISTS: until 2026-09-01 the server admitted ~10 transmitters, all
+  our own hardware. A per-node subcarrier-grid gate discarded every frame on a
+  sparser grid than the associated AP had negotiated, which was essentially
+  every other transmitter in the building. With that gate moved per-link the
+  fleet admits 30+, including a second access point at -58 dBm across seven
+  receivers and a Powerwall gateway at -73 across four. This page is how those
+  get judged.
+
+  WHAT DECIDES "KEEPER":
+
+    receivers  How many nodes hear it. THE number that matters — one receiver
+               gives a single ellipsoid and no intersection, so it can never
+               localise however loud it is. Two is a constraint; three or more
+               is geometry.
+    rssi       Best across receivers. Below about -85 dBm links flicker between
+               windows rather than holding (MEASURED on this fleet), so they
+               add variance to a solver rather than evidence.
+    fps        Delivery rate. A link needs 8 frames at one grid width before it
+               produces any metric at all, so a loud transmitter at 0.02 fps is
+               permanently useless.
+    drift      How much its per-receiver RSSI signature MOVES. This is the
+               mobility test, measured here rather than guessed from the MAC:
+               phones randomise their addresses precisely to defeat vendor
+               lookup, but nothing hides a signature that changes as the device
+               is carried around. A mobile emitter is worse than none, because
+               the association it teaches is only true while it stands still.
+
+  DRIFT IS OBSERVED IN THIS PAGE, IN THIS SESSION. It needs minutes, not
+  seconds, and it resets on reload — the server does not yet track it. Until a
+  transmitter has enough samples the verdict says so instead of guessing.
+-->
+<style>
+  :root{
+    --bg:#0d1117; --fg:#e6edf3; --dim:#8b949e; --line:#30363d; --card:#161b22;
+    --ok:#2ea043; --warn:#d29922; --bad:#f85149; --accent:#388bfd; --violet:#a371f7;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0; background:var(--bg); color:var(--fg);
+       font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;}
+  header{padding:12px 16px 10px; border-bottom:1px solid var(--line);
+         position:sticky; top:0; background:var(--bg); z-index:2;}
+  h1{font-size:15px; margin:0 0 2px;}
+  .sub{color:var(--dim); font-size:11.5px;}
+  .bar{display:flex; flex-wrap:wrap; gap:14px; margin-top:8px; font-size:11.5px;}
+  .bar b{color:var(--fg); font-weight:600;}
+  .bar span{color:var(--dim);}
+  main{padding:12px 16px 40px;}
+  table{width:100%; border-collapse:collapse; font-size:12px;}
+  th{text-align:left; color:var(--dim); font-weight:600; font-size:10.5px;
+     letter-spacing:.06em; text-transform:uppercase; padding:6px 6px;
+     border-bottom:1px solid var(--line); cursor:pointer; white-space:nowrap;}
+  th:hover{color:var(--fg);}
+  td{padding:5px 6px; border-bottom:1px solid rgba(48,54,61,0.45); white-space:nowrap;}
+  td.n{text-align:right; font-variant-numeric:tabular-nums;}
+  tr:hover td{background:rgba(56,139,253,0.06);}
+  .mac{color:var(--fg);}
+  .v-KEEPER{color:var(--ok); font-weight:600;}
+  .v-GOOD{color:var(--ok);}
+  .v-WATCH{color:var(--warn);}
+  .v-WAIT{color:var(--dim);}
+  .v-DROP{color:var(--bad);}
+  .v-MOBILE{color:var(--bad); font-weight:600;}
+  .pill{display:inline-block; padding:0 5px; border-radius:3px; font-size:10.5px;
+        border:1px solid var(--line); color:var(--dim);}
+  .assigned{color:var(--violet);}
+  .dev{color:var(--fg); font-weight:600;}
+  .unnamed{color:var(--dim); font-weight:400; font-style:italic;}
+  .macsub{color:var(--dim); font-size:10px;}
+  .note{color:var(--dim); font-size:11.5px; margin:10px 0 0; max-width:78ch;}
+</style>
+</head>
+<body>
+<header>
+  <h1>Illuminator Triage</h1>
+  <div class="sub">Every transmitter the fleet hears, and whether it earns a place. Click a column to sort.</div>
+  <div class="bar" id="bar"><span>loading…</span></div>
+</header>
+<main>
+  <table>
+    <thead><tr id="head"></tr></thead>
+    <tbody id="rows"></tbody>
+  </table>
+  <p class="note" id="foot"></p>
+</main>
+<script>
+'use strict';
+
+var POLL_MS = 4000;
+/* Drift needs several samples before it means anything. Below this the verdict
+ * says "watching" rather than inventing a judgement from two readings. */
+var MIN_DRIFT_SAMPLES = 8;
+
+var OUR_OUI = ['e8:f6:0a', '9c:cc:01'];
+
+var sortKey = 'receivers', sortDir = -1;
+var track = {};      /* tx_mac -> {prev:{node:rssi}, drift:ema, samples:n} */
+var assigned = {};   /* tx_mac -> emitter row from room config */
+
+var COLS = [
+  ['verdict',    'verdict',   false],
+  ['tx_mac',     'device',    false],
+  ['kind',       'kind',      false],
+  ['receivers',  'rx',        true],
+  ['bestRssi',   'best dBm',  true],
+  ['fps',        'fps',       true],
+  ['visible',    'vis/links', true],
+  ['drift',      'drift dB',  true],
+  ['grids',      'grid',      false],
+  ['assigned',   'assigned',  false]
+];
+
+function oui(m){ return m.slice(0,8); }
+
+function kindOf(m, row){
+  if (m === apMac) return 'our AP (assoc)';
+  if (OUR_OUI.indexOf(oui(m)) >= 0) return 'our node';
+  /* The locally-administered bit is set both by an AP advertising extra SSIDs
+   * and by a client randomising its address. Beaconing separates them, which
+   * this page cannot see — so it reports the bit and leaves the call to drift. */
+  if (row.locally_administered) return 'virtual/random';
+  return 'device';
+}
+
+var apMac = null;
+
+/** Human name from the room-config roster, if the device has been named.
+ *  The MAC stays visible underneath — it is the identity everything else keys
+ *  on, and a label is a convenience that can be wrong or missing. */
+function labelOf(t){
+  var a = assigned[t.mac];
+  if (a && a.label) return a.label;
+  if (apMac && t.mac === apMac) return 'AP (associated)';
+  return '';
+}
+
+function verdict(t){
+  /* Mobility overrides everything: a moving emitter teaches an association
+   * that is only true while it stands still. */
+  if (t.samples >= MIN_DRIFT_SAMPLES && t.drift > 4.0) return 'MOBILE';
+  if (t.receivers >= 3 && t.bestRssi > -80 && t.fps >= 1.0) {
+    return t.samples >= MIN_DRIFT_SAMPLES ? 'KEEPER' : 'WATCH';
+  }
+  if (t.receivers >= 2 && t.bestRssi > -85) return 'GOOD';
+  if (t.fps < 0.2 || t.bestRssi <= -88) return 'DROP';
+  return 'WAIT';
+}
+
+function reasonFor(t, v){
+  if (v === 'MOBILE') return 'signature drifts ' + t.drift.toFixed(1) + ' dB — carried, not fixed';
+  if (v === 'KEEPER') return 'stable, ' + t.receivers + ' receivers — usable as a fixed focus';
+  if (v === 'WATCH')  return 'looks good; needs ' + (MIN_DRIFT_SAMPLES - t.samples) + ' more samples to confirm it is stationary';
+  if (v === 'GOOD')   return 'can intersect (' + t.receivers + ' receivers) but weak or slow';
+  if (v === 'DROP')   return t.receivers === 1 ? 'one receiver — cannot intersect' : 'too weak or too slow to form a history';
+  return 'not enough evidence yet';
+}
+
+function fetchJSON(p){
+  return fetch(p, {cache:'no-store'}).then(function(r){
+    if (!r.ok) throw new Error(p + ' -> ' + r.status);
+    return r.json();
+  });
+}
+
+function refresh(){
+  Promise.all([
+    fetchJSON('/api/v1/links/inventory'),
+    fetchJSON('/api/v1/config/room')
+  ]).then(function(res){
+    var inv = res[0], room = res[1];
+    /* The associated AP is identified by ap_mac in the room config rather
+     * than by an emitter row, so it needs naming here or the loudest
+     * transmitter in the house reads as "unnamed". */
+    apMac = (room && room.ap_mac) ? room.ap_mac : null;
+    assigned = {};
+    (room.emitters || []).forEach(function(e){ assigned[e.mac] = e; });
+
+    /* Group links by transmitter. */
+    var tx = {};
+    inv.links.forEach(function(r){
+      var t = tx[r.tx_mac];
+      if (!t) {
+        t = tx[r.tx_mac] = {
+          mac: r.tx_mac, rows: [], receivers: 0, bestRssi: -999, fps: 0,
+          visible: 0, grids: {}, la: r.locally_administered, sig: {}
+        };
+      }
+      t.rows.push(r);
+      t.receivers++;
+      t.bestRssi = Math.max(t.bestRssi, r.rssi_dbm);
+      t.fps += r.fps || 0;
+      if (r.visible_in_links) t.visible++;
+      t.grids[r.grid] = true;
+      t.sig[r.rx_node] = r.rssi_dbm;
+    });
+
+    /* Drift: mean absolute change of the per-receiver RSSI signature between
+     * polls, smoothed. A fixed transmitter's signature barely moves; one being
+     * carried through the house changes on several receivers at once. */
+    Object.keys(tx).forEach(function(m){
+      var t = tx[m], k = track[m];
+      if (!k) { k = track[m] = {prev: t.sig, drift: 0, samples: 0}; }
+      else {
+        var deltas = [], shared = 0;
+        Object.keys(t.sig).forEach(function(n){
+          if (k.prev[n] !== undefined) { deltas.push(Math.abs(t.sig[n] - k.prev[n])); shared++; }
+        });
+        if (shared > 0) {
+          var mean = deltas.reduce(function(a,b){return a+b;},0) / shared;
+          k.drift = k.samples === 0 ? mean : (k.drift * 0.7 + mean * 0.3);
+          k.samples++;
+        }
+        k.prev = t.sig;
+      }
+      t.drift = k.drift; t.samples = k.samples;
+    });
+
+    render(inv, Object.keys(tx).map(function(m){ return tx[m]; }));
+  }).catch(function(e){
+    document.getElementById('bar').innerHTML = '<span style="color:var(--bad)">' + e.message + '</span>';
+  });
+}
+
+function render(inv, list){
+  list.forEach(function(t){ t.verdict = verdict(t); t.kind = kindOf(t.mac, {locally_administered: t.la}); });
+
+  var order = {KEEPER:0, WATCH:1, GOOD:2, WAIT:3, DROP:4, MOBILE:5};
+  list.sort(function(a,b){
+    var x, y;
+    if (sortKey === 'verdict') { x = order[a.verdict]; y = order[b.verdict]; }
+    else if (sortKey === 'grids') { x = Object.keys(a.grids)[0]; y = Object.keys(b.grids)[0]; }
+    else if (sortKey === 'assigned') { x = assigned[a.mac] ? 1 : 0; y = assigned[b.mac] ? 1 : 0; }
+    else if (sortKey === 'tx_mac') { x = labelOf(a) || ('zzz' + a.mac); y = labelOf(b) || ('zzz' + b.mac); }
+    else if (sortKey === 'kind') { x = a.kind; y = b.kind; }
+    else { x = a[sortKey]; y = b[sortKey]; }
+    if (x < y) return sortDir; if (x > y) return -sortDir; return 0;
+  });
+
+  var counts = {};
+  list.forEach(function(t){ counts[t.verdict] = (counts[t.verdict] || 0) + 1; });
+  document.getElementById('bar').innerHTML =
+    '<span><b>' + list.length + '</b> transmitters</span>' +
+    '<span><b>' + inv.links_total + '</b> links (' + inv.links_visible + ' renderable)</span>' +
+    '<span>headroom <b>' + inv.headroom + '</b>/' + inv.max_links + '</span>' +
+    ['KEEPER','WATCH','GOOD','WAIT','DROP','MOBILE'].map(function(v){
+      return counts[v] ? '<span class="v-' + v + '">' + v + ' <b>' + counts[v] + '</b></span>' : '';
+    }).join('');
+
+  var head = document.getElementById('head');
+  head.innerHTML = COLS.map(function(c){
+    var arrow = sortKey === c[0] ? (sortDir < 0 ? ' ▾' : ' ▴') : '';
+    return '<th data-k="' + c[0] + '">' + c[1] + arrow + '</th>';
+  }).join('');
+  Array.prototype.forEach.call(head.querySelectorAll('th'), function(th){
+    th.addEventListener('click', function(){
+      var k = th.dataset.k;
+      if (sortKey === k) sortDir = -sortDir; else { sortKey = k; sortDir = -1; }
+      refresh();
+    });
+  });
+
+  document.getElementById('rows').innerHTML = list.map(function(t){
+    var a = assigned[t.mac];
+    var asg = a
+      ? '<span class="assigned">' + a.status + (a.position ? '' : ' (no pos)') + '</span>'
+      : '<span class="pill">unassigned</span>';
+    var drift = t.samples >= 2
+      ? t.drift.toFixed(1) + (t.samples < MIN_DRIFT_SAMPLES ? ' <span class="pill">n=' + t.samples + '</span>' : '')
+      : '<span class="pill">watching</span>';
+    return '<tr title="' + reasonFor(t, t.verdict) + '">' +
+      '<td class="v-' + t.verdict + '">' + t.verdict + '</td>' +
+      '<td><span class="dev">' + (labelOf(t) || '<span class="unnamed">unnamed</span>') + '</span>'
+        + '<br><span class="macsub">' + t.mac + '</span></td>' +
+      '<td>' + t.kind + '</td>' +
+      '<td class="n">' + t.receivers + '</td>' +
+      '<td class="n">' + t.bestRssi.toFixed(0) + '</td>' +
+      '<td class="n">' + t.fps.toFixed(2) + '</td>' +
+      '<td class="n">' + t.visible + '/' + t.rows.length + '</td>' +
+      '<td class="n">' + drift + '</td>' +
+      '<td class="n">' + Object.keys(t.grids).join(',') + '</td>' +
+      '<td>' + asg + '</td>' +
+    '</tr>';
+  }).join('');
+
+  document.getElementById('foot').textContent =
+    'Drift is measured in this page over this session and resets on reload — the server does not track it yet. '
+    + 'It needs ' + MIN_DRIFT_SAMPLES + ' samples (~' + Math.round(MIN_DRIFT_SAMPLES * POLL_MS / 1000)
+    + ' s) before a stationary verdict is offered, so leave this open while you decide. '
+    + 'Hover a row for why it got its verdict.';
+}
+
+refresh();
+setInterval(refresh, POLL_MS);
+</script>
+</body>
+</html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -36,6 +36,7 @@
             <button class="nav-tab" data-tab="performance" role="tab" aria-selected="false" aria-controls="performance">Performance</button>
             <button class="nav-tab" data-tab="applications" role="tab" aria-selected="false" aria-controls="applications">Applications</button>
             <button class="nav-tab" data-tab="sensing" role="tab" aria-selected="false" aria-controls="sensing">Sensing</button>
+            <button class="nav-tab" data-tab="roombuilder" role="tab" aria-selected="false" aria-controls="roombuilder">Room Builder</button>
             <button class="nav-tab" data-tab="training" role="tab" aria-selected="false" aria-controls="training">Training</button>
             <a href="pose-fusion.html" class="nav-tab" style="text-decoration:none">Pose Fusion</a>
             <a href="observatory.html" class="nav-tab" style="text-decoration:none">Observatory</a>
@@ -498,6 +499,9 @@
 
         <!-- Sensing Tab -->
         <section id="sensing" class="tab-content" role="tabpanel" aria-labelledby="sensing" aria-hidden="true"></section>
+
+        <!-- Room Builder Tab -->
+        <section id="roombuilder" class="tab-content" role="tabpanel" aria-labelledby="roombuilder" aria-hidden="true"></section>
 
         <!-- Training Tab -->
         <section id="training" class="tab-content" role="tabpanel" aria-labelledby="training" aria-hidden="true">

--- a/ui/mesh3d.html
+++ b/ui/mesh3d.html
@@ -1,0 +1,546 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RF Distance Map</title>
+<!--
+  Orbitable 3D map of the mesh, laid out by RF distance rather than geometry.
+  No dependencies, so it works with the internet down — same as mark.html and
+  mesh.html.
+
+  Pipeline: RSSI -> distance (log-distance path loss) -> 3D positions
+  (gradient-descent MDS) -> projection you can orbit.
+
+  WHAT THIS IS NOT: architectural truth. Through walls and floors the signal
+  diffracts and bounces, so the path really is longer than the straight line
+  and every such link reads long. The reconstruction puffs up wherever
+  material intervenes.
+
+  WHAT IT IS: a map where distance means RF isolation. Two nodes in one room
+  sit close; two separated by a floor sit far apart *because the floor
+  attenuates*. Floors separate on their own without being told they exist,
+  and the gap between them measures what that floor costs. For sensing that
+  is the more useful quantity — RF coupling, not metres, is what decides
+  whether a link can see anything. It is also why the geometric link-line
+  model failed on this fleet: physical distance is not what matters.
+
+  The payoff is the comparison. Enter what you know to be physically true and
+  a link reading 80 ft across a 45 ft span is telling you something is in the
+  way — in feet, which is actionable, rather than dBm, which is not.
+
+  MDS by gradient descent rather than eigendecomposition: it needs no matrix
+  library, tolerates missing pairs (a link that cannot be heard is simply not
+  a constraint), and for N <= 16 converges in milliseconds.
+
+  At three nodes this is degenerate — three points always form a triangle, so
+  it fits perfectly and proves nothing. It starts testing itself at nine,
+  where 36 distances constrain 21 free parameters.
+-->
+<style>
+  :root{
+    --bg:#0d1117; --fg:#e6edf3; --dim:#8b949e; --line:#30363d; --card:#161b22;
+    --ok:#2ea043; --warn:#d29922; --bad:#f85149; --accent:#388bfd;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0; background:var(--bg); color:var(--fg);
+       font:13.5px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+       display:flex; flex-direction:column; height:100vh; overflow:hidden;}
+  header{padding:12px 16px 10px; border-bottom:1px solid var(--line); flex:0 0 auto;}
+  h1{font-size:15px; margin:0 0 2px;}
+  .sub{color:var(--dim); font-size:11.5px;}
+  .wrap{flex:1 1 auto; display:flex; min-height:0;}
+  #stage{flex:1 1 auto; position:relative; min-width:0;}
+  canvas{display:block; width:100%; height:100%; cursor:grab;}
+  canvas:active{cursor:grabbing;}
+  aside{flex:0 0 288px; border-left:1px solid var(--line); padding:14px;
+        overflow-y:auto; background:var(--card);}
+  @media (max-width:760px){ .wrap{flex-direction:column;} aside{flex:0 0 auto; border-left:none; border-top:1px solid var(--line);} }
+  h2{font-size:11px; letter-spacing:.1em; text-transform:uppercase;
+     color:var(--dim); margin:0 0 8px; font-weight:600;}
+  .grp{margin-bottom:18px;}
+  label{display:block; font-size:12px; color:var(--dim); margin:9px 0 3px;}
+  input[type=range]{width:100%;}
+  input[type=number]{width:100%; background:#0d1117; color:var(--fg);
+    border:1px solid var(--line); border-radius:5px; padding:5px 7px; font:inherit;}
+  .val{color:var(--fg); font-weight:600;}
+  table{width:100%; border-collapse:collapse; font-size:11.5px;}
+  td{padding:3px 4px; border-bottom:1px solid var(--line);}
+  td.n{text-align:right; font-variant-numeric:tabular-nums; white-space:nowrap;}
+  .hint{color:var(--dim); font-size:11px; margin-top:7px; line-height:1.45;}
+  button{font:inherit; font-size:12px; padding:6px 11px; border-radius:6px;
+    cursor:pointer; border:1px solid var(--line); background:#21262d; color:var(--fg);}
+  .err{color:var(--bad);}
+</style>
+</head>
+<body>
+
+<header>
+  <h1>RF Distance Map</h1>
+  <div class="sub">Laid out by signal isolation, not geometry. Drag to orbit, scroll to zoom.</div>
+  <div style="margin:8px 0 4px;">
+    <button id="vTop">Top &mdash; N up</button>
+    <button id="vNorth">Look north</button>
+    <button id="vWest">Look west</button>
+    <button id="vIso">Isometric</button>
+    <span class="sub" style="margin-left:10px;">presets match the floor plan: east is right, south is down</span>
+  </div>
+</header>
+
+<div class="wrap">
+  <div id="stage"><canvas id="cv"></canvas></div>
+  <aside>
+    <div class="grp">
+      <h2>Path loss</h2>
+      <label>reference power at 1 ft <span class="val" id="p0v"></span></label>
+      <input type="range" id="p0" min="-60" max="-20" step="1" value="-40">
+      <label>exponent <span class="val" id="nv"></span> <span class="sub">(2 = open air, 3&ndash;4 = walls)</span></label>
+      <input type="range" id="n" min="15" max="45" step="1" value="30">
+      <label>AP transmits harder by <span class="val" id="apv"></span></label>
+      <input type="range" id="apg" min="0" max="16" step="1" value="8">
+      <div class="hint">Calibrate: pick two nodes whose real separation you
+      know, then move the exponent until the map agrees. Everything else
+      follows.</div>
+    </div>
+
+    <div class="grp">
+      <h2>Known distance <span class="sub">(optional)</span></h2>
+      <label>between node <input type="number" id="ka" value="0" style="width:52px;display:inline-block"> and <input type="number" id="kb" value="1" style="width:52px;display:inline-block"></label>
+      <label>actually <input type="number" id="kd" placeholder="feet" style="width:80px;display:inline-block"> ft apart</label>
+      <button id="solve">Fit exponent to this</button>
+      <div class="hint" id="fitnote"></div>
+    </div>
+
+    <div class="grp">
+      <h2>Auto-calibrate</h2>
+      <button id="auto">Fit model to surveyed nodes</button>
+      <div class="hint" id="autonote">Least-squares over every link whose true
+      distance is known, solving reference power, exponent and AP gain at once.
+      Until it is run, part of the &ldquo;excess&rdquo; column is model error
+      rather than obstruction.</div>
+    </div>
+
+    <div class="grp">
+      <h2>Links &mdash; true vs RF</h2>
+      <table id="tbl"></table>
+    </div>
+    <div class="sub" id="stamp"></div>
+  </aside>
+</div>
+
+<script>
+// ---- state ---------------------------------------------------------------
+var links = [], ids = [], pos = {}, az = 0.6, el = 0.4, zoom = 1, drag = null;
+var truth = null;      // /api/v1/config/room, when a node's position is known
+var M2F = 3.28084;
+
+// Known positions win over inference.
+//
+// MDS exists to place nodes when we do not know where they are. For nodes we
+// DO know, inferring a position from RSSI and then comparing it to the answer
+// we already had is worse than useless -- it hides the measurement behind a
+// reconstruction. So a node with a surveyed position is drawn there, and the
+// RF estimate is spent on the thing we actually want: how much longer the
+// signal path is than the straight line.
+//
+// Unknown nodes still get MDS, anchored against the known ones -- which is
+// what a newly plugged-in board looks like before it has been surveyed.
+// Room space is x=east, y=south, z=up. The projector below treats y as the
+// VERTICAL screen axis and rotates azimuth in the x-z plane, so surveyed
+// positions have to be remapped or the building is drawn lying on its side --
+// north-south pointing at the ceiling, and no amount of orbiting can align it
+// to the real house. Swapping here rather than in project() keeps MDS output
+// (which has no meaningful orientation anyway) in the same convention.
+function toView(east, south, up){ return {x: east, y: up, z: south}; }
+
+function truthPos(id){
+  if (!truth) return null;
+  if (id === 'AP') {
+    var a = truth.ap_position;
+    return a ? toView(a[0]*M2F, a[1]*M2F, a[2]*M2F) : null;
+  }
+  var n = (truth.nodes || []).filter(function(x){ return String(x.id) === String(id); })[0];
+  return n ? toView(n.x*M2F, n.y*M2F, n.z*M2F) : null;
+}
+function trueFeet(a, b){
+  var A = truthPos(a), B = truthPos(b);
+  if (!A || !B) return null;
+  return Math.sqrt(Math.pow(A.x-B.x,2) + Math.pow(A.y-B.y,2) + Math.pow(A.z-B.z,2));
+}
+var P0 = -40, PLE = 3.0;   // dBm at 1 ft for a NODE transmitter
+var AP_GAIN = 8;           // dB the AP transmits harder than a node
+
+// Separate reference power per transmitter class.
+//
+// d = d0 * 10^((P0 - RSSI) / (10 * n)) assumes a fixed transmit power, so one
+// P0 across mixed transmitters is a real error: an AP with more output and a
+// better antenna reads stronger at the same distance, and a single P0 would
+// place it too close. The AP's stronger link is still the *better* measurement
+// — higher SNR means a steadier RSSI — but only once its extra output is
+// accounted for rather than mistaken for proximity.
+function rssiToFeet(dbm, isAp){
+  var ref = isAp ? (P0 + AP_GAIN) : P0;
+  return Math.pow(10, (ref - dbm) / (10 * PLE));
+}
+
+// ---- MDS by gradient descent --------------------------------------------
+// Positions are pushed toward satisfying every observed distance. Missing
+// pairs contribute nothing rather than being guessed at.
+function layout(pairs, idlist){
+  var p = {};
+  idlist.forEach(function(id, i){
+    // Deterministic spread, so the map does not jump on every refresh.
+    var a = i * 2.399, r = 20 + i * 3;
+    p[id] = {x: Math.cos(a) * r, y: Math.sin(a) * r, z: ((i % 3) - 1) * 12};
+  });
+  for (var it = 0; it < 600; it++){
+    var lr = 0.10 * (1 - it / 600);
+    pairs.forEach(function(pr){
+      var A = p[pr.a], B = p[pr.b];
+      var dx = B.x - A.x, dy = B.y - A.y, dz = B.z - A.z;
+      var d = Math.sqrt(dx*dx + dy*dy + dz*dz) || 1e-6;
+      var err = (d - pr.d) / d * lr * 0.5;
+      A.x += dx * err; A.y += dy * err; A.z += dz * err;
+      B.x -= dx * err; B.y -= dy * err; B.z -= dz * err;
+    });
+  }
+  // Centre it so orbiting feels natural.
+  var c = {x:0,y:0,z:0}, k = idlist.length || 1;
+  idlist.forEach(function(id){ c.x+=p[id].x; c.y+=p[id].y; c.z+=p[id].z; });
+  idlist.forEach(function(id){ p[id].x-=c.x/k; p[id].y-=c.y/k; p[id].z-=c.z/k; });
+  return p;
+}
+
+function residual(pairs, p){
+  var s = 0, n = 0;
+  pairs.forEach(function(pr){
+    var A=p[pr.a], B=p[pr.b];
+    var d = Math.sqrt(Math.pow(B.x-A.x,2)+Math.pow(B.y-A.y,2)+Math.pow(B.z-A.z,2));
+    s += Math.abs(d - pr.d) / pr.d; n++;
+  });
+  return n ? s / n : 0;
+}
+
+// ---- render --------------------------------------------------------------
+var cv = document.getElementById('cv'), ctx = cv.getContext('2d');
+
+function project(pt, w, h){
+  var ca=Math.cos(az), sa=Math.sin(az), ce=Math.cos(el), se=Math.sin(el);
+  var x = pt.x*ca - pt.z*sa;
+  var z = pt.x*sa + pt.z*ca;
+  var y = pt.y*ce - z*se;
+  var depth = pt.y*se + z*ce;
+  var s = zoom * Math.min(w,h) / 140;
+  return {x: w/2 + x*s, y: h/2 - y*s, d: depth};
+}
+
+function draw(){
+  var w = cv.clientWidth, h = cv.clientHeight;
+  if (cv.width !== w || cv.height !== h){ cv.width = w; cv.height = h; }
+  ctx.clearRect(0,0,w,h);
+  if (!ids.length){
+    ctx.fillStyle = '#8b949e'; ctx.font = '13px ui-monospace';
+    ctx.fillText('waiting for links…', 18, 26); return;
+  }
+
+  var pairs = buildPairs();
+  // Edges first, far ones dimmer.
+  pairs.forEach(function(pr){
+    var A = project(pos[pr.a], w, h), B = project(pos[pr.b], w, h);
+    var bad;
+    if (pr.ratio !== null) {
+      // Excess over the straight line is the diagnostic: 1.0x is clear air,
+      // anything well above it is something in the way.
+      bad = pr.ratio > 1.8 ? 2 : (pr.ratio > 1.25 ? 1 : 0);
+    } else {
+      bad = pr.d > 40 ? 2 : (pr.d > 20 ? 1 : 0);
+    }
+    ctx.strokeStyle = bad === 2 ? 'rgba(248,81,73,.6)'
+                    : bad === 1 ? 'rgba(210,153,34,.6)' : 'rgba(46,160,67,.65)';
+    ctx.lineWidth = bad === 2 ? 2.4 : 1.6;
+    ctx.beginPath(); ctx.moveTo(A.x,A.y); ctx.lineTo(B.x,B.y); ctx.stroke();
+    var mx=(A.x+B.x)/2, my=(A.y+B.y)/2;
+    ctx.fillStyle = bad ? '#e6edf3' : '#8b949e'; ctx.font = '10px ui-monospace';
+    ctx.fillText(pr.truth !== null
+      ? pr.truth.toFixed(0) + ' ft → ' + pr.d.toFixed(0)
+      : pr.d.toFixed(0) + ' ft', mx + 3, my - 3);
+  });
+
+  ids.map(function(id){ return {id:id, p:project(pos[id], w, h)}; })
+     .sort(function(a,b){ return a.p.d - b.p.d; })
+     .forEach(function(o){
+       var r = 9 + o.p.d * 0.02;
+       ctx.beginPath(); ctx.arc(o.p.x, o.p.y, Math.max(5,r), 0, Math.PI*2);
+       ctx.fillStyle = o.id === 'AP' ? '#388bfd' : '#e6edf3';
+       ctx.fill();
+       ctx.fillStyle = '#0d1117'; ctx.font = 'bold 10px ui-monospace';
+       ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+       ctx.fillText(o.id === 'AP' ? 'AP' : o.id, o.p.x, o.p.y);
+       ctx.textAlign = 'start'; ctx.textBaseline = 'alphabetic';
+     });
+}
+
+function buildPairs(){
+  var best = {};
+  links.forEach(function(l){
+    var tx = (l.tx_node_inferred === null || l.tx_node_inferred === undefined)
+             ? 'AP' : String(l.tx_node_inferred);
+    var rx = String(l.rx_node);
+    if (tx === rx) return;
+    var k = [rx,tx].sort().join('|');
+    // Average the two directions where both exist — propagation is reciprocal,
+    // so disagreement is noise and the mean is the better estimate.
+    if (!best[k]) best[k] = {a:k.split('|')[0], b:k.split('|')[1], v:[]};
+    best[k].v.push(l.rssi_dbm);
+  });
+  return Object.keys(best).map(function(k){
+    var e = best[k];
+    var mean = e.v.reduce(function(s,x){return s+x;},0) / e.v.length;
+    var isAp = (e.a === 'AP' || e.b === 'AP');
+    var rf = rssiToFeet(mean, isAp), tf = trueFeet(e.a, e.b);
+    return {a:e.a, b:e.b, d:rf, rssi:mean, ap:isAp,
+            truth:tf, excess:(tf ? rf - tf : null), ratio:(tf ? rf / tf : null)};
+  });
+}
+
+function recompute(){
+  var pairs = buildPairs();
+  var set = {};
+  pairs.forEach(function(p){ set[p.a]=1; set[p.b]=1; });
+  ids = Object.keys(set).sort();
+  // Solve only for nodes without a surveyed position; pin the rest.
+  pos = layout(pairs, ids);
+  var anchored = 0;
+  ids.forEach(function(id){
+    var t = truthPos(id);
+    if (t) { pos[id] = {x:t.x, y:t.y, z:t.z}; anchored++; }
+  });
+  if (anchored) {
+    // Re-run with anchors held fixed so unsurveyed nodes settle around them.
+    for (var it = 0; it < 400; it++){
+      var lr = 0.08 * (1 - it/400);
+      pairs.forEach(function(pr){
+        var A = pos[pr.a], B = pos[pr.b];
+        var fa = !truthPos(pr.a), fb = !truthPos(pr.b);
+        if (!fa && !fb) return;
+        var dx=B.x-A.x, dy=B.y-A.y, dz=B.z-A.z;
+        var d = Math.sqrt(dx*dx+dy*dy+dz*dz) || 1e-6;
+        var err = (d - pr.d)/d * lr * 0.5;
+        if (fa){ A.x += dx*err; A.y += dy*err; A.z += dz*err; }
+        if (fb){ B.x -= dx*err; B.y -= dy*err; B.z -= dz*err; }
+      });
+    }
+  }
+
+  // Re-centre on the whole layout.
+  //
+  // layout() centres the MDS cloud, but anchoring then overwrites nodes with
+  // RAW room coordinates, which run 0..44 ft from the north-west corner. Since
+  // project() rotates about the origin, the building ended up orbiting a point
+  // at its own corner -- outside the house -- which reads as "it picks an
+  // anchor and pivots around that". Once every node is surveyed, every node is
+  // overwritten, so the centring done inside layout() is entirely discarded.
+  var cc = {x:0, y:0, z:0}, ck = ids.length || 1;
+  ids.forEach(function(id){ cc.x += pos[id].x; cc.y += pos[id].y; cc.z += pos[id].z; });
+  ids.forEach(function(id){
+    pos[id].x -= cc.x/ck; pos[id].y -= cc.y/ck; pos[id].z -= cc.z/ck;
+  });
+
+  var rows = '<tr><td>pair</td><td class="n">true</td><td class="n">rf</td><td class="n">excess</td></tr>';
+  pairs.sort(function(a,b){
+    return (b.ratio || 0) - (a.ratio || 0);
+  }).forEach(function(p){
+    var col = p.ratio === null ? '#8b949e'
+            : p.ratio > 1.8 ? '#f85149' : p.ratio > 1.25 ? '#d29922' : '#2ea043';
+    rows += '<tr><td>' + p.a + ' &harr; ' + p.b + '</td>' +
+            '<td class="n">' + (p.truth === null ? '&mdash;' : p.truth.toFixed(0)) + '</td>' +
+            '<td class="n">' + p.d.toFixed(0) + '</td>' +
+            '<td class="n" style="color:' + col + '">' +
+            (p.excess === null ? '&mdash;'
+              : (p.excess > 0 ? '+' : '') + p.excess.toFixed(0) + ' ft') + '</td></tr>';
+  });
+  document.getElementById('tbl').innerHTML = rows;
+  document.getElementById('stamp').textContent =
+    ids.length + ' nodes · ' + pairs.length + ' links · fit residual ' +
+    (residual(pairs, pos)*100).toFixed(1) + '%' +
+    (truth ? ' · ' + ids.filter(function(i){return !!truthPos(i);}).length + ' surveyed' : '') +
+    (ids.length <= 3 ? ' — degenerate below 4 nodes' : '');
+  draw();
+}
+
+// ---- controls ------------------------------------------------------------
+function syncLabels(){
+  document.getElementById('p0v').textContent = P0 + ' dBm';
+  document.getElementById('nv').textContent = PLE.toFixed(1);
+  document.getElementById('apv').textContent = AP_GAIN + ' dB';
+}
+document.getElementById('p0').oninput = function(){
+  P0 = +this.value; syncLabels(); recompute();
+};
+document.getElementById('n').oninput = function(){
+  PLE = +this.value / 10; syncLabels(); recompute();
+};
+document.getElementById('apg').oninput = function(){
+  AP_GAIN = +this.value; syncLabels(); recompute();
+};
+document.getElementById('solve').onclick = function(){
+  var a = document.getElementById('ka').value.trim();
+  var b = document.getElementById('kb').value.trim();
+  var want = parseFloat(document.getElementById('kd').value);
+  var note = document.getElementById('fitnote');
+  if (!(want > 0)) { note.innerHTML = '<span class="err">enter a distance in feet</span>'; return; }
+  var pr = buildPairs().filter(function(p){
+    return (p.a===a&&p.b===b) || (p.a===b&&p.b===a); })[0];
+  if (!pr) { note.innerHTML = '<span class="err">no link between those two</span>'; return; }
+  // Solve n directly: want = 10^((P0 - rssi)/(10n))  ->  n = (P0-rssi)/(10*log10(want))
+  var lg = Math.log(want) / Math.LN10;
+  if (Math.abs(lg) < 1e-6) { note.innerHTML = '<span class="err">pick a pair not 1 ft apart</span>'; return; }
+  var ref = pr.ap ? (P0 + AP_GAIN) : P0;
+  var n = (ref - pr.rssi) / (10 * lg);
+  if (!(n > 1.5 && n < 4.5)) {
+    note.innerHTML = '<span class="err">that implies exponent ' + n.toFixed(2) +
+      ', outside the physical 1.5&ndash;4.5 range. Check the node numbers or the distance.</span>';
+    return;
+  }
+  PLE = n; document.getElementById('n').value = Math.round(n*10);
+  syncLabels(); recompute();
+  note.textContent = 'exponent set to ' + n.toFixed(2) +
+    ' — every other distance is now scaled against that pair.';
+};
+
+// Path loss is linear in log-distance:  RSSI = P0 + G*isAP - (10n)*log10(d)
+// so the three parameters fall out of an ordinary least-squares fit over the
+// surveyed links. Worth doing before reading the excess column: an uncalibrated
+// model contributes its own error there, which is indistinguishable by eye from
+// something physically in the way.
+document.getElementById('auto').onclick = function(){
+  var note = document.getElementById('autonote');
+  var all = buildPairs().filter(function(p){ return p.truth !== null && p.truth > 0.5; });
+  if (all.length < 4) {
+    note.innerHTML = '<span class="err">need at least 4 surveyed links, have ' +
+                     all.length + '</span>';
+    return;
+  }
+
+  function fit(set){
+    var A=[[0,0,0],[0,0,0],[0,0,0]], y=[0,0,0];
+    set.forEach(function(p){
+      var r=[1, p.ap?1:0, -Math.log(p.truth)/Math.LN10];
+      for (var i=0;i<3;i++){
+        for (var j=0;j<3;j++) A[i][j]+=r[i]*r[j];
+        y[i]+=r[i]*p.rssi;
+      }
+    });
+    var M=[[A[0][0],A[0][1],A[0][2],y[0]],
+           [A[1][0],A[1][1],A[1][2],y[1]],
+           [A[2][0],A[2][1],A[2][2],y[2]]];
+    for (var c=0;c<3;c++){
+      var piv=c;
+      for (var r2=c+1;r2<3;r2++) if (Math.abs(M[r2][c])>Math.abs(M[piv][c])) piv=r2;
+      if (Math.abs(M[piv][c])<1e-12) return null;
+      var t=M[c]; M[c]=M[piv]; M[piv]=t;
+      for (var r3=0;r3<3;r3++){
+        if (r3===c) continue;
+        var f=M[r3][c]/M[c][c];
+        for (var k=c;k<4;k++) M[r3][k]-=f*M[c][k];
+      }
+    }
+    return {p0:M[0][3]/M[0][0], g:M[1][3]/M[1][1], n:(M[2][3]/M[2][2])/10};
+  }
+
+  // Robust fit: an obstructed link is an outlier in dB, and a single blocked
+  // link can invert the slope entirely — the cage-shadowed pair here is both
+  // the closest and the weakest, which a plain least-squares reads as "closer
+  // is weaker". So fit, drop the worst offender, refit, and keep going while
+  // the model is unphysical or the residual is dominated by one point.
+  //
+  // The excluded links are not a nuisance: they are the obstructed ones, and
+  // naming them is the actual output.
+  var set = all.slice(), dropped = [], f = null;
+  while (set.length >= 4) {
+    f = fit(set);
+    if (f) {
+      var resid = set.map(function(p){
+        var pred = f.p0 + (p.ap?f.g:0) - 10*f.n*Math.log(p.truth)/Math.LN10;
+        return {p:p, e:Math.abs(pred - p.rssi)};
+      });
+      var worst = resid.reduce(function(a,b){ return a.e>b.e ? a : b; });
+      var ok = (f.n>1.2 && f.n<5 && f.g>-6 && f.g<25);
+      if (ok && worst.e < 8) break;              // physical, and no wild outlier
+      if (set.length === 4) break;
+      dropped.push({pair:worst.p, dB:worst.e});
+      set = set.filter(function(p){ return p !== worst.p; });
+      continue;
+    }
+    break;
+  }
+
+  if (!f || !(f.n>1.2 && f.n<5) || !(f.g>-6 && f.g<25)) {
+    note.innerHTML = '<span class="err">no physical fit even after excluding ' +
+      dropped.length + ' link(s). Check the surveyed positions.</span>';
+    return;
+  }
+
+  P0 = Math.round(f.p0); PLE = f.n; AP_GAIN = Math.round(f.g);
+  document.getElementById('p0').value = P0;
+  document.getElementById('n').value = Math.round(f.n*10);
+  document.getElementById('apg').value = AP_GAIN;
+  syncLabels(); recompute();
+
+  var msg = 'fitted on ' + set.length + ' clear link(s): exponent ' +
+            f.n.toFixed(2) + ', AP gain ' + AP_GAIN + ' dB.';
+  if (dropped.length) {
+    msg += '<br><b>Excluded as obstructed:</b> ' + dropped.map(function(d){
+      return d.pair.a + '&harr;' + d.pair.b + ' (' + d.dB.toFixed(0) + ' dB off)';
+    }).join(', ') + '. Those are the blocked paths &mdash; the model is now ' +
+    'calibrated on the clear ones, so the excess column reads the room.';
+  }
+  note.innerHTML = msg;
+};
+
+// Fixed viewpoints. Orbiting from an arbitrary angle to a recognisable one is
+// fiddly, and the whole point of the surveyed layout is that it CAN be matched
+// to the real building -- so give it known orientations to snap to.
+function setView(a, e2){ az = a; el = e2; zoom = 1; draw(); }
+document.getElementById('vTop').onclick   = function(){ setView(0, 1.4); };
+document.getElementById('vNorth').onclick = function(){ setView(0, 0.12); };
+document.getElementById('vWest').onclick  = function(){ setView(Math.PI/2, 0.12); };
+document.getElementById('vIso').onclick   = function(){ setView(0.6, 0.4); };
+
+cv.addEventListener('mousedown', function(e){ drag = {x:e.clientX, y:e.clientY}; });
+window.addEventListener('mouseup', function(){ drag = null; });
+window.addEventListener('mousemove', function(e){
+  if (!drag) return;
+  az += (e.clientX - drag.x) * 0.01;
+  el += (e.clientY - drag.y) * 0.01;
+  el = Math.max(-1.4, Math.min(1.4, el));
+  drag = {x:e.clientX, y:e.clientY};
+  draw();
+});
+cv.addEventListener('wheel', function(e){
+  e.preventDefault();
+  zoom *= e.deltaY > 0 ? 0.92 : 1.08;
+  zoom = Math.max(0.2, Math.min(6, zoom));
+  draw();
+}, {passive:false});
+window.addEventListener('resize', draw);
+
+function load(){
+  fetch('/api/v1/config/room', {cache:'no-store'})
+    .then(function(r){ return r.json(); })
+    .then(function(c){ if (c && c.nodes) truth = c; })
+    .catch(function(){ /* unsurveyed is a valid state — fall back to pure MDS */ })
+    .then(loadLinks);
+}
+function loadLinks(){
+  fetch('/api/v1/links', {cache:'no-store'})
+    .then(function(r){ return r.json(); })
+    .then(function(d){ links = d.links || []; recompute(); })
+    .catch(function(){
+      document.getElementById('stamp').innerHTML = '<span class="err">server unreachable</span>';
+    });
+}
+syncLabels(); load(); setInterval(load, 5000);
+</script>
+</body>
+</html>

--- a/v2/crates/wifi-densepose-sensing-server/src/links.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/links.rs
@@ -1,0 +1,1357 @@
+//! Per-link CSI state, keyed by (receiver, transmitter).
+//!
+//! The rest of the server models one link per node: `NodeState` holds a single
+//! `frame_history` per `node_id`. That was accurate while the only labelled
+//! traffic was AP -> node. It is not accurate for what the radios actually
+//! hear: a node in promiscuous MGMT+DATA mode receives CSI from the AP, from
+//! every peer node's ESP-NOW beacon, and from unrelated household traffic —
+//! measured 2026-08-28 at roughly 75% non-AP on a normal home channel.
+//!
+//! Interleaving those into one history mixes links with completely different
+//! geometry. Until wire v2 carried the transmitter MAC there was no way to
+//! separate them, so the only remedy was `filter_mac`, which fixes the mixing
+//! by throwing ~75% of the measurements away.
+//!
+//! This module keeps them instead. Each (receiver, transmitter) pair is its own
+//! link with its own history and its own motion metric.
+//!
+//! # Why this matters for position
+//!
+//! Three AP -> node links leave a single distant transmitter within a ~36 degree
+//! fan and converge on the node cluster, which is very little parallax to
+//! localize with. The node <-> node links between the same three boards cross
+//! the room from three sides, ~109 degrees apart. Link count also grows as
+//! `N*(N-1)/2`, so adding boards adds links quadratically: 3 nodes give 3
+//! links, 6 give 15, 13 give 78.
+//!
+//! Everything here is **amplitude-derived**. That is deliberate: CSI phase on
+//! this hardware was measured to be uniform-random per packet (see
+//! `phase_diag`), so nothing that depends on phase coherence can be built on
+//! it. Link-based localization needs only per-link signal perturbation.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::time::{Duration, Instant};
+
+/// One RF link: frames received by `rx_node` that were sent by `tx_mac`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct LinkId {
+    pub rx_node: u8,
+    pub tx_mac: [u8; 6],
+}
+
+impl LinkId {
+    /// Compact label for logs: receiver plus the last three octets of the
+    /// transmitter, which is enough to tell the AP from peers and neighbours.
+    pub fn label(&self) -> String {
+        format!(
+            "{}<-{:02x}:{:02x}:{:02x}",
+            self.rx_node, self.tx_mac[3], self.tx_mac[4], self.tx_mac[5]
+        )
+    }
+}
+
+/// How many amplitude frames to retain per link.
+///
+/// At the ~35-50 fps a single transmitter sustains this is 1.3-1.8 s, enough
+/// for a motion statistic without holding a large multiple of the node count in
+/// memory once link counts grow quadratically.
+const LINK_HISTORY: usize = 32;
+
+/// Maximum links tracked at once. A busy channel presents many transmitters and
+/// most are irrelevant; this is a sensing surface, not a registry. Links are
+/// admitted first-come and expired by staleness, so a full table still turns
+/// over rather than wedging permanently.
+///
+/// Raised 256 -> 1024 on 2026-09-01. Until then the per-node grid gate in
+/// `main.rs` discarded every transmitter that did not match the AP's format, so
+/// the table only ever held ~30 links. With that gate moved per-link, a node
+/// admits everything it hears: MEASURED 24 transmitters at one node, so nine
+/// nodes is ~216 links before churn — inside 256, but with no headroom, and
+/// admission fails SILENTLY when full. Memory is the trade: a link holds up to
+/// `LINK_HISTORY` amplitude vectors, so 1024 links of 64-bin frames is ~17 MB
+/// and the realistic mixed case is well under 30 MB.
+pub const MAX_LINKS: usize = 1024;
+
+/// Eviction floor: never drop a link faster than this, however chatty it is.
+const LINK_STALE_MIN: Duration = Duration::from_secs(30);
+
+/// Eviction ceiling: never keep a silent link longer than this, however slowly
+/// it normally speaks. Bounds the table against transmitters that leave for
+/// good — a visiting phone, a neighbour who moves house.
+const LINK_STALE_MAX: Duration = Duration::from_secs(900);
+
+/// Silence, as a multiple of the link's OWN typical interval, before it is
+/// considered gone.
+///
+/// A flat wall-clock threshold cannot serve this fleet. MEASURED 2026-09-01
+/// over the same 100 s, two Nest Protects of the same make: `cb:35:e2` held
+/// ~22 fps with `age_ms` never above 364, while `cb:17:07` sat at 0 fps with
+/// `age_ms` climbing 16 s -> 28 s toward eviction. The sleepy one accumulated
+/// 2-3 frames per wake, was dropped at 30 s, and started from zero on the next
+/// wake — so it could never reach `MIN_FRAMES_FOR_METRIC`, and never reach the
+/// 200 samples `rti` wants for a baseline either. It was structurally
+/// incapable of ever becoming usable.
+///
+/// Judging silence against the link's own cadence serves both without anyone
+/// classifying anything: the arrival history IS the classification.
+const STALE_INTERVAL_MULTIPLE: f64 = 20.0;
+
+/// Gap, as a multiple of the link's own typical interval, that ends the current
+/// measurement window.
+///
+/// Separate from eviction on purpose, because they are different concerns that
+/// were conflated in one constant. Eviction is about reclaiming a slot; this is
+/// about MEASUREMENT VALIDITY. A 32-frame history spanning two wakes ten
+/// minutes apart, differenced, reports how the room changed overnight and calls
+/// it motion — the same category of error as differencing a 64-bin frame
+/// against a 256-bin one, and it gets the same remedy: a discontinuity starts a
+/// fresh window rather than being blended into the old one.
+const HISTORY_GAP_MULTIPLE: f64 = 8.0;
+
+/// Absolute floor on that gap, whatever the cadence.
+///
+/// Without it a fast link resets constantly: at 10 ms between frames, eight
+/// intervals is 80 ms, and UDP delivers in bursts — the fps estimator's own
+/// notes record arrivals clumping hard enough to bias a reciprocal-mean
+/// estimator. A sub-second hiccup does not make two frames incomparable; the
+/// measurement is of human movement over roughly one-second windows. Only a
+/// gap long enough for the room itself to have changed should end the window.
+const HISTORY_GAP_MIN: Duration = Duration::from_secs(2);
+
+/// Smoothing for the per-link interval estimate. Deliberately brisk: a link
+/// that changes cadence (a device entering power-save) should be tracked in a
+/// few samples, not a few hundred.
+const INTERVAL_ALPHA: f64 = 0.25;
+
+/// Cap on how fast the interval estimate may grow per sample, so one long gap
+/// cannot inflate it and thereby make the link near-immortal. Growth to a
+/// genuinely slower cadence still happens, over a handful of samples.
+const INTERVAL_GROWTH_CAP: f64 = 4.0;
+
+/// EMA rate for a link's resting-state baseline. Matches the amplitude
+/// pipeline's existing slow-baseline approach rather than inventing a second
+/// convention.
+const BASELINE_ALPHA: f64 = 0.02;
+
+/// How far above its own resting level a link may sit and still update the
+/// baseline. Above this the baseline holds — see the freeze rationale in
+/// `LinkTable::observe`.
+const BASELINE_FREEZE_RATIO: f64 = 1.5;
+
+/// Fraction of the learned baseline subtracted from the raw metric. Mirrors
+/// `BASELINE_SUBTRACTION_FRACTION` in the per-node path, which live testing
+/// moved from 0.7 to 0.85 after 30% of the noise floor kept surviving as
+/// residual "motion" in an empty room.
+const BASELINE_SUBTRACTION: f64 = 0.85;
+
+/// How many transmitters beyond the receiver count `infer_transmitting_node`
+/// tolerates before it stops guessing. Each node may transmit, and a house has
+/// an access point or two; anything past that and a one-receiver hole in a
+/// hearing set is coincidence rather than a fingerprint.
+const INFERENCE_EXTRA_TRANSMITTERS: usize = 3;
+
+/// Frames required before a link reports a motion metric at all.
+const MIN_FRAMES_FOR_METRIC: usize = 8;
+
+/// Which percentile over subcarriers `agc_normalised_motion` reports. See the
+/// rationale at the aggregation step — the mean dilutes a minority response.
+///
+/// Note the sensitivity floor this implies: a nearest-rank p90 only moves when
+/// **more than 10% of subcarriers** respond. A perturbation confined to fewer
+/// bins than that lands below the rank and reads as quiet, exactly as the
+/// `p90_is_not_the_maximum...` test asserts. That is the intended trade — it is
+/// what makes the statistic robust to a single noisy bin — but it means the
+/// metric is tuned for a body-sized response across the grid, not a pinpoint one.
+const MOTION_PERCENTILE: f64 = 0.90;
+
+#[derive(Debug, Clone)]
+struct LinkState {
+    history: VecDeque<Vec<f64>>,
+    /// Arrival time of each frame in `history`, pushed and popped in lockstep.
+    ///
+    /// `history` is a fixed 64-frame window, so its *wall-clock span* is set by
+    /// how fast the link is currently delivering. Measured on the 2026-08-28
+    /// baseline, per-link delivery swung 0.70x to 4.83x within one session
+    /// (one link went 1.79 -> 8.66 fps), which stretched or shrank the window
+    /// behind `raw_motion` and `rssi` by the same factor. Two readings of the
+    /// same link are therefore only comparable when their spans are — so the
+    /// span is measured and reported rather than assumed constant.
+    stamps: VecDeque<Instant>,
+    last_seen: Instant,
+    frames: u64,
+    rssi_ema: f64,
+    /// Smoothed receiver noise floor, dBm, as the chip reports it per frame.
+    ///
+    /// Carried because AGC is otherwise invisible. ESP-IDF exposes no gain
+    /// field -- `wifi_pkt_rx_ctrl_t` gives `noise_floor` and then a run of
+    /// reserved bits -- so there is no documented way to tell a real 6 dB drop
+    /// (a body, a wall) from the receiver quietly turning itself down. If the
+    /// reported noise floor moves with gain state, it is the only observable
+    /// that betrays an AGC step, and correcting for it costs no firmware
+    /// change. If it turns out to be constant it carries nothing, and a
+    /// register-level gain lock is the only route. This exists to settle
+    /// which.
+    noise_ema: f64,
+    baseline: f64,
+    baseline_samples: u64,
+    /// Subcarrier width this link's history is locked to. 0 until the first
+    /// frame. Densest-wins: a denser frame clears the history and re-locks.
+    grid: usize,
+    /// Frames dropped for arriving on a sparser grid than `grid`. Counted, not
+    /// silent — an invisible drop is what hid every foreign transmitter until
+    /// 2026-09-01.
+    sparser_skipped: u64,
+    /// Typical seconds between frames on this link. 0 until the second frame.
+    /// This is what makes staleness and continuity relative to the transmitter
+    /// rather than to a constant chosen around the access point.
+    interval_s: f64,
+    /// Times the measurement window was reset by a gap. Counted, because a link
+    /// that resets constantly is telling you its cadence estimate is wrong.
+    gap_resets: u64,
+}
+
+impl LinkState {
+    /// How long this link may stay silent before it is considered gone.
+    ///
+    /// Relative to its own cadence, bounded at both ends: a link delivering
+    /// every 20 s is not stale at 30 s, it is on schedule, while a link that
+    /// has genuinely left must still free its slot eventually.
+    fn stale_after(&self) -> Duration {
+        if self.interval_s <= 0.0 {
+            return LINK_STALE_MIN;
+        }
+        let secs = self.interval_s * STALE_INTERVAL_MULTIPLE;
+        Duration::from_secs_f64(
+            secs.clamp(LINK_STALE_MIN.as_secs_f64(), LINK_STALE_MAX.as_secs_f64()),
+        )
+    }
+
+    /// Wall-clock seconds between the oldest and newest frame in the window.
+    fn window_span_s(&self) -> f64 {
+        match (self.stamps.front(), self.stamps.back()) {
+            (Some(a), Some(b)) => b.duration_since(*a).as_secs_f64(),
+            _ => 0.0,
+        }
+    }
+
+    /// Delivery rate over the window. `n - 1` intervals span `n` frames, and
+    /// a zero span (a single frame, or several inside the clock's resolution)
+    /// has no rate to report.
+    fn delivery_fps(&self) -> f64 {
+        let span = self.window_span_s();
+        if span <= 0.0 || self.stamps.len() < 2 {
+            return 0.0;
+        }
+        (self.stamps.len() as f64 - 1.0) / span
+    }
+}
+
+/// One row of [`LinkTable::inventory`] — a link as the table holds it, before
+/// any scoring decides whether it is renderable.
+#[derive(Debug, Clone)]
+pub struct LinkInventory {
+    pub id: LinkId,
+    pub frames: u64,
+    pub rssi: f64,
+    /// Smoothed receiver noise floor, dBm. See `LinkState::noise_ema`.
+    pub noise: f64,
+    /// Frames currently in the rolling history (cap `LINK_HISTORY`).
+    pub history_len: usize,
+    /// `(subcarrier_width, frames)` seen in that history, most frequent first.
+    /// A transmitter that interleaves PPDU formats shows several entries.
+    pub widths: Vec<(usize, usize)>,
+    pub modal_width: usize,
+    pub frames_at_modal: usize,
+    /// Whether this link currently survives into `metrics()`.
+    pub visible: bool,
+    /// Why not, when `visible` is false.
+    pub reason: &'static str,
+    pub age_ms: u64,
+    pub baseline_samples: u64,
+    /// Delivery rate over the link's own window. The single best triage
+    /// number: a loud transmitter at 0.02 fps cannot form a history and will
+    /// never be usable, however strong it looks.
+    pub fps: f64,
+    /// Wall-clock span of the history window, seconds. `fps` is only
+    /// comparable between links whose spans are comparable.
+    pub window_span_s: f64,
+    /// Subcarrier width this link is locked to.
+    pub grid: usize,
+    /// Frames refused for arriving on a sparser grid.
+    pub sparser_skipped: u64,
+    /// Typical seconds between frames on this link.
+    pub interval_s: f64,
+    /// Seconds of silence this link is allowed before eviction.
+    pub stale_after_s: f64,
+    /// Times a gap ended the measurement window.
+    pub gap_resets: u64,
+}
+
+/// Per-link motion, as reported to callers.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LinkMetric {
+    pub id: LinkId,
+    /// Frames observed on this link since it was admitted.
+    pub frames: u64,
+    /// EMA of received signal strength, dBm.
+    pub rssi: f64,
+    /// Smoothed receiver noise floor, dBm. See `LinkState::noise_ema`.
+    pub noise: f64,
+    /// Raw perturbation: p90 over subcarriers of the temporal standard
+    /// deviation of AGC-normalised amplitude.
+    pub raw_motion: f64,
+    /// `raw_motion` with the link's learned resting baseline subtracted, floored
+    /// at zero. This is the quantity a localiser should consume.
+    pub motion: f64,
+    /// The link's learned resting level. Exposed because it is the only scale
+    /// on which links of wildly different intrinsic sensitivity can be
+    /// compared: measured live, an AP link rests near 20 while a peer link
+    /// rests near 1.3, and a solver fed raw values lets the loud links decide
+    /// everything. See `rti::normalise_response`.
+    pub baseline: f64,
+    /// How many frames the baseline EMA has seen. Below a few hundred it has
+    /// not converged and the normalised response it produces is unreliable.
+    pub baseline_samples: u64,
+    /// Wall-clock seconds spanned by the frames currently in the window.
+    ///
+    /// `raw_motion` is a statistic over that span, so this is the quantity
+    /// that makes two samples comparable. A large change here means the
+    /// window moved, not the room.
+    pub window_span_s: f64,
+    /// Current delivery rate on this link, frames per second, measured over
+    /// the window rather than assumed. A link whose rate collapses while its
+    /// peers surge is showing transport contention, not motion — on the
+    /// 2026-08-28 baseline that pattern produced the night's *largest*
+    /// apparent motion excursions with nobody in the room.
+    pub fps: f64,
+}
+
+/// All currently tracked links.
+#[derive(Debug, Default)]
+pub struct LinkTable {
+    links: BTreeMap<LinkId, LinkState>,
+}
+
+/// High-percentile over subcarriers of the temporal standard deviation, after
+/// removing each frame's own mean across subcarriers.
+///
+/// The per-frame mean removal is essential, not cosmetic: the ESP32 applies
+/// automatic gain control per packet, so the absolute amplitude level jumps
+/// between packets for reasons that have nothing to do with the channel. A
+/// statistic built on the raw level is dominated by AGC. Removing each frame's
+/// mean cancels that scalar gain and leaves the response *shape*, whose
+/// variation over time is real channel perturbation.
+pub fn agc_normalised_motion(history: &VecDeque<Vec<f64>>) -> Option<f64> {
+    if history.len() < MIN_FRAMES_FOR_METRIC {
+        return None;
+    }
+    // Lock to the *most common* width in the window, not the newest frame's.
+    //
+    // A C6 on an 11ax AP interleaves formats: measured upstream at 84% HE-SU
+    // (256 bins, 78.125 kHz tone spacing) with an HT minority (64 bins,
+    // 312.5 kHz) — see ruvnet/RuView#1005. Keying off `history.back()` meant
+    // that whenever the newest frame happened to be one of the HT minority,
+    // every HE frame in the window was discarded and the metric was computed
+    // from the handful of HT frames instead. Those sample a different grid at
+    // a quarter the frequency resolution, so the number that came out was not
+    // a noisier version of the same measurement — it was a different one,
+    // reported under the same name, in roughly one sample in six.
+    //
+    // The mode follows a genuine, lasting format change (the window refills
+    // with the new width and the mode moves) while ignoring a transient
+    // minority, which is what "lock the densest grid, re-warm on upgrade"
+    // amounts to without needing an explicit upgrade state machine.
+    let mut width_counts: BTreeMap<usize, usize> = BTreeMap::new();
+    for f in history.iter() {
+        if !f.is_empty() {
+            *width_counts.entry(f.len()).or_insert(0) += 1;
+        }
+    }
+    // Ties break toward the denser grid: it carries more information, and on
+    // this hardware the dense format is the one the AP actually negotiated.
+    let n_sc = width_counts
+        .iter()
+        .max_by_key(|(width, count)| (**count, **width))
+        .map(|(width, _)| *width)?;
+    if n_sc == 0 {
+        return None;
+    }
+    let frames: Vec<&Vec<f64>> = history.iter().filter(|f| f.len() == n_sc).collect();
+    if frames.len() < MIN_FRAMES_FOR_METRIC {
+        return None;
+    }
+
+    let normalised: Vec<Vec<f64>> = frames
+        .iter()
+        .map(|f| {
+            let mean = f.iter().sum::<f64>() / n_sc as f64;
+            f.iter().map(|a| a - mean).collect()
+        })
+        .collect();
+
+    let n = normalised.len() as f64;
+    let mut per_sc: Vec<f64> = Vec::with_capacity(n_sc);
+    for sc in 0..n_sc {
+        let mean: f64 = normalised.iter().map(|f| f[sc]).sum::<f64>() / n;
+        let var: f64 = normalised
+            .iter()
+            .map(|f| {
+                let d = f[sc] - mean;
+                d * d
+            })
+            .sum::<f64>()
+            / n;
+        per_sc.push(var.sqrt());
+    }
+
+    // High percentile over subcarriers, not the mean.
+    //
+    // A body perturbs a *minority* of subcarriers strongly and leaves the rest
+    // near noise, so any statistic averaged across all bins is diluted by the
+    // unperturbed majority and floors close to the resting level. Measured
+    // upstream on C6 HE20 256-bin captures (ruvnet/RuView#1015): median |z|
+    // moved 0.40 -> 0.75 between an empty room and a person moving, while p90
+    // |z| moved 1.30 -> 2.27 on the same data. Same signal, roughly three
+    // times the separation, because the percentile follows the bins that
+    // actually responded.
+    //
+    // p90 rather than the max: the maximum is a single bin and rides on
+    // whatever noise spike happened to be largest, whereas the 90th percentile
+    // still requires ~10% of the grid to agree. Nearest-rank, so it is a real
+    // observed value and needs no interpolation.
+    per_sc.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let idx = ((MOTION_PERCENTILE * (per_sc.len() as f64 - 1.0)).round() as usize)
+        .min(per_sc.len() - 1);
+    Some(per_sc[idx])
+}
+
+impl LinkTable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one frame against its link.
+    ///
+    /// Frames with no transmitter identity (wire v1) must not be passed here —
+    /// they cannot be attributed to a link, and inventing a placeholder key
+    /// would silently recreate the mixing this module exists to undo.
+    pub fn observe(
+        &mut self,
+        rx_node: u8,
+        tx_mac: [u8; 6],
+        amplitudes: &[f64],
+        rssi: i8,
+        noise_floor: i8,
+        now: Instant,
+    ) {
+        if amplitudes.is_empty() {
+            return;
+        }
+        let id = LinkId { rx_node, tx_mac };
+        let known = self.links.contains_key(&id);
+        if !known && self.links.len() >= MAX_LINKS {
+            return; // table full; expiry will free slots
+        }
+        let st = self.links.entry(id).or_insert_with(|| LinkState {
+            history: VecDeque::with_capacity(LINK_HISTORY),
+            stamps: VecDeque::with_capacity(LINK_HISTORY),
+            last_seen: now,
+            frames: 0,
+            rssi_ema: rssi as f64,
+            noise_ema: noise_floor as f64,
+            baseline: 0.0,
+            baseline_samples: 0,
+            grid: 0,
+            sparser_skipped: 0,
+            interval_s: 0.0,
+            gap_resets: 0,
+        });
+        // ── Cadence, and the continuity guard ────────────────────────────────
+        //
+        // Measured BEFORE `last_seen` moves, so `dt` is the real silence since
+        // the previous frame. A brand-new link has dt == 0 and teaches nothing.
+        let dt = now.duration_since(st.last_seen).as_secs_f64();
+        if dt > 0.0 {
+            let gap_limit =
+                (HISTORY_GAP_MULTIPLE * st.interval_s).max(HISTORY_GAP_MIN.as_secs_f64());
+            if st.interval_s > 0.0 && dt > gap_limit {
+                // The window ended. Drop the samples — they are not comparable
+                // across the gap — but KEEP the link, its baseline, its frame
+                // count and its cadence estimate. Throwing those away is what
+                // made a sleepy transmitter permanently unusable: the baseline
+                // needs 200 samples and was being reset every 30 s.
+                st.history.clear();
+                st.stamps.clear();
+                st.gap_resets += 1;
+            }
+            st.interval_s = if st.interval_s <= 0.0 {
+                dt
+            } else {
+                let capped = dt.min(st.interval_s * INTERVAL_GROWTH_CAP);
+                st.interval_s * (1.0 - INTERVAL_ALPHA) + capped * INTERVAL_ALPHA
+            };
+        }
+
+        // ── Per-link subcarrier-grid policy (ADR-110 / issue #1005) ──────────
+        //
+        // Same rule the per-node gate applied, applied where it belongs. A
+        // 64-bin HT frame and a 256-bin HE frame sample different frequency
+        // grids (312.5 kHz against 78.125 kHz tone spacing); differencing them
+        // is not a noisier measurement, it is a different one reported under
+        // the same name.
+        //
+        // Keyed per LINK rather than per node, because grid is a property of
+        // the transmitter. Keying it by node locked every link to whatever the
+        // associated AP negotiated and silently discarded every other
+        // transmitter in the building — measured 2026-09-01, 24 transmitters
+        // seen by a node, 10 admitted fleet-wide.
+        //
+        // Densest-wins, re-warm on upgrade: a denser grid carries more
+        // information, so adopt it and drop the coarser history rather than
+        // mixing. A sparser frame still refreshes liveness and RSSI — the link
+        // is real and present — it simply contributes no sample.
+        let width = amplitudes.len();
+        if width > st.grid {
+            st.history.clear();
+            st.stamps.clear();
+            st.grid = width;
+            st.baseline = 0.0;
+            st.baseline_samples = 0;
+        }
+        if width < st.grid {
+            st.last_seen = now;
+            st.frames += 1;
+            st.rssi_ema = st.rssi_ema * 0.9 + rssi as f64 * 0.1;
+            st.noise_ema = st.noise_ema * 0.9 + noise_floor as f64 * 0.1;
+            st.sparser_skipped += 1;
+            return;
+        }
+
+        st.history.push_back(amplitudes.to_vec());
+        st.stamps.push_back(now);
+        if st.history.len() > LINK_HISTORY {
+            st.history.pop_front();
+        }
+        if st.stamps.len() > LINK_HISTORY {
+            st.stamps.pop_front();
+        }
+        st.last_seen = now;
+        st.frames += 1;
+        st.rssi_ema = st.rssi_ema * 0.9 + rssi as f64 * 0.1;
+        st.noise_ema = st.noise_ema * 0.9 + noise_floor as f64 * 0.1;
+
+        if let Some(raw) = agc_normalised_motion(&st.history) {
+            st.baseline_samples += 1;
+            // Track fast while the baseline is still meaningless, then settle to
+            // a slow EMA — same warm-up shape as the per-node amplitude path.
+            if st.baseline_samples < 40 {
+                st.baseline = st.baseline * 0.8 + raw * 0.2;
+            } else if raw <= st.baseline * BASELINE_FREEZE_RATIO {
+                // Freeze while the link is responding.
+                //
+                // BASELINE_ALPHA is a ~50-sample time constant, which at the
+                // 6-16 fps a link actually runs is 3-8 seconds. An unfrozen
+                // EMA therefore absorbs a stationary person into "resting"
+                // within seconds, and the reported `motion` — which is
+                // `raw - 0.85 * baseline` — decays back to zero while they are
+                // still there. That makes the live signal a *change* detector
+                // rather than a presence detector, and it is why a seated
+                // human is invisible while a walking one is not.
+                //
+                // Updating only when the link is near rest keeps adaptation to
+                // genuine environmental drift (furniture, temperature, a door
+                // left open) while refusing to learn away the thing we are
+                // trying to detect.
+                st.baseline = st.baseline * (1.0 - BASELINE_ALPHA) + raw * BASELINE_ALPHA;
+            }
+        }
+    }
+
+    /// Drop links unseen for [`LINK_STALE_AFTER`].
+    pub fn expire(&mut self, now: Instant) {
+        self.links
+            .retain(|_, st| now.duration_since(st.last_seen) < st.stale_after());
+    }
+
+    /// Current per-link metrics, strongest perturbation first.
+    pub fn metrics(&self) -> Vec<LinkMetric> {
+        let mut out: Vec<LinkMetric> = self
+            .links
+            .iter()
+            .filter_map(|(id, st)| {
+                let raw = agc_normalised_motion(&st.history)?;
+                Some(LinkMetric {
+                    id: *id,
+                    frames: st.frames,
+                    rssi: st.rssi_ema,
+                    noise: st.noise_ema,
+                    raw_motion: raw,
+                    motion: (raw - st.baseline * BASELINE_SUBTRACTION).max(0.0),
+                    baseline: st.baseline,
+                    baseline_samples: st.baseline_samples,
+                    window_span_s: st.window_span_s(),
+                    fps: st.delivery_fps(),
+                })
+            })
+            .collect();
+        out.sort_by(|a, b| {
+            b.motion
+                .partial_cmp(&a.motion)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        out
+    }
+
+    pub fn len(&self) -> usize {
+        self.links.len()
+    }
+
+    /// Every link in the table, including the ones [`LinkTable::metrics`]
+    /// omits, with the reason each one is missing.
+    ///
+    /// `metrics()` is a `filter_map` over [`agc_normalised_motion`], so a link
+    /// that cannot yet produce a motion value vanishes from `/api/v1/links`,
+    /// from `hearing_index`, and from the RTI observation set with no error, no
+    /// counter and no log. MEASURED 2026-09-01: a node hears ~24 transmitters
+    /// and the server renders 3 of them. That gap was invisible from every
+    /// existing endpoint, which is exactly why this one exists — it reports
+    /// what the table HOLDS rather than what survived scoring.
+    ///
+    /// Diagnosis is taken from `agc_normalised_motion` itself for `visible`,
+    /// and the supporting fields are recomputed alongside it, so the two can
+    /// never drift into disagreeing about the same link.
+    pub fn inventory(&self, now: Instant) -> Vec<LinkInventory> {
+        let mut out: Vec<LinkInventory> = self
+            .links
+            .iter()
+            .map(|(id, st)| {
+                let mut width_counts: BTreeMap<usize, usize> = BTreeMap::new();
+                for f in st.history.iter() {
+                    if !f.is_empty() {
+                        *width_counts.entry(f.len()).or_insert(0) += 1;
+                    }
+                }
+                let modal_width = width_counts
+                    .iter()
+                    .max_by_key(|(width, count)| (**count, **width))
+                    .map(|(w, _)| *w)
+                    .unwrap_or(0);
+                let frames_at_modal = width_counts.get(&modal_width).copied().unwrap_or(0);
+
+                let visible = agc_normalised_motion(&st.history).is_some();
+                let reason = if visible {
+                    "ok"
+                } else if st.history.len() < MIN_FRAMES_FOR_METRIC {
+                    "history_below_min"
+                } else if modal_width == 0 {
+                    "no_usable_width"
+                } else if frames_at_modal < MIN_FRAMES_FOR_METRIC {
+                    "modal_width_below_min"
+                } else {
+                    "motion_undefined"
+                };
+
+                let mut widths: Vec<(usize, usize)> = width_counts.into_iter().collect();
+                widths.sort_by(|a, b| b.1.cmp(&a.1));
+
+                LinkInventory {
+                    id: *id,
+                    frames: st.frames,
+                    rssi: st.rssi_ema,
+                    noise: st.noise_ema,
+                    history_len: st.history.len(),
+                    widths,
+                    modal_width,
+                    frames_at_modal,
+                    visible,
+                    reason,
+                    age_ms: now.duration_since(st.last_seen).as_millis() as u64,
+                    baseline_samples: st.baseline_samples,
+                    fps: st.delivery_fps(),
+                    window_span_s: st.window_span_s(),
+                    grid: st.grid,
+                    sparser_skipped: st.sparser_skipped,
+                    interval_s: st.interval_s,
+                    stale_after_s: st.stale_after().as_secs_f64(),
+                    gap_resets: st.gap_resets,
+                }
+            })
+            .collect();
+        // Loudest first: the ones worth keeping as illuminators sort to the top.
+        out.sort_by(|a, b| b.rssi.partial_cmp(&a.rssi).unwrap_or(std::cmp::Ordering::Equal));
+        out
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.links.is_empty()
+    }
+}
+
+/// Which of our own nodes transmitted `tx_mac`, inferred from who did *not*
+/// hear it.
+///
+/// Nothing in the system records a node's own MAC — a node reports the
+/// addresses it hears, never its own. A radio does not receive its own
+/// transmissions, though, and that absence is the signature: given the set of
+/// receivers currently reporting links, a transmitter heard by all of them
+/// except exactly one is that one receiver's own board. A transmitter heard by
+/// every receiver is external infrastructure.
+///
+/// This is an inference and callers must present it as one. Limits, all of
+/// which return `None` rather than a guess:
+///
+/// - Fewer than three receivers. With two, "heard by all but one" and "heard by
+///   exactly one" are the same observation, so the signature carries nothing.
+/// - More than one receiver missing — a peer out of range, or newly booted,
+///   looks identical to a peer that is simply not ours.
+/// - **More transmitters than the signature can survive.** The whole premise
+///   assumes the population is "our boards plus some infrastructure", so a
+///   one-receiver hole is distinctive. MEASURED 2026-09-01: once the per-link
+///   grid fix admitted 40 transmitters, any foreign device heard by 8 of 9
+///   nodes matches the signature by coincidence and would be labelled as that
+///   ninth node's own board. So the inference now switches itself off when the
+///   population outgrows its assumption.
+///
+/// A wrong answer used to only mislabel a display row. That is NO LONGER TRUE:
+/// `attribute_transmitter` feeds `rti_from_links`, so a wrong answer places a
+/// link at a node's surveyed coordinates and hands it to the position solver as
+/// if measured. Callers must keep preferring a reported MAC over this.
+pub fn infer_transmitting_node(
+    tx_mac: &[u8; 6],
+    receivers: &std::collections::BTreeSet<u8>,
+    heard_by: &std::collections::BTreeMap<[u8; 6], std::collections::BTreeSet<u8>>,
+) -> Option<u8> {
+    if receivers.len() < 3 {
+        return None;
+    }
+    // Each receiver can transmit, plus a small allowance for infrastructure.
+    // Beyond that the hole in a hearing set is coincidence, not a signature.
+    if heard_by.len() > receivers.len() + INFERENCE_EXTRA_TRANSMITTERS {
+        return None;
+    }
+    let heard = heard_by.get(tx_mac)?;
+    let mut missing = receivers.difference(heard);
+    let candidate = *missing.next()?;
+    // Exactly one receiver missing, or the signature does not hold.
+    missing.next().is_none().then_some(candidate)
+}
+
+/// Receivers currently reporting, and which receivers heard each transmitter —
+/// the two indexes [`infer_transmitting_node`] needs.
+#[allow(clippy::type_complexity)]
+pub fn hearing_index(
+    metrics: &[LinkMetric],
+) -> (
+    std::collections::BTreeSet<u8>,
+    std::collections::BTreeMap<[u8; 6], std::collections::BTreeSet<u8>>,
+) {
+    let mut receivers = std::collections::BTreeSet::new();
+    let mut heard_by: std::collections::BTreeMap<[u8; 6], std::collections::BTreeSet<u8>> =
+        std::collections::BTreeMap::new();
+    for m in metrics {
+        receivers.insert(m.id.rx_node);
+        heard_by.entry(m.id.tx_mac).or_default().insert(m.id.rx_node);
+    }
+    (receivers, heard_by)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const AP: [u8; 6] = [0x8c, 0x30, 0x66, 0x86, 0xa4, 0x21];
+    const PEER: [u8; 6] = [0xe8, 0xf6, 0x0a, 0xfc, 0xb2, 0xa8];
+
+    fn steady(n_sc: usize, level: f64) -> Vec<f64> {
+        vec![level; n_sc]
+    }
+
+    /// AGC changes the whole frame's level at once. A motion metric must not
+    /// respond to that, or it reports gain changes as movement.
+    #[test]
+    fn per_frame_gain_changes_do_not_register_as_motion() {
+        let mut h = VecDeque::new();
+        for i in 0..32 {
+            // Same shape, wildly different level each frame.
+            let level = 10.0 + (i % 7) as f64 * 25.0;
+            h.push_back(steady(56, level));
+        }
+        let m = agc_normalised_motion(&h).expect("defined");
+        assert!(
+            m < 1e-9,
+            "constant shape under varying gain must read as no motion, got {m}"
+        );
+    }
+
+    /// A changing response *shape* is real channel perturbation and must
+    /// register even if the frame mean stays constant.
+    #[test]
+    fn shape_change_registers_as_motion() {
+        let mut h = VecDeque::new();
+        for i in 0..32 {
+            // Mean held at 10.0; the tilt across subcarriers varies.
+            let tilt = ((i % 5) as f64 - 2.0) * 0.5;
+            let f: Vec<f64> = (0..56)
+                .map(|k| 10.0 + tilt * (k as f64 - 27.5) / 27.5)
+                .collect();
+            h.push_back(f);
+        }
+        let m = agc_normalised_motion(&h).expect("defined");
+        assert!(m > 0.05, "shape variation must register, got {m}");
+    }
+
+    #[test]
+    fn insufficient_history_yields_no_metric() {
+        let mut h = VecDeque::new();
+        for _ in 0..(MIN_FRAMES_FOR_METRIC - 1) {
+            h.push_back(steady(56, 10.0));
+        }
+        assert!(agc_normalised_motion(&h).is_none());
+    }
+
+    /// The whole point of the module: two transmitters heard by one receiver
+    /// are two separate links, not one mixed history.
+    #[test]
+    fn two_transmitters_on_one_receiver_are_separate_links() {
+        let mut t = LinkTable::new();
+        let now = Instant::now();
+        for i in 0..20 {
+            t.observe(2, AP, &steady(56, 10.0), -60, -92, now);
+            let tilt = (i % 5) as f64;
+            let moving: Vec<f64> = (0..56).map(|k| 10.0 + tilt * (k as f64 % 3.0)).collect();
+            t.observe(2, PEER, &moving, -70, -92, now);
+        }
+        assert_eq!(t.len(), 2, "one receiver, two transmitters => two links");
+        let m = t.metrics();
+        assert_eq!(m.len(), 2);
+        let ap = m.iter().find(|x| x.id.tx_mac == AP).expect("AP link");
+        let peer = m.iter().find(|x| x.id.tx_mac == PEER).expect("peer link");
+        assert!(
+            ap.raw_motion < peer.raw_motion,
+            "the static link must not inherit the moving link's perturbation \
+             (ap={} peer={})",
+            ap.raw_motion,
+            peer.raw_motion
+        );
+    }
+
+    #[test]
+    fn same_transmitter_on_two_receivers_are_separate_links() {
+        let mut t = LinkTable::new();
+        let now = Instant::now();
+        for _ in 0..12 {
+            t.observe(0, AP, &steady(56, 10.0), -60, -92, now);
+            t.observe(1, AP, &steady(56, 20.0), -50, -92, now);
+        }
+        assert_eq!(t.len(), 2);
+    }
+
+
+    /// The failure this guard prevents. With nine receivers and forty
+    /// transmitters — the fleet as of 2026-09-01 — a foreign device heard by
+    /// eight of nine matches "all but one" purely by coincidence, and would be
+    /// labelled as the ninth node's own board. That label now feeds the
+    /// position solver, so it would place the link at that node's surveyed
+    /// coordinates as if measured.
+    #[test]
+    fn inference_stops_guessing_once_the_channel_is_crowded() {
+        use std::collections::{BTreeMap, BTreeSet};
+        let receivers: BTreeSet<u8> = (0..9u8).collect();
+        let foreign = [0x64, 0x16, 0x66, 0xc7, 0x8c, 0x51];
+        let mut heard: BTreeMap<[u8; 6], BTreeSet<u8>> = BTreeMap::new();
+        // heard by 8 of 9 — exactly the signature of node 8's own board
+        heard.insert(foreign, (0..9u8).filter(|n| *n != 8).collect());
+
+        // A quiet channel: the signature is trustworthy and still fires.
+        assert_eq!(infer_transmitting_node(&foreign, &receivers, &heard), Some(8));
+
+        // A crowded one: same hearing set, but the population has outgrown the
+        // assumption, so it declines rather than guessing.
+        for i in 0..40u8 {
+            heard.insert([0xAA, 0xBB, 0xCC, 0, 0, i], (0..4u8).collect());
+        }
+        assert_eq!(
+            infer_transmitting_node(&foreign, &receivers, &heard), None,
+            "with 40+ transmitters a one-receiver hole is coincidence, not a fingerprint"
+        );
+    }
+
+    #[test]
+    fn stale_links_expire_and_free_their_slot() {
+        let mut t = LinkTable::new();
+        let t0 = Instant::now();
+        for _ in 0..12 {
+            t.observe(0, AP, &steady(56, 10.0), -60, -92, t0);
+        }
+        assert_eq!(t.len(), 1);
+        // Every frame arrived at the same instant, so there is no cadence to
+        // measure and the link falls back to the eviction floor.
+        t.expire(t0 + LINK_STALE_MIN + Duration::from_secs(1));
+        assert_eq!(t.len(), 0, "stale link must be dropped");
+    }
+
+    // ---- cadence-relative staleness ----------------------------------------
+
+    /// The bug this replaces: a flat 30 s window evicted a slow-but-steady
+    /// transmitter mid-conversation. MEASURED 2026-09-01 on a Nest Protect that
+    /// accumulated 2-3 frames per wake, was dropped, and started from zero every
+    /// time — so it could never reach MIN_FRAMES_FOR_METRIC, nor the 200 samples
+    /// rti wants for a baseline.
+    #[test]
+    fn a_slow_but_steady_link_is_not_evicted_at_the_old_flat_window() {
+        let t0 = Instant::now();
+        let mut t = LinkTable::new();
+        for i in 0..6 {
+            t.observe(0, PEER, &steady(64, 10.0), -80, -92, t0 + Duration::from_secs(i * 20));
+        }
+        let last = t0 + Duration::from_secs(100);
+        // 40 s of silence: past the old flat window, well inside 20x a 20 s cadence.
+        t.expire(last + Duration::from_secs(40));
+        assert_eq!(t.len(), 1, "a link on a 20 s cadence is not stale at 40 s");
+
+        let inv = t.inventory(last + Duration::from_secs(40));
+        assert!(inv[0].interval_s > 10.0, "cadence learned: {}", inv[0].interval_s);
+        assert!(inv[0].stale_after_s > 100.0, "allowance scales with it: {}", inv[0].stale_after_s);
+    }
+
+    /// It must still bound the table: a transmitter that leaves for good frees
+    /// its slot rather than living forever behind a generous multiplier.
+    #[test]
+    fn a_link_that_stops_for_good_is_still_evicted() {
+        let t0 = Instant::now();
+        let mut t = LinkTable::new();
+        for i in 0..6 {
+            t.observe(0, PEER, &steady(64, 10.0), -80, -92, t0 + Duration::from_secs(i * 20));
+        }
+        t.expire(t0 + Duration::from_secs(100) + LINK_STALE_MAX + Duration::from_secs(1));
+        assert_eq!(t.len(), 0, "silence beyond the ceiling always evicts");
+    }
+
+    /// A chatty link keeps the floor, not a 1-second allowance derived from its
+    /// own 50 ms cadence.
+    #[test]
+    fn a_fast_link_keeps_the_eviction_floor() {
+        let t0 = Instant::now();
+        let mut t = LinkTable::new();
+        for i in 0..20 {
+            t.observe(0, AP, &steady(256, 10.0), -60, -92, t0 + Duration::from_millis(i * 50));
+        }
+        let inv = t.inventory(t0 + Duration::from_secs(1));
+        assert!(inv[0].interval_s < 0.2, "fast cadence: {}", inv[0].interval_s);
+        assert!((inv[0].stale_after_s - LINK_STALE_MIN.as_secs_f64()).abs() < 0.001,
+                "clamped to the floor, got {}", inv[0].stale_after_s);
+    }
+
+
+    /// The floor exists because a fast link would otherwise reset constantly:
+    /// eight intervals of 10 ms is 80 ms, and UDP arrives in bursts. A
+    /// sub-second hiccup must not end the measurement window.
+    #[test]
+    fn a_brief_hiccup_does_not_reset_a_fast_link() {
+        let t0 = Instant::now();
+        let mut t = LinkTable::new();
+        for i in 0..10 {
+            t.observe(0, AP, &steady(256, 20.0), -60, -92, t0 + Duration::from_millis(i * 10));
+        }
+        // 110 ms later: 11x the cadence, but far below the absolute floor.
+        t.observe(0, AP, &steady(256, 20.0), -60, -92, t0 + Duration::from_millis(200));
+        let inv = t.inventory(t0 + Duration::from_millis(200));
+        assert_eq!(inv[0].gap_resets, 0, "a 110 ms gap is jitter, not a discontinuity");
+        assert_eq!(inv[0].history_len, 11, "history survives intact");
+    }
+
+    /// Continuity: a gap ends the measurement window, because differencing
+    /// frames either side of a long silence reports how the room changed while
+    /// nobody was looking and calls it motion. The LINK survives — throwing away
+    /// its baseline is what made a sleepy transmitter permanently unusable.
+    #[test]
+    fn a_long_gap_resets_the_window_but_keeps_the_link() {
+        let t0 = Instant::now();
+        let mut t = LinkTable::new();
+        for i in 0..12 {
+            t.observe(0, PEER, &steady(64, 10.0 + i as f64), -80, -92, t0 + Duration::from_secs(i));
+        }
+        let before = t.inventory(t0 + Duration::from_secs(12));
+        assert_eq!(before[0].history_len, 12);
+        let frames_before = before[0].frames;
+
+        // Wake far later: 8x a ~1 s cadence is comfortably exceeded.
+        let woke = t0 + Duration::from_secs(300);
+        t.observe(0, PEER, &steady(64, 99.0), -80, -92, woke);
+
+        let after = t.inventory(woke);
+        assert_eq!(after[0].history_len, 1, "window restarted, not blended across the gap");
+        assert_eq!(after[0].gap_resets, 1, "and the reset is counted, not silent");
+        assert_eq!(after[0].frames, frames_before + 1, "the link itself survives");
+        assert_eq!(t.len(), 1);
+    }
+
+    #[test]
+    fn table_is_bounded_against_a_busy_channel() {
+        let mut t = LinkTable::new();
+        let now = Instant::now();
+        for i in 0..(MAX_LINKS as u32 + 40) {
+            let mac = [0xAA, 0xBB, 0xCC, (i >> 16) as u8, (i >> 8) as u8, i as u8];
+            t.observe(0, mac, &steady(56, 10.0), -70, -92, now);
+        }
+        assert!(
+            t.len() <= MAX_LINKS,
+            "must not grow without bound on a busy channel, got {}",
+            t.len()
+        );
+    }
+
+    /// Frames of differing width within one window must not be mixed into the
+    /// variance — a transmitter switching PPDU format would otherwise look like
+    /// a huge motion event.
+    /// A minority of HT frames arriving in a mostly-HE window must not hijack
+    /// the measurement. Before the mode-lock this failed: whichever format the
+    /// newest frame happened to be decided the whole window.
+    #[test]
+    fn an_ht_minority_does_not_displace_the_he_majority() {
+        let mut h: VecDeque<Vec<f64>> = VecDeque::new();
+        for i in 0..40 {
+            h.push_back((0..256).map(|k| ((i + k) as f64 * 0.01).sin()).collect());
+        }
+        // Five HT frames scattered in, and crucially the NEWEST frame is HT.
+        for i in 0..5 {
+            h.push_back((0..64).map(|k| ((i + k) as f64 * 0.3).sin()).collect());
+        }
+        let with_ht_newest = agc_normalised_motion(&h).expect("metric");
+
+        // The same history without the HT frames at all.
+        let he_only: VecDeque<Vec<f64>> =
+            h.iter().filter(|f| f.len() == 256).cloned().collect();
+        let pure = agc_normalised_motion(&he_only).expect("metric");
+
+        assert!(
+            (with_ht_newest - pure).abs() < 1e-12,
+            "HT minority changed the metric: {with_ht_newest} vs {pure}"
+        );
+    }
+
+    /// A lasting format change must be followed, not ignored forever — the
+    /// window refills with the new width and the mode moves with it.
+    #[test]
+    fn a_sustained_format_change_is_adopted() {
+        let mut h: VecDeque<Vec<f64>> = VecDeque::new();
+        for i in 0..10 {
+            h.push_back((0..256).map(|k| ((i + k) as f64 * 0.01).sin()).collect());
+        }
+        for i in 0..40 {
+            h.push_back((0..64).map(|k| ((i + k) as f64 * 0.02).sin()).collect());
+        }
+        let got = agc_normalised_motion(&h).expect("metric");
+        let ht_only: VecDeque<Vec<f64>> =
+            h.iter().filter(|f| f.len() == 64).cloned().collect();
+        let pure = agc_normalised_motion(&ht_only).expect("metric");
+        assert!((got - pure).abs() < 1e-12, "did not follow the new format");
+    }
+
+    #[test]
+    fn frames_of_differing_width_do_not_corrupt_the_metric() {
+        let mut h = VecDeque::new();
+        for _ in 0..20 {
+            h.push_back(steady(56, 10.0));
+        }
+        for _ in 0..4 {
+            h.push_back(steady(128, 10.0));
+        }
+        // The 56-wide majority IS the measurement. The four 128-wide frames are
+        // a transient minority and must neither corrupt it nor suppress it.
+        //
+        // This test previously asserted `is_none()`, encoding the old
+        // newest-frame-wins rule: twenty perfectly good frames were thrown away
+        // because four frames of another format happened to arrive last. That
+        // was the defect, not the contract.
+        let m = agc_normalised_motion(&h).expect("the majority width yields a metric");
+        assert!(m.abs() < 1e-12, "steady frames must show no motion, got {m}");
+    }
+
+    // ---- transmitter-identity inference (ADR-345) ----------------------
+
+    const NODE0: [u8; 6] = [0x9c, 0xcc, 0x01, 0x40, 0x18, 0xb8];
+    const NODE1: [u8; 6] = [0xe8, 0xf6, 0x0a, 0xfc, 0xfb, 0x6c];
+
+    /// Build the two indexes from an explicit (rx_node, tx_mac) list, so each
+    /// test states the mesh it is describing rather than driving a LinkTable.
+    fn indexes(
+        pairs: &[(u8, [u8; 6])],
+    ) -> (
+        std::collections::BTreeSet<u8>,
+        std::collections::BTreeMap<[u8; 6], std::collections::BTreeSet<u8>>,
+    ) {
+        let metrics: Vec<LinkMetric> = pairs
+            .iter()
+            .map(|&(rx_node, tx_mac)| LinkMetric {
+                id: LinkId { rx_node, tx_mac },
+                frames: 100,
+                rssi: -70.0,
+                noise: -92.0,
+                raw_motion: 1.0,
+                motion: 0.5,
+                baseline: 1.0,
+                baseline_samples: 500,
+                window_span_s: 4.0,
+                fps: 16.0,
+            })
+            .collect();
+        hearing_index(&metrics)
+    }
+
+    #[test]
+    fn a_transmitter_every_receiver_hears_is_infrastructure() {
+        // The AP is external, so all three nodes hear it and none is excluded.
+        let (rx, heard) = indexes(&[(0, AP), (1, AP), (2, AP)]);
+        assert_eq!(infer_transmitting_node(&AP, &rx, &heard), None);
+    }
+
+    #[test]
+    fn the_one_receiver_that_cannot_hear_a_transmitter_is_that_transmitter() {
+        // NODE0's beacons reach nodes 1 and 2. Node 0 cannot hear its own
+        // radio, and that hole identifies it.
+        let (rx, heard) = indexes(&[
+            (0, AP),
+            (1, AP),
+            (2, AP),
+            (1, NODE0),
+            (2, NODE0),
+        ]);
+        assert_eq!(infer_transmitting_node(&NODE0, &rx, &heard), Some(0));
+    }
+
+    #[test]
+    fn two_receivers_missing_is_ambiguous_and_yields_no_guess() {
+        // A neighbour's router that only node 2 happens to hear leaves nodes 0
+        // and 1 both "missing" — indistinguishable from a peer out of range,
+        // so the inference must decline rather than pick one.
+        let stranger: [u8; 6] = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let (rx, heard) = indexes(&[(0, AP), (1, AP), (2, AP), (2, stranger)]);
+        assert_eq!(infer_transmitting_node(&stranger, &rx, &heard), None);
+    }
+
+    #[test]
+    fn two_receivers_carry_no_signature_at_all() {
+        // With only nodes 0 and 1 reporting, "heard by all but one" and "heard
+        // by exactly one" are the same observation. Refuse regardless of how
+        // suggestive the pattern looks.
+        let (rx, heard) = indexes(&[(0, AP), (1, AP), (1, NODE0)]);
+        assert_eq!(rx.len(), 2);
+        assert_eq!(infer_transmitting_node(&NODE0, &rx, &heard), None);
+    }
+
+    #[test]
+    fn a_full_three_node_mesh_labels_every_peer_and_leaves_the_ap_external() {
+        // The validated 2026-08-28 topology: 3 AP links + 6 directional
+        // node-to-node links.
+        let (rx, heard) = indexes(&[
+            (0, AP),
+            (1, AP),
+            (2, AP),
+            (1, NODE0),
+            (2, NODE0),
+            (0, NODE1),
+            (2, NODE1),
+            (0, PEER),
+            (1, PEER),
+        ]);
+        assert_eq!(infer_transmitting_node(&NODE0, &rx, &heard), Some(0));
+        assert_eq!(infer_transmitting_node(&NODE1, &rx, &heard), Some(1));
+        assert_eq!(infer_transmitting_node(&PEER, &rx, &heard), Some(2));
+        assert_eq!(infer_transmitting_node(&AP, &rx, &heard), None);
+    }
+
+    // ── Pre-nine-node changes, 2026-08-29 ──────────────────────────────────
+
+    /// Build a history where only `n_hot` of `n_sc` subcarriers carry a
+    /// time-varying response and the rest are static.
+    fn history_with_minority_response(
+        n_sc: usize, n_hot: usize, frames: usize, amp: f64,
+    ) -> VecDeque<Vec<f64>> {
+        let mut h = VecDeque::new();
+        for t in 0..frames {
+            let mut f = vec![10.0; n_sc];
+            for sc in 0..n_hot {
+                // Alternate so the temporal std of a hot bin is exactly `amp`.
+                f[sc] = 10.0 + if t % 2 == 0 { amp } else { -amp };
+            }
+            h.push_back(f);
+        }
+        h
+    }
+
+    #[test]
+    fn p90_follows_a_minority_response_that_the_mean_would_dilute() {
+        // The #1015 result, as a property: a body perturbs a minority of
+        // subcarriers strongly. With 20% of bins hot, the mean over all bins is
+        // pulled toward the static majority; p90 sits on the responding bins.
+        let h = history_with_minority_response(100, 20, 32, 4.0);
+        let got = agc_normalised_motion(&h).expect("metric must be produced");
+
+        // Mean-over-subcarriers, the statistic this replaced, for comparison.
+        let mean_stat = {
+            let n_sc = 100usize;
+            let frames: Vec<&Vec<f64>> = h.iter().collect();
+            let n = frames.len() as f64;
+            let normalised: Vec<Vec<f64>> = frames.iter().map(|f| {
+                let m = f.iter().sum::<f64>() / n_sc as f64;
+                f.iter().map(|a| a - m).collect()
+            }).collect();
+            let mut total = 0.0;
+            for sc in 0..n_sc {
+                let m: f64 = normalised.iter().map(|f| f[sc]).sum::<f64>() / n;
+                let v: f64 = normalised.iter().map(|f| (f[sc] - m).powi(2)).sum::<f64>() / n;
+                total += v.sqrt();
+            }
+            total / n_sc as f64
+        };
+
+        assert!(got > mean_stat * 2.0,
+            "p90 ({got}) should be well above the diluted mean ({mean_stat})");
+    }
+
+    #[test]
+    fn p90_is_not_the_maximum_so_a_single_noisy_bin_cannot_drive_it() {
+        // One hot bin in 100 is below the 90th percentile, so the metric must
+        // stay near the quiet level — this is why p90 and not max.
+        let h = history_with_minority_response(100, 1, 32, 50.0);
+        let got = agc_normalised_motion(&h).expect("metric must be produced");
+        let quiet = agc_normalised_motion(&history_with_minority_response(100, 0, 32, 0.0))
+            .expect("metric must be produced");
+        assert!(got < quiet + 1.0,
+            "a single spiking bin must not drive p90 (got {got}, quiet {quiet})");
+    }
+
+    #[test]
+    fn baseline_freezes_while_the_link_is_responding() {
+        // The change-detector defect: an unfrozen EMA absorbs a stationary
+        // person within seconds, so `motion` decays to zero while they are
+        // still present. Drive a link to a settled baseline, then hold it high
+        // and assert the baseline does not chase.
+        let now = Instant::now();
+        let mut t = LinkTable::new();
+        let quiet = vec![10.0f64; 32];
+        for i in 0..300 {
+            t.observe(0, [1, 2, 3, 4, 5, 6], &quiet, -60, -92,
+                      now + Duration::from_millis(i * 50));
+        }
+        let settled = t.metrics()[0].baseline;
+        assert!(settled >= 0.0);
+
+        // Now a sustained strong response, far above the freeze ratio.
+        for i in 300..900 {
+            let hot: Vec<f64> = (0..32)
+                .map(|sc| if sc < 8 { 10.0 + if i % 2 == 0 { 6.0 } else { -6.0 } } else { 10.0 })
+                .collect();
+            t.observe(0, [1, 2, 3, 4, 5, 6], &hot, -60, -92,
+                      now + Duration::from_millis(i * 50));
+        }
+        let m = &t.metrics()[0];
+        assert!(m.raw_motion > settled * BASELINE_FREEZE_RATIO,
+            "test setup: response must exceed the freeze ratio");
+        assert!(m.baseline <= settled * BASELINE_FREEZE_RATIO,
+            "baseline must not chase a sustained response              (settled {settled}, now {})", m.baseline);
+        assert!(m.motion > 0.0,
+            "a sustained responder must still report motion, not decay to zero");
+    }
+
+    #[test]
+    fn table_admits_more_links_than_a_nine_node_mesh_needs() {
+        // Nine receivers x (8 peers + AP) = 81 links minimum. The old cap of
+        // 64 admitted first-come and silently dropped the rest.
+        let now = Instant::now();
+        let mut t = LinkTable::new();
+        let amp = vec![10.0f64; 16];
+        for rx in 0..9u8 {
+            for tx in 0..9u8 {
+                if rx == tx { continue; }
+                let mac = [0xE8, 0xF6, 0x0A, 0, 0, tx];
+                for i in 0..MIN_FRAMES_FOR_METRIC + 2 {
+                    t.observe(rx, mac, &amp, -70, -92,
+                              now + Duration::from_millis(i as u64 * 10));
+                }
+            }
+            let ap = [0x8C, 0x30, 0x66, 0, 0, 1];
+            for i in 0..MIN_FRAMES_FOR_METRIC + 2 {
+                t.observe(rx, ap, &amp, -70, -92, now + Duration::from_millis(i as u64 * 10));
+            }
+        }
+        assert_eq!(t.len(), 81, "all 81 nine-node links must be admitted");
+    }
+
+    // ---- per-link subcarrier-grid policy -----------------------------------
+
+    /// The bug this replaced: the gate was keyed by NODE, so whichever grid the
+    /// associated AP used locked out every other transmitter. Two transmitters
+    /// on the SAME receiver must be able to hold different grids at once.
+    #[test]
+    fn two_transmitters_on_one_receiver_keep_independent_grids() {
+        let t0 = Instant::now();
+        let mut t = LinkTable::new();
+        for i in 0..12 {
+            let at = t0 + Duration::from_millis(i * 10);
+            t.observe(3, AP, &steady(256, 20.0), -70, -92, at);    // dense HE
+            t.observe(3, PEER, &steady(64, 20.0), -85, -92, at);   // sparse HT
+        }
+        let inv = t.inventory(t0 + Duration::from_millis(200));
+        let ap = inv.iter().find(|r| r.id.tx_mac == AP).expect("AP link");
+        let peer = inv.iter().find(|r| r.id.tx_mac == PEER).expect("peer link");
+        assert_eq!(ap.grid, 256, "AP locked to its own grid");
+        assert_eq!(peer.grid, 64, "peer keeps ITS grid, not the AP's");
+        assert_eq!(peer.history_len, 12, "sparse transmitter still accumulates");
+        assert_eq!(peer.sparser_skipped, 0);
+    }
+
+    /// A denser frame is more information, so it wins and the coarser history
+    /// is discarded rather than mixed — bins from different grids are not
+    /// comparable (issue #1005).
+    #[test]
+    fn a_denser_frame_upgrades_the_link_and_rewarms() {
+        let t0 = Instant::now();
+        let mut t = LinkTable::new();
+        for i in 0..10 {
+            t.observe(1, AP, &steady(64, 20.0), -70, -92, t0 + Duration::from_millis(i * 10));
+        }
+        t.observe(1, AP, &steady(256, 20.0), -70, -92, t0 + Duration::from_millis(200));
+        let inv = t.inventory(t0 + Duration::from_millis(210));
+        let r = &inv[0];
+        assert_eq!(r.grid, 256, "upgraded to the denser grid");
+        assert_eq!(r.history_len, 1, "coarse history cleared, not mixed");
+        assert_eq!(r.baseline_samples, 0, "baseline re-warms on upgrade");
+    }
+
+    /// A sparser frame must not enter the history, but the link is still real:
+    /// liveness and frame count keep moving, and the skip is COUNTED. A silent
+    /// drop is what hid every foreign transmitter until 2026-09-01.
+    #[test]
+    fn a_sparser_frame_is_counted_not_silently_dropped() {
+        let t0 = Instant::now();
+        let mut t = LinkTable::new();
+        for i in 0..10 {
+            t.observe(1, AP, &steady(256, 20.0), -70, -92, t0 + Duration::from_millis(i * 10));
+        }
+        t.observe(1, AP, &steady(64, 20.0), -70, -92, t0 + Duration::from_millis(200));
+        let inv = t.inventory(t0 + Duration::from_millis(210));
+        let r = &inv[0];
+        assert_eq!(r.grid, 256);
+        assert_eq!(r.history_len, 10, "sparser frame kept out of the history");
+        assert_eq!(r.sparser_skipped, 1, "and counted");
+        assert_eq!(r.frames, 11, "but it still counts as a frame on the link");
+    }
+
+    /// A uniform-grid history is what `agc_normalised_motion` wants, so after
+    /// the policy runs the link should actually be renderable.
+    #[test]
+    fn a_sparse_only_transmitter_becomes_visible() {
+        let t0 = Instant::now();
+        let mut t = LinkTable::new();
+        for i in 0..16 {
+            let level = 20.0 + (i % 5) as f64;
+            t.observe(2, PEER, &steady(64, level), -84, -92, t0 + Duration::from_millis(i * 10));
+        }
+        let inv = t.inventory(t0 + Duration::from_millis(200));
+        let r = &inv[0];
+        assert_eq!(r.grid, 64);
+        assert!(r.visible, "a 64-bin-only transmitter must render: {}", r.reason);
+    }
+}

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -21,6 +21,7 @@ mod mediatek_csi;
 mod qualcomm_csi;
 mod realtek_radar;
 mod path_safety;
+mod links;
 pub mod pose;
 pub mod pose_physics;
 mod rvf_container;
@@ -2020,6 +2021,7 @@ struct AppStateInner {
     room_debounced_level: String,
     room_debounce_candidate: String,
     room_debounce_since: Option<std::time::Instant>,
+    link_table: links::LinkTable,
     // ── Accuracy sprint: Kalman tracker, multistatic fusion, eigenvalue counting ──
     /// Global Kalman-based pose tracker for stable person IDs and smoothed keypoints.
     pose_tracker: PoseTracker,
@@ -2295,6 +2297,7 @@ impl AppStateInner {
             room_debounced_level: "absent".to_string(),
             room_debounce_candidate: "absent".to_string(),
             room_debounce_since: None,
+            link_table: links::LinkTable::new(),
             pose_tracker: PoseTracker::new(),
             last_tracker_instant: None,
             multistatic_fuser: MultistaticFuser::new(),
@@ -7025,6 +7028,168 @@ async fn mesh_endpoint(State(state): State<SharedState>) -> Json<serde_json::Val
     }))
 }
 
+
+///
+/// MEASURED 2026-09-01: a node's radio produces CSI for ~24 transmitters, the
+/// node forwards ~20 of them, and `/api/v1/links` renders 3. The difference is
+/// `LinkTable::metrics`, a `filter_map` that drops any link without a motion
+/// value — silently, with no error, counter or log. Every existing endpoint
+/// therefore agreed the other transmitters did not exist.
+///
+/// This reports the table's actual contents so illuminator selection is made
+/// from data rather than inference. It also surfaces `MAX_LINKS` headroom: the
+/// admission check drops new links silently once full, which would be the same
+/// class of invisible failure one layer up.
+async fn links_inventory_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let s = state.read().await;
+    let now = std::time::Instant::now();
+    let inv = s.link_table.inventory(now);
+
+    let visible = inv.iter().filter(|r| r.visible).count();
+    let mut by_reason: std::collections::BTreeMap<&'static str, usize> =
+        std::collections::BTreeMap::new();
+    for r in &inv {
+        *by_reason.entry(r.reason).or_insert(0) += 1;
+    }
+    // Distinct transmitters across every receiver — the illuminator roster,
+    // as opposed to the link count, which counts each (rx, tx) pair.
+    let distinct_tx: std::collections::BTreeSet<[u8; 6]> =
+        inv.iter().map(|r| r.id.tx_mac).collect();
+
+    let rows: Vec<serde_json::Value> = inv
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "rx_node": r.id.rx_node,
+                "tx_mac": format!(
+                    "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                    r.id.tx_mac[0], r.id.tx_mac[1], r.id.tx_mac[2],
+                    r.id.tx_mac[3], r.id.tx_mac[4], r.id.tx_mac[5]
+                ),
+                // The locally-administered bit separates a virtual BSSID (an AP
+                // advertising several SSIDs) from a burned-in device address.
+                // Cheap, and it is the difference between "an access point" and
+                // "somebody's phone" without any vendor lookup.
+                "locally_administered": (r.id.tx_mac[0] & 0x02) != 0,
+                "frames": r.frames,
+                "rssi_dbm": r.rssi,
+                "history_len": r.history_len,
+                "widths": r.widths.iter()
+                    .map(|(w, c)| serde_json::json!({"subcarriers": w, "frames": c}))
+                    .collect::<Vec<_>>(),
+                "modal_width": r.modal_width,
+                "frames_at_modal": r.frames_at_modal,
+                "visible_in_links": r.visible,
+                "reason": r.reason,
+                "age_ms": r.age_ms,
+                "baseline_samples": r.baseline_samples,
+                "fps": r.fps,
+                "window_span_s": r.window_span_s,
+                "grid": r.grid,
+                "sparser_skipped": r.sparser_skipped,
+                "interval_s": r.interval_s,
+                "stale_after_s": r.stale_after_s,
+                "gap_resets": r.gap_resets,
+            })
+        })
+        .collect();
+
+    Json(serde_json::json!({
+        "links_total": inv.len(),
+        "links_visible": visible,
+        "links_hidden": inv.len() - visible,
+        "distinct_transmitters": distinct_tx.len(),
+        "max_links": links::MAX_LINKS,
+        "headroom": links::MAX_LINKS.saturating_sub(inv.len()),
+        "hidden_by_reason": by_reason,
+        "links": rows,
+        "note": "everything the link table holds; /api/v1/links shows only rows \
+                 with a computable motion metric"
+    }))
+}
+
+
+async fn links_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let s = state.read().await;
+
+    // Attribute each link's transmitter. A node that reports its own MAC in
+    // its sync packet (proto v2+) is known outright; the old hearing-set
+    // inference is kept only as a fallback for a node still on older
+    // firmware, since it cannot work once boards are more than a room apart.
+    let metrics = s.link_table.metrics();
+    let (receivers, heard_by) = links::hearing_index(&metrics);
+
+    let rows: Vec<serde_json::Value> = metrics
+        .iter()
+        .map(|m| {
+            // No node-MAC registry on this path, so attribution rests on
+            // the hearing-set heuristic, which `links` restricts to the
+            // case where nothing has reported a MAC yet.
+            let tx_node =
+                links::infer_transmitting_node(&m.id.tx_mac, &receivers, &heard_by);
+            serde_json::json!({
+                "rx_node": m.id.rx_node,
+                "tx_mac": format!(
+                    "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                    m.id.tx_mac[0], m.id.tx_mac[1], m.id.tx_mac[2],
+                    m.id.tx_mac[3], m.id.tx_mac[4], m.id.tx_mac[5]
+                ),
+                // Inferred, never measured — see `infer_node` above.
+                "tx_node_inferred": tx_node,
+                "kind": if tx_node.is_some() { "node" } else { "infrastructure" },
+                "label": m.id.label(),
+                "frames": m.frames,
+                "rssi_dbm": m.rssi,
+                // Reported per frame by the chip. ESP-IDF exposes no AGC gain
+                // field, so this is the only observable that can betray a gain
+                // step -- without it a drop in amplitude is ambiguous between
+                // attenuation and the receiver down-rating itself.
+                "noise_floor_dbm": m.noise,
+                "snr_db": m.rssi - m.noise,
+                "raw_motion": m.raw_motion,
+                "motion": m.motion,
+                // Both metrics above are statistics over a fixed 64-frame
+                // window, so they mean nothing without the window they were
+                // taken over. A link whose delivery collapses while its peers
+                // surge produces a large apparent `motion` from transport
+                // contention alone — that pattern accounted for 56% of
+                // above-threshold bins on the 2026-08-28 overnight baseline,
+                // including the night's largest excursions, with the room
+                // empty. Report the window so a consumer can reject the
+                // comparison instead of believing it.
+                "window_span_s": m.window_span_s,
+                "fps": m.fps,
+            })
+        })
+        .collect();
+
+    // The link-line estimate, computed and reported *alongside* the live
+    // position rather than replacing it. It has never been scored against
+    // ground truth, so promoting it to the dot on the strength of it being
+    // newer would be exactly the overclaim this repository forbids. Reporting
+    // both here lets a labelled walk record them together and settle it with
+    // numbers.
+
+    Json(serde_json::json!({
+        "links": rows,
+        "count": rows.len(),
+        // A v1-only fleet carries no transmitter address, so the table stays
+        // empty. Say so explicitly rather than letting an empty list read as
+        // "no motion anywhere".
+        "wire_v2_active": !rows.is_empty(),
+    }))
+}
+
+/// Build link-line observations from the current link table and solve for a
+/// position. `null` whenever the geometry or the data cannot support one — a
+/// missing node position, an unconfigured AP, too few usable links, or a
+/// baseline that has not converged.
+///
+/// Only links whose *both* endpoints have known coordinates can contribute. A
+/// link to an unidentified transmitter (a neighbour's router, a phone) is real
+/// signal but its geometry is unknown, so including it would inject an
+/// arbitrary line into the solve.
+
 async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
     let now = std::time::Instant::now();
@@ -7656,6 +7821,35 @@ async fn udp_receiver_task(
                     let mut s = state.write().await;
                     s.source = "esp32".to_string();
                     s.last_esp32_frame = Some(std::time::Instant::now());
+
+
+                    // ---- Per-link accumulation, BEFORE the per-node gate ----
+                    //
+                    // MEASURED 2026-09-01: the gate below is keyed by NODE and
+                    // locks onto the densest grid that node has seen, which the
+                    // associated AP sets at 256-bin HE. Because it `continue`s,
+                    // every 64-bin HT frame -- essentially every OTHER
+                    // transmitter in the building -- was discarded before it
+                    // could become a link. A node's radio produced CSI for 24
+                    // transmitters and the server admitted 10, all our own.
+                    //
+                    // A link is (receiver, transmitter), so grid consistency is
+                    // a per-LINK property, not a per-node one, and `LinkTable`
+                    // enforces it there. Running this first leaves a frame the
+                    // node-level feature path cannot use still available to the
+                    // link path, which can. The gate itself is unchanged.
+                    if let Some(tx) = frame.source_mac {
+                        let now = std::time::Instant::now();
+                        s.link_table.observe(
+                            frame.node_id,
+                            tx,
+                            &frame.amplitudes,
+                            frame.rssi,
+                            frame.noise_floor,
+                            now,
+                        );
+                        s.link_table.expire(now);
+                    }
 
                     // ── ADR-110 / issue #1005: per-node subcarrier-grid gate ──
                     // ESP32-C6 nodes interleave HE-SU 256-bin frames (~84%)
@@ -9496,6 +9690,7 @@ async fn main() {
     let mut node_positions_config: Vec<[f32; 3]> = Vec::new();
     let state: SharedState = Arc::new(RwLock::new(AppStateInner {
         latest_update: None,
+        link_table: links::LinkTable::new(),
         rssi_history: VecDeque::new(),
         frame_history: VecDeque::new(),
         tick: 0,
@@ -9825,6 +10020,8 @@ async fn main() {
         .route("/api/v1/rf/vendors/:vendor/events", post(ingest_vendor_events))
         // Per-node health endpoint
         .route("/api/v1/nodes", get(nodes_endpoint))
+        .route("/api/v1/links", get(links_endpoint))
+        .route("/api/v1/links/inventory", get(links_inventory_endpoint))
         // ADR-110 iter 29 — per-node mesh sync state for HTTP clients.
         .route("/api/v1/nodes/:id/sync", get(node_sync_endpoint))
         .route("/api/v1/mesh", get(mesh_endpoint))

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1449,9 +1449,78 @@ pub(crate) struct RoomNode {
     pub id: u8,
     pub x: f32,
     pub y: f32,
+    /// Height above the FIRST floor's surface, not above this node's own
+    /// floor. A node on the second storey at 1.2 m sits at z = elevation of
+    /// that floor + 1.2, so z stays a single global axis and distances between
+    /// nodes on different floors are just Euclidean.
     pub z: f32,
+    /// Which storey this node is on. `None` means the first floor, so configs
+    /// written before floors existed keep working unchanged.
+    ///
+    /// Redundant with `z` for geometry, and deliberately so: it is what the
+    /// Room Builder groups by and what walls are associated with. Deriving it
+    /// from `z` would guess wrong for a node mounted high on a stairwell.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub floor: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+}
+
+/// One storey of the building.
+///
+/// `level` is the storey number, 1 for the ground floor. `elevation_m` is the
+/// height of that storey's *floor surface* above the origin, so level 1 is
+/// 0.0 by definition and level 2 is roughly first-floor ceiling plus joist
+/// depth.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Floor {
+    pub level: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub elevation_m: f32,
+    /// Ceiling height above this storey's own floor surface (not above the
+    /// origin), because that is the number a person reads off a tape measure.
+    pub ceiling_m: f32,
+    /// Thickness of the structure between this storey's ceiling and the next
+    /// storey's floor surface: joists, subfloor, and any service void.
+    ///
+    /// Recorded so `elevation_m` can be DERIVED rather than measured. Nobody
+    /// can put a tape measure on the height of a second floor above a first
+    /// floor, but everyone can measure a ceiling and look up a joist depth.
+    /// Without it, siting a node meant arithmetic like "8 ft + 16 in + 20 in"
+    /// at every measurement, and arithmetic done nine times is arithmetic done
+    /// wrong at least once.
+    #[serde(default)]
+    pub subfloor_m: f32,
+}
+
+/// An interior or exterior wall segment, in plan view.
+///
+/// Walls are 2D segments plus a height rather than 3D solids: for RF purposes
+/// what matters is whether the straight line between two nodes crosses one,
+/// and a segment answers that with a cheap intersection test. Modelling
+/// thickness or openings would add cost to every link evaluation for accuracy
+/// the rest of the pipeline cannot yet use.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Wall {
+    /// Storey this wall belongs to. A wall only obstructs links whose
+    /// endpoints are on that storey; a floor slab is a different thing and is
+    /// implied by two nodes having different `floor` values.
+    pub level: i32,
+    pub x1: f32,
+    pub y1: f32,
+    pub x2: f32,
+    pub y2: f32,
+    /// Height above this storey's floor. Defaults to full height when absent —
+    /// a half-wall or a pony wall is the exception, not the rule.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height_m: Option<f32>,
+    /// Free text: "exterior", "interior", "glass", "brick". Not interpreted
+    /// yet. Recorded now because it is knowledge the person drawing the plan
+    /// has and will not have later, and attenuation per material is the
+    /// obvious next use of this data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
 }
 
 /// Room geometry (a simple rectangle) plus sensor node placements, as
@@ -1461,6 +1530,42 @@ pub(crate) struct RoomConfig {
     pub width_m: f32,
     pub depth_m: f32,
     pub nodes: Vec<RoomNode>,
+    /// The WiFi access point's position, same room-space meters/NW-origin
+    /// convention as `nodes`. Optional — `None` means not yet configured, not
+    /// "AP is at the origin". Needed for bistatic Doppler-geometry position
+    /// estimation (a link's Doppler shift decomposes into a 2D velocity
+    /// constraint only once both endpoints — AP and node — are known; see
+    /// `doppler_weighted_centroid`'s doc comment for why raw per-node Doppler
+    /// magnitude alone isn't full geometric triangulation). Deliberately a
+    /// single point, not a list: real position estimation needs one known,
+    /// fixed link endpoint per node, and supporting multiple candidate APs
+    /// would require knowing which AP each CSI frame's traffic actually came
+    /// from, which isn't tracked anywhere today. A house with more rooms is
+    /// future scope; this stays "one room, one AP, up to a few nodes."
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ap_position: Option<[f32; 3]>,
+    /// Storeys, ascending. Empty means a single implicit ground floor, which
+    /// is how every config written before this field existed behaves.
+    ///
+    /// ORIGIN: (0, 0, 0) is the north-west corner of the FIRST floor, at floor
+    /// level. x runs east, y runs south, z runs up. Every storey shares that
+    /// origin — the second floor is not re-zeroed — so a node's coordinates
+    /// mean the same thing regardless of which storey it is on, and a
+    /// through-floor distance is just Euclidean.
+    #[serde(default)]
+    pub floors: Vec<Floor>,
+    /// Wall segments in plan view, tagged by storey.
+    #[serde(default)]
+    pub walls: Vec<Wall>,
+    /// Which storey the access point is on. `None` means the first floor.
+    ///
+    /// `ap_position` already carries an absolute z, so this is not needed for
+    /// geometry. It exists so the Room Builder can show the AP's height the
+    /// way it was measured -- above its own floor -- rather than as a total
+    /// from the ground floor, and so the AP appears on the storey it is
+    /// actually on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ap_floor: Option<i32>,
 }
 
 /// Load persisted room config from `<data_dir>/room_config.json`.
@@ -1490,6 +1595,181 @@ pub(crate) fn save_room_config(data_dir: &std::path::Path, config: &RoomConfig) 
 mod room_config_tests {
     use super::*;
 
+    fn base() -> RoomConfig {
+        RoomConfig {
+            width_m: 13.4,
+            depth_m: 10.4,
+            nodes: Vec::new(),
+            ap_position: None,
+            ap_floor: None,
+            floors: Vec::new(),
+            walls: Vec::new(),
+        }
+    }
+
+    fn floor(level: i32, elevation_m: f32) -> Floor {
+        Floor { level, name: None, elevation_m, ceiling_m: 2.7, subfloor_m: 0.3 }
+    }
+
+    /// The whole coordinate system hangs off this. If floor 1 is allowed to
+    /// float, every node coordinate in the building is silently offset and
+    /// nothing downstream can detect it.
+    #[test]
+    fn first_floor_must_sit_at_the_origin() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.3)];
+        let err = validate_room_config(&c).unwrap_err();
+        assert!(err.contains("floor 1"), "{err}");
+
+        c.floors = vec![floor(1, 0.0)];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    /// A second storey below the first is a typo every time, and it would
+    /// invert every through-floor distance without erroring anywhere.
+    #[test]
+    fn storeys_must_ascend() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0), floor(2, -2.9)];
+        let err = validate_room_config(&c).unwrap_err();
+        assert!(err.contains("floor 2"), "{err}");
+
+        c.floors = vec![floor(1, 0.0), floor(2, 2.9)];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    #[test]
+    fn duplicate_floor_levels_are_rejected() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0), floor(1, 2.9)];
+        assert!(validate_room_config(&c).unwrap_err().contains("duplicate floor"));
+    }
+
+    #[test]
+    fn a_node_cannot_live_on_a_storey_that_does_not_exist() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0)];
+        c.nodes = vec![RoomNode {
+            id: 3, x: 1.0, y: 1.0, z: 3.5, floor: Some(2), label: None,
+        }];
+        assert!(validate_room_config(&c).unwrap_err().contains("undefined floor"));
+    }
+
+    /// Configs written before floors existed must keep loading and validating
+    /// unchanged — the fleet's own room_config.json is one of them.
+    #[test]
+    fn pre_floors_configs_remain_valid() {
+        let mut c = base();
+        c.nodes = vec![RoomNode {
+            id: 0, x: 1.2, y: 0.0, z: 0.56, floor: None, label: Some("front right".into()),
+        }];
+        assert!(c.floors.is_empty());
+        assert!(validate_room_config(&c).is_ok(), "no floors declared is still a valid room");
+    }
+
+    /// Zero-length walls make any segment-intersection test degenerate rather
+    /// than merely wrong, so they are rejected at the door.
+    #[test]
+    fn negative_subfloor_is_rejected() {
+        let mut c = base();
+        let mut f = floor(2, 3.0);
+        f.subfloor_m = -0.1;
+        c.floors = vec![floor(1, 0.0), f];
+        assert!(validate_room_config(&c).unwrap_err().contains("subfloor_m"));
+    }
+
+    /// A flat slab between storeys is legitimate (a concrete floor), so zero
+    /// must be allowed even though negative is not.
+    #[test]
+    fn zero_subfloor_is_allowed() {
+        let mut c = base();
+        let mut f = floor(2, 3.0);
+        f.subfloor_m = 0.0;
+        c.floors = vec![floor(1, 0.0), f];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    #[test]
+    fn ap_cannot_be_on_an_undeclared_floor() {
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0)];
+        c.ap_position = Some([2.0, 2.0, 2.2]);
+        c.ap_floor = Some(3);
+        assert!(validate_room_config(&c).unwrap_err().contains("ap_floor"));
+        c.ap_floor = Some(1);
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    /// Elevations are derived in the UI from ceiling + subfloor, so the
+    /// arithmetic that produces them has to survive a round trip intact --
+    /// otherwise every height on the upper storey silently shifts.
+    #[test]
+    fn ceiling_and_subfloor_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = base();
+        let mut f1 = floor(1, 0.0);
+        f1.ceiling_m = 2.44;   // 8 ft
+        f1.subfloor_m = 0.41;  // 16 in
+        let mut f2 = floor(2, 2.85);
+        f2.ceiling_m = 2.44;
+        f2.subfloor_m = 0.0;
+        c.floors = vec![f1, f2];
+        save_room_config(dir.path(), &c);
+        let loaded = load_room_config(dir.path());
+        assert!((loaded.floors[0].ceiling_m - 2.44).abs() < 1e-6);
+        assert!((loaded.floors[0].subfloor_m - 0.41).abs() < 1e-6);
+        // floor 2 sits at floor 1's ceiling plus its structure
+        let derived = loaded.floors[0].ceiling_m + loaded.floors[0].subfloor_m;
+        assert!((loaded.floors[1].elevation_m - derived).abs() < 1e-6,
+                "elevation must equal ceiling + subfloor of the storey below");
+    }
+
+    #[test]
+    fn zero_length_walls_are_rejected() {
+        let mut c = base();
+        c.walls = vec![Wall {
+            level: 1, x1: 2.0, y1: 2.0, x2: 2.0, y2: 2.0,
+            height_m: None, kind: None,
+        }];
+        assert!(validate_room_config(&c).unwrap_err().contains("zero length"));
+    }
+
+    #[test]
+    fn walls_round_trip_with_their_storey_and_kind() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0), floor(2, 2.9)];
+        c.walls = vec![
+            Wall { level: 1, x1: 0.0, y1: 0.0, x2: 5.0, y2: 0.0,
+                   height_m: None, kind: Some("exterior".into()) },
+            Wall { level: 2, x1: 0.0, y1: 3.0, x2: 4.0, y2: 3.0,
+                   height_m: Some(1.1), kind: Some("pony".into()) },
+        ];
+        save_room_config(dir.path(), &c);
+        let loaded = load_room_config(dir.path());
+        assert_eq!(loaded.walls.len(), 2);
+        assert_eq!(loaded.walls[1].level, 2, "storey survives the round trip");
+        assert_eq!(loaded.walls[1].height_m, Some(1.1));
+        assert_eq!(loaded.walls[0].kind.as_deref(), Some("exterior"));
+        assert_eq!(loaded.floors[1].elevation_m, 2.9);
+    }
+
+    #[test]
+    fn node_storey_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = base();
+        c.floors = vec![floor(1, 0.0), floor(2, 2.9)];
+        c.nodes = vec![RoomNode {
+            id: 7, x: 2.0, y: 3.0, z: 4.1, floor: Some(2), label: Some("landing".into()),
+        }];
+        save_room_config(dir.path(), &c);
+        let loaded = load_room_config(dir.path());
+        assert_eq!(loaded.nodes[0].floor, Some(2));
+        // z stays a single global axis: a second-floor node is above the
+        // storey's own elevation, not re-zeroed to it.
+        assert!(loaded.nodes[0].z > loaded.floors[1].elevation_m);
+    }
+
     #[test]
     fn load_missing_file_returns_default() {
         let dir = tempfile::tempdir().unwrap();
@@ -1515,9 +1795,13 @@ mod room_config_tests {
             width_m: 5.0,
             depth_m: 4.0,
             nodes: vec![
-                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, label: Some("front-right".into()) },
-                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, label: None },
+                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, floor: None, label: Some("front-right".into()) },
+                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, floor: None, label: None },
             ],
+            ap_position: Some([2.5, -1.0, 2.2]),
+            ap_floor: None,
+        floors: Vec::new(),
+        walls: Vec::new(),
         };
         save_room_config(dir.path(), &saved);
         let loaded = load_room_config(dir.path());
@@ -1534,9 +1818,13 @@ mod room_config_tests {
             width_m: 5.0,
             depth_m: 4.0,
             nodes: vec![
-                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, label: None },
-                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, label: None },
+                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, floor: None, label: None },
+                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, floor: None, label: None },
             ],
+            ap_position: None,
+            ap_floor: None,
+        floors: Vec::new(),
+        walls: Vec::new(),
         }
     }
 
@@ -10104,16 +10392,19 @@ async fn config_get_room(State(state): State<SharedState>) -> Json<serde_json::V
         .node_positions_config
         .iter()
         .map(|(&id, p)| {
-            let label = saved
-                .nodes
-                .iter()
-                .find(|n| n.id == id)
-                .and_then(|n| n.label.clone());
+            let saved_node = saved.nodes.iter().find(|n| n.id == id);
+            let label = saved_node.and_then(|n| n.label.clone());
+            // Storey is carried on the persisted config, not on the live
+            // position map, so it has to be looked up rather than derived --
+            // deriving it from z would guess wrong for a node mounted high on
+            // a stairwell.
+            let floor = saved_node.and_then(|n| n.floor);
             RoomNode {
                 id,
                 x: p[0],
                 y: p[1],
                 z: p[2],
+                floor,
                 label,
             }
         })
@@ -10122,6 +10413,21 @@ async fn config_get_room(State(state): State<SharedState>) -> Json<serde_json::V
         "width_m": saved.width_m,
         "depth_m": saved.depth_m,
         "nodes": nodes,
+        // Storeys, walls, and the AP's position and storey are pure geometry
+        // with no live counterpart in memory, so they are served straight from
+        // the persisted config.
+        //
+        // These were being saved correctly and never served, which looked
+        // exactly like "the setting will not stick": the round trip lost them
+        // on the way OUT, so the editor reopened with its defaults and an AP
+        // height was then shown as if measured from the ground floor.
+        //
+        // Any field added to RoomConfig has to be added here too -- this list
+        // is hand-maintained and will not complain when it falls behind.
+        "ap_position": saved.ap_position,
+        "floors": saved.floors,
+        "walls": saved.walls,
+        "ap_floor": saved.ap_floor,
     }))
 }
 
@@ -10150,6 +10456,102 @@ pub(crate) fn validate_room_config(config: &RoomConfig) -> Result<(), String> {
             return Err(format!("node {} has a non-finite coordinate", n.id));
         }
     }
+    if let Some([x, y, z]) = config.ap_position {
+        if !x.is_finite() || !y.is_finite() || !z.is_finite() {
+            return Err("ap_position has a non-finite coordinate".to_string());
+        }
+        // Deliberately no room-bounds check here (unlike nothing else checks
+        // node bounds either, but worth stating): a real AP is very often
+        // physically outside the sensed room (another floor, a hallway
+        // closet), and that's fine — ap_position only needs to be a real,
+        // finite point in the same coordinate frame, not inside width_m/depth_m.
+    }
+
+    // ── Storeys ──────────────────────────────────────────────────────────
+    let mut levels = std::collections::HashSet::new();
+    for f in &config.floors {
+        if !levels.insert(f.level) {
+            return Err(format!("duplicate floor level {}", f.level));
+        }
+        if !f.elevation_m.is_finite() || !f.ceiling_m.is_finite() {
+            return Err(format!("floor {} has a non-finite height", f.level));
+        }
+        if f.ceiling_m <= 0.0 {
+            return Err(format!("floor {} ceiling_m must be positive", f.level));
+        }
+        if !f.subfloor_m.is_finite() || f.subfloor_m < 0.0 {
+            return Err(format!(
+                "floor {} subfloor_m must be zero or positive",
+                f.level
+            ));
+        }
+        // Level 1 defines the origin, so it cannot float. Catching this here
+        // stops a plan whose every coordinate is silently offset.
+        if f.level == 1 && f.elevation_m != 0.0 {
+            return Err(
+                "floor 1 must have elevation_m = 0: the origin is the \
+                 north-west corner of the first floor, at floor level"
+                    .to_string(),
+            );
+        }
+    }
+    // Ascending storeys must ascend. A second floor below a first is a typo
+    // every time, and it would silently invert every through-floor distance.
+    let mut sorted: Vec<&Floor> = config.floors.iter().collect();
+    sorted.sort_by_key(|f| f.level);
+    for w in sorted.windows(2) {
+        if w[1].elevation_m <= w[0].elevation_m {
+            return Err(format!(
+                "floor {} is at or below floor {} ({} m vs {} m)",
+                w[1].level, w[0].level, w[1].elevation_m, w[0].elevation_m
+            ));
+        }
+    }
+
+    // A node may only sit on a storey that exists — but only once storeys are
+    // being used at all, so pre-floors configs stay valid.
+    if !config.floors.is_empty() {
+        for n in &config.nodes {
+            let lvl = n.floor.unwrap_or(1);
+            if !levels.contains(&lvl) {
+                return Err(format!("node {} is on undefined floor {}", n.id, lvl));
+            }
+        }
+    }
+
+    if !config.floors.is_empty() {
+        if let Some(lvl) = config.ap_floor {
+            if !levels.contains(&lvl) {
+                return Err(format!("ap_floor {lvl} is not a declared floor"));
+            }
+        }
+    }
+
+    // ── Walls ────────────────────────────────────────────────────────────
+    for (i, wall) in config.walls.iter().enumerate() {
+        if ![wall.x1, wall.y1, wall.x2, wall.y2]
+            .iter()
+            .all(|v| v.is_finite())
+        {
+            return Err(format!("wall {i} has a non-finite endpoint"));
+        }
+        // A zero-length wall is not a wall. It would also make any
+        // segment-intersection test degenerate rather than merely wrong.
+        let dx = wall.x2 - wall.x1;
+        let dy = wall.y2 - wall.y1;
+        if (dx * dx + dy * dy).sqrt() < 1e-3 {
+            return Err(format!("wall {i} has zero length"));
+        }
+        if let Some(h) = wall.height_m {
+            if !h.is_finite() || h <= 0.0 {
+                return Err(format!("wall {i} height_m must be positive"));
+            }
+        }
+        if !config.floors.is_empty() && !levels.contains(&wall.level) {
+            return Err(format!("wall {i} is on undefined floor {}", wall.level));
+        }
+    }
+
     Ok(())
 }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -45,7 +45,7 @@ use wifi_densepose_sensing_server::inference::{fuse_room, NodeInference, RoomInf
 use wifi_densepose_sensing_server::provenance::SourceState;
 
 use ruvector_mincut::{DynamicMinCut, MinCutBuilder};
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -1549,6 +1549,62 @@ pub(crate) struct Wall {
 
 /// Room geometry (a simple rectangle) plus sensor node placements, as
 /// defined via the Room Builder UI (`POST /api/v1/config/room`).
+/// A transmitter the fleet can hear, and what is known about where it is.
+///
+/// Deliberately separates "where" from "how sure", because for illumination
+/// those are different questions and conflating them is what makes a solver
+/// trust a guess as much as a tape measure. Four states are expressible:
+///
+/// - **surveyed** — `position` set, `uncertainty_m` zero or absent. Your own
+///   access points, the Powerwall gateway, anything you can walk to.
+/// - **approximate** — `position` set with a large `uncertainty_m`. A
+///   neighbour's router: you know which house, not which room.
+/// - **unknown** — `position` is `None`. Still useful: cross-receiver
+///   correlation learns which region a receiver group covers WITHOUT ever
+///   needing the transmitter's coordinates. Only the geometric/ellipsoid path
+///   requires a position.
+/// - **excluded** — `exclude` set, for a transmitter known to move. A mobile
+///   emitter is worse than none, because the association it teaches is only
+///   true while it stands still.
+///
+/// On why `uncertainty_m` is worth carrying rather than rounding away: an
+/// emitter's positional error matters in proportion to its DISTANCE. Fifteen
+/// metres of doubt about a router 60 m away is roughly 14 degrees of bearing,
+/// and error along the line of sight matters far less than error across it. A
+/// consumer can weight by `uncertainty_m / distance`; it cannot recover that
+/// from a bare coordinate.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Emitter {
+    /// Lower-case colon-separated MAC, matching `/api/v1/links` `tx_mac`.
+    pub mac: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Room coordinates, same frame as `nodes`. `None` means "position not
+    /// known", which is a first-class state here, not a missing field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<[f32; 3]>,
+    /// Which storey, when that is meaningful. A neighbour's house has none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub floor: Option<i32>,
+    /// Radius of doubt around `position`, metres. Absent or zero means
+    /// surveyed. Meaningless without a `position`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uncertainty_m: Option<f32>,
+    /// Admission state. Defaults to `pending`: a newly discovered transmitter
+    /// is NEVER trusted as a fixed illuminator just because it was heard.
+    ///
+    /// - `pending`  — seen, not yet judged. Usable for learned/fingerprint
+    ///   work, never as a fixed geometric focus.
+    /// - `approved` — observed stationary long enough to be trusted as a focus.
+    ///   Promotion is a decision, informed by measured stability, not an
+    ///   automatic consequence of being loud.
+    /// - `excluded` — known to move, or otherwise unwanted. A mobile emitter is
+    ///   worse than none: the association it teaches is only true while it
+    ///   stands still.
+    #[serde(default = "emitter_status_default")]
+    pub status: String,
+}
+
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub(crate) struct RoomConfig {
     pub width_m: f32,
@@ -1590,11 +1646,96 @@ pub(crate) struct RoomConfig {
     /// actually on.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ap_floor: Option<i32>,
+    /// Transmitters the fleet can hear, and what is known about each.
+    #[serde(default)]
+    pub emitters: Vec<Emitter>,
 }
 
 /// Load persisted room config from `<data_dir>/room_config.json`.
 /// Falls back to [`RoomConfig::default`] (empty room, no nodes) if the file
 /// is absent or malformed.
+/// Approved emitters that carry a position, keyed by MAC.
+///
+/// `pending` entries are deliberately excluded. Pending means "heard, not yet
+/// judged stationary", and a transmitter that moves teaches an association that
+/// is only true while it stands still — worse than having no illuminator at
+/// all. Promotion to `approved` is a decision, not a consequence of being loud.
+/// MACs marked `excluded`: known to move, or otherwise unwanted.
+///
+/// Enforced by refusing them at ingestion, so an excluded emitter leaves the
+/// link table, the fusion index and every consumer at once — and frees its
+/// slot. Without this, `excluded` only meant "not approved", which is
+/// indistinguishable from `pending` and quietly does nothing.
+pub(crate) fn excluded_emitter_macs(config: &RoomConfig) -> HashSet<[u8; 6]> {
+    config
+        .emitters
+        .iter()
+        .filter(|e| e.status == "excluded")
+        .filter_map(|e| parse_mac_str(&e.mac.to_ascii_lowercase()))
+        .collect()
+}
+
+pub(crate) fn approved_emitter_positions(
+    config: &RoomConfig,
+) -> HashMap<[u8; 6], [f32; 3]> {
+    let mut out = HashMap::new();
+    for e in &config.emitters {
+        if !EMITTER_FOCUS_STATUSES.contains(&e.status.as_str()) {
+            continue;
+        }
+        if let (Some(mac), Some(pos)) = (parse_mac_str(&e.mac.to_ascii_lowercase()), e.position) {
+            out.insert(mac, pos);
+        }
+    }
+    out
+}
+
+/// Newly discovered transmitters start unapproved. Being audible is not
+/// evidence of being stationary, and only a stationary emitter can serve as a
+/// fixed focus.
+pub(crate) fn emitter_status_default() -> String {
+    "pending".to_string()
+}
+
+/// The admission states an emitter may hold, in triage order.
+///
+/// Status answers "do I trust this thing to stay put"; `uncertainty_m` answers
+/// "how well do I know where it is". They are orthogonal everywhere except at
+/// the ends of the scale, which is why `surveyed` exists as its own state
+/// rather than being inferred from a zero uncertainty: it is the difference
+/// between "I measured this" and "I left the box empty".
+///
+/// - `excluded` — it moves. Refused at ingestion; leaves every consumer.
+/// - `pending`  — heard, shortlisted, not yet judged. Feeds position-free
+///   pattern-matching work but is never a geometric focus.
+/// - `approved` — trusted as fixed, position ESTIMATED. Needs a position and a
+///   non-zero `uncertainty_m`: a neighbour's router does not move, but you only
+///   know which house.
+/// - `surveyed` — trusted as fixed, position MEASURED. Needs a position and no
+///   uncertainty. Your own access point, a gateway you can put a tape on.
+pub(crate) const EMITTER_STATUSES: [&str; 4] =
+    ["excluded", "pending", "approved", "surveyed"];
+
+/// Statuses whose position may be used as a solver focus.
+pub(crate) const EMITTER_FOCUS_STATUSES: [&str; 2] = ["approved", "surveyed"];
+
+/// Parse `aa:bb:cc:dd:ee:ff` into six octets. `None` for anything else.
+pub(crate) fn parse_mac_str(s: &str) -> Option<[u8; 6]> {
+    let mut out = [0u8; 6];
+    let mut parts = s.split(':');
+    for slot in out.iter_mut() {
+        let p = parts.next()?;
+        if p.len() != 2 {
+            return None;
+        }
+        *slot = u8::from_str_radix(p, 16).ok()?;
+    }
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(out)
+}
+
 pub(crate) fn load_room_config(data_dir: &std::path::Path) -> RoomConfig {
     let path = data_dir.join("room_config.json");
     match std::fs::read_to_string(&path) {
@@ -1616,6 +1757,222 @@ pub(crate) fn save_room_config(data_dir: &std::path::Path, config: &RoomConfig) 
 }
 
 #[cfg(test)]
+
+    fn base() -> RoomConfig {
+        RoomConfig {
+            width_m: 13.4,
+            depth_m: 10.4,
+            nodes: Vec::new(),
+            ap_position: None,
+            ap_floor: None,
+            floors: Vec::new(),
+            walls: Vec::new(),
+            emitters: Vec::new(),
+        }
+    }
+
+    // ── Emitters ─────────────────────────────────────────────────────────
+
+    fn emitter(mac: &str) -> Emitter {
+        Emitter { mac: mac.into(), label: None, position: None,
+                  floor: None, uncertainty_m: None,
+                  status: emitter_status_default() }
+    }
+
+    #[test]
+    fn an_emitter_with_no_position_is_valid() {
+        // "I have no idea where this is" is a first-class state: cross-receiver
+        // correlation never needs the transmitter's coordinates, only the
+        // geometric path does.
+        let mut c = base();
+        c.emitters = vec![emitter("02:00:00:00:00:01")];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    #[test]
+    fn a_malformed_emitter_mac_is_rejected() {
+        let mut c = base();
+        for bad in ["02:00:00:00:00", "0200:00:00:00:01", "zz:00:00:00:00:01",
+                    "02:00:00:00:00:01:ff", "002:00:00:00:0:01"] {
+            c.emitters = vec![emitter(bad)];
+            assert!(validate_room_config(&c).is_err(), "accepted `{bad}`");
+        }
+        c.emitters = vec![emitter("02:00:00:00:00:01")];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    /// Two rows for one transmitter would let a later save silently win and
+    /// move an illuminator without anyone seeing it.
+    #[test]
+    fn duplicate_emitter_macs_are_rejected() {
+        let mut c = base();
+        c.emitters = vec![emitter("02:00:00:00:00:01"), emitter("02:00:00:00:00:01")];
+        assert!(validate_room_config(&c).unwrap_err().contains("duplicate emitter"));
+    }
+
+    /// Uncertainty describes a position. Left behind after the position was
+    /// cleared it describes nothing, so it is refused rather than carried.
+    #[test]
+    fn uncertainty_without_a_position_is_rejected() {
+        let mut c = base();
+        let mut e = emitter("02:00:00:00:00:01");
+        e.uncertainty_m = Some(15.0);
+        c.emitters = vec![e];
+        assert!(validate_room_config(&c).unwrap_err().contains("no position"));
+    }
+
+    /// The neighbour case: a position you only know to within a house.
+    #[test]
+    fn an_approximate_position_round_trips_with_its_uncertainty() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut c = base();
+        let mut neighbour_ap = emitter("02:00:00:00:00:02");
+        neighbour_ap.label = Some("neighbour AP".into());
+        neighbour_ap.position = Some([-30.0, 12.0, 3.0]);
+        neighbour_ap.uncertainty_m = Some(15.0);
+        let mut gateway = emitter("02:00:00:00:00:03");
+        gateway.label = Some("utility gateway".into());
+        gateway.position = Some([6.0, 5.0, -2.5]);
+        gateway.uncertainty_m = Some(0.5);
+        c.emitters = vec![neighbour_ap, gateway];
+        assert!(validate_room_config(&c).is_ok());
+
+        save_room_config(dir.path(), &c);
+        let loaded = load_room_config(dir.path());
+        assert_eq!(loaded.emitters.len(), 2);
+        assert_eq!(loaded.emitters[0].uncertainty_m, Some(15.0));
+        assert_eq!(loaded.emitters[1].position, Some([6.0, 5.0, -2.5]),
+                   "a basement emitter keeps its negative z");
+    }
+
+    #[test]
+    fn a_config_without_emitters_is_still_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("room_config.json"),
+            r#"{"width_m":13.4,"depth_m":10.4,"nodes":[]}"#).unwrap();
+        let loaded = load_room_config(dir.path());
+        assert!(loaded.emitters.is_empty());
+        assert!(validate_room_config(&loaded).is_ok());
+    }
+
+    #[test]
+    fn mac_parsing_accepts_exactly_six_octets() {
+        assert_eq!(parse_mac_str("02:00:00:00:00:03"),
+                   Some([0x02, 0x00, 0x00, 0x00, 0x00, 0x03]));
+        assert!(parse_mac_str("02:00:00:00:00").is_none());
+        assert!(parse_mac_str("").is_none());
+    }
+
+
+    /// A newly heard transmitter must never arrive pre-trusted. Being loud is
+    /// not evidence of standing still.
+    #[test]
+    fn a_new_emitter_defaults_to_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("room_config.json"),
+            r#"{"width_m":13.4,"depth_m":10.4,"nodes":[],
+                "emitters":[{"mac":"02:00:00:00:00:01"}]}"#).unwrap();
+        let loaded = load_room_config(dir.path());
+        assert_eq!(loaded.emitters[0].status, "pending",
+                   "an emitter with no status must not be trusted");
+        assert!(validate_room_config(&loaded).is_ok());
+    }
+
+    /// Approval asserts "this does not move", which is a claim about a PLACE.
+    /// Approving something unlocated would put an unpositioned focus into the
+    /// geometric path.
+    #[test]
+    fn approving_an_emitter_requires_a_position() {
+        let mut c = base();
+        let mut e = emitter("02:00:00:00:00:01");
+        e.status = "approved".into();
+        c.emitters = vec![e.clone()];
+        assert!(validate_room_config(&c).unwrap_err().contains("no position"));
+
+        e.position = Some([2.0, 3.0, 1.0]);
+        e.uncertainty_m = Some(2.0);   // approved == estimated, so it needs one
+        c.emitters = vec![e];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+    #[test]
+    fn an_unknown_emitter_status_is_rejected() {
+        let mut c = base();
+        let mut e = emitter("02:00:00:00:00:01");
+        e.status = "trusted".into();
+        c.emitters = vec![e];
+        assert!(validate_room_config(&c).unwrap_err().contains("unknown status"));
+    }
+
+    /// Excluding a mobile emitter must not require knowing where it is - the
+    /// whole point is that it has no stable position.
+    #[test]
+    fn excluding_an_emitter_needs_no_position() {
+        let mut c = base();
+        let mut e = emitter("02:00:00:00:00:01");
+        e.status = "excluded".into();
+        c.emitters = vec![e];
+        assert!(validate_room_config(&c).is_ok());
+    }
+
+
+
+    /// Only APPROVED emitters become solver foci. `pending` means "heard, not
+    /// yet judged stationary", and a transmitter that moves teaches an
+    /// association only true while it stands still.
+    #[test]
+    fn only_approved_emitters_become_foci() {
+        let mut c = base();
+        let mut pending = emitter("64:16:66:c7:8c:51");
+        pending.position = Some([3.0, 4.0, 2.4]);           // positioned but unjudged
+        let mut approved = emitter("02:00:00:00:00:03");
+        approved.position = Some([0.0, 7.92, -1.22]);
+        approved.uncertainty_m = Some(1.5);
+        approved.status = "approved".into();
+        let mut excluded = emitter("18:b4:30:b4:be:b7");
+        excluded.position = Some([1.0, 1.0, 1.0]);
+        excluded.status = "excluded".into();
+        c.emitters = vec![pending, approved, excluded];
+
+        let foci = approved_emitter_positions(&c);
+        assert_eq!(foci.len(), 1, "only the approved emitter is a focus");
+        let gateway_mac = parse_mac_str("02:00:00:00:00:03").unwrap();
+        assert_eq!(foci.get(&gateway_mac), Some(&[0.0f32, 7.92, -1.22]),
+                   "a basement emitter keeps its negative z as a focus");
+    }
+
+    /// An approved emitter with no position cannot be a focus. Validation
+    /// forbids that combination, but the table must not depend on it.
+    #[test]
+    fn an_approved_emitter_without_a_position_is_not_a_focus() {
+        let mut c = base();
+        let mut e = emitter("64:16:66:cb:36:db");
+        e.status = "approved".into();          // deliberately no position
+        c.emitters = vec![e];
+        assert!(approved_emitter_positions(&c).is_empty());
+    }
+
+
+    /// `excluded` must actually exclude. Before this it only meant "not
+    /// approved", which is indistinguishable from `pending` and did nothing.
+    #[test]
+    fn excluded_emitters_are_collected_for_refusal() {
+        let mut c = base();
+        let mut moving = emitter("aa:bb:cc:dd:ee:ff");
+        moving.status = "excluded".into();
+        let mut fixed = emitter("02:00:00:00:00:03");
+        fixed.position = Some([0.0, 7.92, -1.22]);
+        fixed.uncertainty_m = Some(1.5);
+        fixed.status = "approved".into();
+        c.emitters = vec![moving, fixed, emitter("64:16:66:c7:8c:51")];
+
+        let ex = excluded_emitter_macs(&c);
+        assert_eq!(ex.len(), 1, "only the excluded one");
+        assert!(ex.contains(&parse_mac_str("aa:bb:cc:dd:ee:ff").unwrap()));
+        // and the other two are untouched by exclusion
+        assert!(!ex.contains(&parse_mac_str("02:00:00:00:00:03").unwrap()));
+        assert!(!ex.contains(&parse_mac_str("64:16:66:c7:8c:51").unwrap()));
+    }
 mod room_config_tests {
     use super::*;
 
@@ -1626,6 +1983,7 @@ mod room_config_tests {
             nodes: Vec::new(),
             ap_position: None,
             ap_floor: None,
+            emitters: Vec::new(),
             floors: Vec::new(),
             walls: Vec::new(),
         }
@@ -1824,6 +2182,7 @@ mod room_config_tests {
             ],
             ap_position: Some([2.5, -1.0, 2.2]),
             ap_floor: None,
+            emitters: Vec::new(),
         floors: Vec::new(),
         walls: Vec::new(),
         };
@@ -1847,6 +2206,7 @@ mod room_config_tests {
             ],
             ap_position: None,
             ap_floor: None,
+            emitters: Vec::new(),
         floors: Vec::new(),
         walls: Vec::new(),
         }
@@ -2021,6 +2381,9 @@ struct AppStateInner {
     room_debounced_level: String,
     room_debounce_candidate: String,
     room_debounce_since: Option<std::time::Instant>,
+    /// MACs of emitters marked `excluded`, refreshed when the room config
+    /// changes. Held as a set so the ingestion check is a hash lookup.
+    excluded_emitters: HashSet<[u8; 6]>,
     link_table: links::LinkTable,
     // ── Accuracy sprint: Kalman tracker, multistatic fusion, eigenvalue counting ──
     /// Global Kalman-based pose tracker for stable person IDs and smoothed keypoints.
@@ -2297,6 +2660,7 @@ impl AppStateInner {
             room_debounced_level: "absent".to_string(),
             room_debounce_candidate: "absent".to_string(),
             room_debounce_since: None,
+            excluded_emitters: HashSet::new(),
             link_table: links::LinkTable::new(),
             pose_tracker: PoseTracker::new(),
             last_tracker_instant: None,
@@ -7839,6 +8203,14 @@ async fn udp_receiver_task(
                     // node-level feature path cannot use still available to the
                     // link path, which can. The gate itself is unchanged.
                     if let Some(tx) = frame.source_mac {
+                        // An emitter marked as moving is refused HERE rather than
+                        // filtered downstream, so it leaves the link table and
+                        // every consumer at once and stops occupying a slot.
+                        // Filtering later would keep teaching an association that
+                        // is only true while the transmitter stands still.
+                        if s.excluded_emitters.contains(&tx) {
+                            continue;
+                        }
                         let now = std::time::Instant::now();
                         s.link_table.observe(
                             frame.node_id,
@@ -9757,6 +10129,7 @@ async fn main() {
         room_debounced_level: "absent".to_string(),
         room_debounce_candidate: "absent".to_string(),
         room_debounce_since: None,
+        excluded_emitters: HashSet::new(),
         // Accuracy sprint
         pose_tracker: PoseTracker::new(),
         last_tracker_instant: None,
@@ -9819,6 +10192,22 @@ async fn main() {
         )
         .expect("default pose physics configuration is valid"),
     }));
+
+    // Seed the ingestion-time exclusion set from the persisted config.
+    //
+    // Without this, exclusions would apply only after someone re-saved the room
+    // config in the current process: a restart would silently start admitting
+    // every emitter the operator had already judged as moving, and nothing
+    // would report that it had happened.
+    {
+        let mut s = state.write().await;
+        let saved = load_room_config(&s.data_dir);
+        let excluded = excluded_emitter_macs(&saved);
+        if !excluded.is_empty() {
+            info!("refusing {} excluded emitter(s) at ingestion", excluded.len());
+        }
+        s.excluded_emitters = excluded;
+    }
 
     // Start background tasks from the resolved plan (issue #1004).
     //
@@ -10770,6 +11159,7 @@ async fn config_get_room(State(state): State<SharedState>) -> Json<serde_json::V
         "floors": saved.floors,
         "walls": saved.walls,
         "ap_floor": saved.ap_floor,
+        "emitters": saved.emitters,
     }))
 }
 
@@ -10894,6 +11284,83 @@ pub(crate) fn validate_room_config(config: &RoomConfig) -> Result<(), String> {
         }
     }
 
+    // A MAC may appear once. A duplicate is two different judgements about
+    // the same transmitter, and nothing downstream can choose between them.
+    let mut seen_macs = std::collections::HashSet::new();
+    for (i, e) in config.emitters.iter().enumerate() {
+        let mac = e.mac.to_ascii_lowercase();
+        if parse_mac_str(&mac).is_none() {
+            return Err(format!(
+                "emitter {i} has a malformed MAC `{}`; expected aa:bb:cc:dd:ee:ff",
+                e.mac
+            ));
+        }
+        // Two entries for one transmitter would let a later save silently win
+        // and quietly move an illuminator, which is exactly the class of
+        // invisible change this config exists to prevent.
+        if !seen_macs.insert(mac) {
+            return Err(format!("duplicate emitter MAC `{}`", e.mac));
+        }
+        if let Some([x, y, z]) = e.position {
+            if !x.is_finite() || !y.is_finite() || !z.is_finite() {
+                return Err(format!("emitter {i} has a non-finite coordinate"));
+            }
+        }
+        if let Some(u) = e.uncertainty_m {
+            if !u.is_finite() || u < 0.0 {
+                return Err(format!("emitter {i} uncertainty_m must be zero or positive"));
+            }
+            // An uncertainty with nothing to be uncertain about is a sign the
+            // position was cleared and the doubt left behind. Reject it rather
+            // than carry a number that describes nothing.
+            if e.position.is_none() {
+                return Err(format!(
+                    "emitter {i} has uncertainty_m but no position; \
+                     an unknown position is expressed by omitting position entirely"
+                ));
+            }
+        }
+        if !EMITTER_STATUSES.contains(&e.status.as_str()) {
+            return Err(format!(
+                "emitter {i} has unknown status `{}`; expected one of {:?}",
+                e.status, EMITTER_STATUSES
+            ));
+        }
+        // Approval asserts "this thing does not move", which is a claim about a
+        // place. Approving an emitter whose position is unknown would put an
+        // unlocated focus into the geometric path.
+        if EMITTER_FOCUS_STATUSES.contains(&e.status.as_str()) && e.position.is_none() {
+            return Err(format!(
+                "emitter {i} is `{}` but has no position; that status means it is                  trusted as a fixed focus, which requires one",
+                e.status
+            ));
+        }
+        // `surveyed` claims the position was measured. Carrying a radius of
+        // doubt alongside that claim means one of the two is wrong, and a
+        // solver has no way to tell which — so the pair is refused rather than
+        // silently preferring one.
+        if e.status == "surveyed" && e.uncertainty_m.is_some_and(|u| u > 0.0) {
+            return Err(format!(
+                "emitter {i} is surveyed but carries uncertainty_m {}; a measured                  position has no radius of doubt — use `approved` for an estimate",
+                e.uncertainty_m.unwrap_or(0.0)
+            ));
+        }
+        // Conversely an approved (estimated) position without a stated doubt is
+        // indistinguishable from a surveyed one, and would be trusted as if
+        // measured.
+        if e.status == "approved" && !e.uncertainty_m.is_some_and(|u| u > 0.0) {
+            return Err(format!(
+                "emitter {i} is approved but states no uncertainty_m; an estimated                  position needs one — use `surveyed` if you measured it"
+            ));
+        }
+        if !config.floors.is_empty() {
+            if let Some(lvl) = e.floor {
+                if !levels.contains(&lvl) {
+                    return Err(format!("emitter {i} is on undefined floor {lvl}"));
+                }
+            }
+        }
+    }
     Ok(())
 }
 
@@ -10906,6 +11373,11 @@ async fn config_set_room(
     }
 
     let mut s = state.write().await;
+    // Refresh the ingestion-time exclusion set from the config just
+    // accepted. Without this the set stays empty and the check at
+    // ingestion is dead code -- excluded would once again mean nothing
+    // more than "not approved".
+    s.excluded_emitters = excluded_emitter_macs(&config);
     s.node_positions_config.clear();
     let max_id = config.nodes.iter().map(|n| n.id).max().unwrap_or(0);
     let mut positions = vec![[0.0f32, 0.0, 0.0]; max_id as usize + 1];

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1439,6 +1439,153 @@ pub(crate) fn save_runtime_config(data_dir: &std::path::Path, config: &RuntimeCo
     }
 }
 
+/// A single sensor node's position in room space, as placed via the Room
+/// Builder UI. `id` must match the node's provisioned `--node-id` on the
+/// physical board — it is not implied by array position, so nodes can be
+/// added/removed/reordered in the UI without breaking the id-to-position
+/// mapping (the same mapping issue #228/#249 was about).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RoomNode {
+    pub id: u8,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// Room geometry (a simple rectangle) plus sensor node placements, as
+/// defined via the Room Builder UI (`POST /api/v1/config/room`).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RoomConfig {
+    pub width_m: f32,
+    pub depth_m: f32,
+    pub nodes: Vec<RoomNode>,
+}
+
+/// Load persisted room config from `<data_dir>/room_config.json`.
+/// Falls back to [`RoomConfig::default`] (empty room, no nodes) if the file
+/// is absent or malformed.
+pub(crate) fn load_room_config(data_dir: &std::path::Path) -> RoomConfig {
+    let path = data_dir.join("room_config.json");
+    match std::fs::read_to_string(&path) {
+        Ok(json) => serde_json::from_str(&json).unwrap_or_default(),
+        Err(_) => RoomConfig::default(),
+    }
+}
+
+/// Persist room config to `<data_dir>/room_config.json`.
+pub(crate) fn save_room_config(data_dir: &std::path::Path, config: &RoomConfig) {
+    let path = data_dir.join("room_config.json");
+    if let Ok(json) = serde_json::to_string_pretty(config) {
+        if let Err(e) = std::fs::write(&path, json) {
+            warn!("Failed to save room config to {}: {e}", path.display());
+        } else {
+            info!("Room config saved to {}", path.display());
+        }
+    }
+}
+
+#[cfg(test)]
+mod room_config_tests {
+    use super::*;
+
+    #[test]
+    fn load_missing_file_returns_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = load_room_config(dir.path());
+        assert_eq!(cfg.width_m, 0.0);
+        assert_eq!(cfg.depth_m, 0.0);
+        assert!(cfg.nodes.is_empty());
+    }
+
+    #[test]
+    fn load_malformed_file_falls_back_to_default() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("room_config.json"), "{ not valid json").unwrap();
+        let cfg = load_room_config(dir.path());
+        assert_eq!(cfg.width_m, 0.0);
+        assert!(cfg.nodes.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let saved = RoomConfig {
+            width_m: 5.0,
+            depth_m: 4.0,
+            nodes: vec![
+                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, label: Some("front-right".into()) },
+                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, label: None },
+            ],
+        };
+        save_room_config(dir.path(), &saved);
+        let loaded = load_room_config(dir.path());
+        assert_eq!(loaded.width_m, 5.0);
+        assert_eq!(loaded.depth_m, 4.0);
+        assert_eq!(loaded.nodes.len(), 2);
+        assert_eq!(loaded.nodes[0].id, 0);
+        assert_eq!(loaded.nodes[0].label.as_deref(), Some("front-right"));
+        assert_eq!(loaded.nodes[1].label, None);
+    }
+
+    fn valid_config() -> RoomConfig {
+        RoomConfig {
+            width_m: 5.0,
+            depth_m: 4.0,
+            nodes: vec![
+                RoomNode { id: 0, x: 0.0, y: 0.0, z: 0.4, label: None },
+                RoomNode { id: 1, x: 3.66, y: 0.0, z: 0.4, label: None },
+            ],
+        }
+    }
+
+    #[test]
+    fn validate_accepts_a_sane_config() {
+        assert!(validate_room_config(&valid_config()).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_non_positive_width() {
+        let mut cfg = valid_config();
+        cfg.width_m = 0.0;
+        assert!(validate_room_config(&cfg).is_err());
+        cfg.width_m = -1.0;
+        assert!(validate_room_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_depth() {
+        let mut cfg = valid_config();
+        cfg.depth_m = f32::NAN;
+        assert!(validate_room_config(&cfg).is_err());
+        cfg.depth_m = f32::INFINITY;
+        assert!(validate_room_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_node_ids() {
+        let mut cfg = valid_config();
+        cfg.nodes[1].id = 0; // collide with nodes[0]
+        let err = validate_room_config(&cfg).unwrap_err();
+        assert!(err.contains("duplicate"), "unexpected error message: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_node_coordinate() {
+        let mut cfg = valid_config();
+        cfg.nodes[0].x = f32::NAN;
+        assert!(validate_room_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn validate_allows_empty_node_list() {
+        let mut cfg = valid_config();
+        cfg.nodes.clear();
+        assert!(validate_room_config(&cfg).is_ok());
+    }
+}
+
 /// Shared application state
 struct AppStateInner {
     latest_update: Option<SensingUpdate>,
@@ -9943,6 +10090,94 @@ async fn config_set_dedup_factor(
     Json(serde_json::json!({
         "status": "ok",
         "dedup_factor": clamped,
+    }))
+}
+
+/// `GET /api/v1/config/room` — read the current room geometry + node
+/// positions. Reflects live in-memory state (`node_positions_config`), not
+/// just whatever was last saved to disk, so a fresh page load in the Room
+/// Builder UI shows what the server is actually using right now.
+async fn config_get_room(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let s = state.read().await;
+    let saved = load_room_config(&s.data_dir);
+    let nodes: Vec<RoomNode> = s
+        .node_positions_config
+        .iter()
+        .map(|(&id, p)| {
+            let label = saved
+                .nodes
+                .iter()
+                .find(|n| n.id == id)
+                .and_then(|n| n.label.clone());
+            RoomNode {
+                id,
+                x: p[0],
+                y: p[1],
+                z: p[2],
+                label,
+            }
+        })
+        .collect();
+    Json(serde_json::json!({
+        "width_m": saved.width_m,
+        "depth_m": saved.depth_m,
+        "nodes": nodes,
+    }))
+}
+
+/// `POST /api/v1/config/room` — set room geometry + node positions from the
+/// Room Builder UI. Takes effect immediately (updates `node_positions_config`
+/// and the live `MultistaticFuser`, no restart needed) and persists to
+/// `<data_dir>/room_config.json` so it's picked up on the next launch too.
+///
+/// Body: a full `RoomConfig` (`{ "width_m", "depth_m", "nodes": [...] }`).
+/// Validate a `RoomConfig` submitted via `POST /api/v1/config/room`. Pure
+/// and side-effect-free so it's directly unit-testable without standing up
+/// a full `SharedState`/axum test harness.
+pub(crate) fn validate_room_config(config: &RoomConfig) -> Result<(), String> {
+    if !config.width_m.is_finite() || config.width_m <= 0.0 {
+        return Err("width_m must be a positive, finite number".to_string());
+    }
+    if !config.depth_m.is_finite() || config.depth_m <= 0.0 {
+        return Err("depth_m must be a positive, finite number".to_string());
+    }
+    let mut seen = std::collections::HashSet::new();
+    for n in &config.nodes {
+        if !seen.insert(n.id) {
+            return Err(format!("duplicate node id {}", n.id));
+        }
+        if !n.x.is_finite() || !n.y.is_finite() || !n.z.is_finite() {
+            return Err(format!("node {} has a non-finite coordinate", n.id));
+        }
+    }
+    Ok(())
+}
+
+async fn config_set_room(
+    State(state): State<SharedState>,
+    Json(config): Json<RoomConfig>,
+) -> Json<serde_json::Value> {
+    if let Err(e) = validate_room_config(&config) {
+        return Json(serde_json::json!({"error": e}));
+    }
+
+    let mut s = state.write().await;
+    s.node_positions_config.clear();
+    let max_id = config.nodes.iter().map(|n| n.id).max().unwrap_or(0);
+    let mut positions = vec![[0.0f32, 0.0, 0.0]; max_id as usize + 1];
+    for n in &config.nodes {
+        s.node_positions_config.insert(n.id, [n.x, n.y, n.z]);
+        positions[n.id as usize] = [n.x, n.y, n.z];
+    }
+    s.multistatic_fuser.set_node_positions(positions);
+    let data_dir = s.data_dir.clone();
+    drop(s);
+    save_room_config(&data_dir, &config);
+    Json(serde_json::json!({
+        "status": "ok",
+        "width_m": config.width_m,
+        "depth_m": config.depth_m,
+        "nodes": config.nodes,
     }))
 }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -307,6 +307,29 @@ struct Esp32Frame {
     /// while the node had a valid IEEE 802.15.4 mesh-time solution.
     adr018_flags: wifi_densepose_hardware::Adr018Flags,
     amplitudes: Vec<f64>,
+    /// 802.11 sequence control of the overheard frame — wire v3
+    /// (`CSI_MAGIC_V3`) only; `None` from v1/v2 firmware.
+    ///
+    /// This is the join key for cross-node fusion. `sequence` above is a
+    /// counter private to each node, so two nodes that captured the same
+    /// packet report unrelated values and nothing links them. `rx_seq` is
+    /// assigned by the transmitter, so every receiver of one transmission
+    /// reports the same number: `(source_mac, rx_seq)` names that
+    /// transmission fleet-wide with no coordination between receivers.
+    ///
+    /// Carries the raw 16-bit field. The low 4 bits are the fragment number;
+    /// mask to 12 bits (`>> 4`) for sequence-only semantics.
+    rx_seq: Option<u16>,
+    /// Transmitter (addr2) of the frame this CSI was sampled from — wire v2
+    /// (`CSI_MAGIC_V2`) only; `None` from v1 firmware.
+    ///
+    /// Without this the server cannot tell which link a frame describes. A
+    /// node in promiscuous MGMT+DATA mode with no `filter_mac` captures the
+    /// AP, its peer nodes, and unrelated household traffic into one
+    /// unlabelled sequence — measured 2026-08-28 at roughly 75% non-AP on a
+    /// normal home channel. Interleaving links with different geometry
+    /// corrupts any temporal statistic built from `frame_history`.
+    source_mac: Option<[u8; 6]>,
     phases: Vec<f64>,
 }
 
@@ -2634,15 +2657,56 @@ mod issue_928_magic_collision_tests {
 
 // ── ESP32 UDP frame parser ───────────────────────────────────────────────────
 
+/// Wire v1 CSI frame magic — 20-byte header, no transmitter identity.
+const CSI_MAGIC_V1: u32 = 0xC511_0001;
+/// Wire v2 CSI frame magic — v1 header plus a 6-byte transmitter MAC.
+///
+/// `0xC511_0002`..`0xC511_0007` were already taken by the vitals, feature and
+/// other edge packets (see `issue_928_magic_collision_tests` for why that
+/// matters), so v2 claims the next free value rather than an adjacent one.
+const CSI_MAGIC_V2: u32 = 0xC511_0008;
+/// Wire v3 CSI frame magic — v2 plus the 802.11 `rx_seq` at bytes 26..27.
+///
+/// `0xC511_0009` is the per-slot vitals packet, so v3 takes the next free
+/// value. See `issue_928_magic_collision_tests` for why adjacency is not
+/// assumed.
+const CSI_MAGIC_V3: u32 = 0xC511_000A;
+/// v1 header length; also the I/Q offset for a v1 frame.
+const CSI_HEADER_V1: usize = 20;
+/// v2 header length: v1 plus `source_mac` at bytes 20..25.
+const CSI_HEADER_V2: usize = 26;
+/// v3 header length: v2 plus `rx_seq` (u16 LE) at bytes 26..27.
+const CSI_HEADER_V3: usize = 28;
+
 fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
-    if buf.len() < 20 {
+    if buf.len() < CSI_HEADER_V1 {
         return None;
     }
 
     let magic = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
-    if magic != 0xC511_0001 {
-        return None;
-    }
+    // Both versions are accepted so a mixed fleet keeps working: a node
+    // running older firmware simply reports no transmitter identity.
+    let (iq_start, source_mac, rx_seq) = match magic {
+        CSI_MAGIC_V1 => (CSI_HEADER_V1, None, None),
+        CSI_MAGIC_V2 => {
+            if buf.len() < CSI_HEADER_V2 {
+                return None;
+            }
+            let mut mac = [0u8; 6];
+            mac.copy_from_slice(&buf[20..26]);
+            (CSI_HEADER_V2, Some(mac), None)
+        }
+        CSI_MAGIC_V3 => {
+            if buf.len() < CSI_HEADER_V3 {
+                return None;
+            }
+            let mut mac = [0u8; 6];
+            mac.copy_from_slice(&buf[20..26]);
+            let seq = u16::from_le_bytes([buf[26], buf[27]]);
+            (CSI_HEADER_V3, Some(mac), Some(seq))
+        }
+        _ => return None,
+    };
 
     // Frame layout (must match firmware csi_collector.c):
     //   [0..3]   magic (u32 LE)
@@ -2677,7 +2741,6 @@ fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
     let ppdu_type = wifi_densepose_hardware::PpduType::from_byte(buf[18]);
     let adr018_flags = wifi_densepose_hardware::Adr018Flags::from_byte(buf[19]);
 
-    let iq_start = 20;
     let n_pairs = n_antennas as usize * n_subcarriers as usize;
     let expected_len = iq_start + n_pairs * 2;
 
@@ -2706,9 +2769,85 @@ fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
         noise_floor,
         ppdu_type,
         adr018_flags,
+        source_mac,
+        rx_seq,
         amplitudes,
         phases,
     })
+}
+
+#[cfg(test)]
+mod csi_wire_v2_v3_tests {
+    //! The v2 and v3 match arms must be REACHABLE.
+    //!
+    //! `parse_esp32_frame` dispatches on the magic with
+    //! `match magic { CSI_MAGIC_V1 => .., CSI_MAGIC_V2 => .., CSI_MAGIC_V3 => .. }`.
+    //! Those are constant patterns only while the constants are in scope. If
+    //! `CSI_MAGIC_V1` is ever removed or renamed, the arm silently degrades
+    //! into an irrefutable BINDING that matches every value, the v2 and v3 arms
+    //! become dead code, and `source_mac` is `None` for every frame -- so every
+    //! per-transmitter consumer sees an empty world. rustc reports this as an
+    //! `unreachable_pattern` warning, not an error, and a release build prints
+    //! no warnings at all.
+    //!
+    //! These tests fail loudly in that case.
+    use super::*;
+
+    fn build(magic: u32, header: usize, n_subcarriers: u16) -> Vec<u8> {
+        let mut buf = vec![0u8; header + n_subcarriers as usize * 2];
+        buf[0..4].copy_from_slice(&magic.to_le_bytes());
+        buf[4] = 7; // node_id
+        buf[5] = 1; // n_antennas
+        buf[6..8].copy_from_slice(&n_subcarriers.to_le_bytes());
+        buf[8..12].copy_from_slice(&5180u32.to_le_bytes());
+        buf[12..16].copy_from_slice(&42u32.to_le_bytes());
+        buf[16] = (-40i8) as u8; // rssi
+        buf[17] = (-90i8) as u8; // noise_floor
+        buf[18] = 0; // ppdu_type
+        buf[19] = 0x10;
+        if header >= CSI_HEADER_V2 {
+            buf[20..26].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+        }
+        if header >= CSI_HEADER_V3 {
+            buf[26..28].copy_from_slice(&0x1234u16.to_le_bytes());
+        }
+        buf
+    }
+
+    #[test]
+    fn v1_frame_carries_no_transmitter_identity() {
+        let f = parse_esp32_frame(&build(CSI_MAGIC_V1, CSI_HEADER_V1, 64)).unwrap();
+        assert_eq!(f.source_mac, None);
+        assert_eq!(f.n_subcarriers, 64);
+    }
+
+    #[test]
+    fn v2_frame_yields_the_transmitter_mac() {
+        let f = parse_esp32_frame(&build(CSI_MAGIC_V2, CSI_HEADER_V2, 64)).unwrap();
+        assert_eq!(
+            f.source_mac,
+            Some([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
+            "v2 arm unreachable -- is CSI_MAGIC_V1 still a constant in scope?"
+        );
+    }
+
+    #[test]
+    fn v3_frame_yields_mac_and_rx_seq() {
+        let f = parse_esp32_frame(&build(CSI_MAGIC_V3, CSI_HEADER_V3, 64)).unwrap();
+        assert_eq!(f.source_mac, Some([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]));
+        assert_eq!(
+            f.rx_seq,
+            Some(0x1234),
+            "v3 arm unreachable -- is CSI_MAGIC_V1 still a constant in scope?"
+        );
+    }
+
+    #[test]
+    fn an_unknown_magic_is_still_rejected() {
+        // The catch-all must stay reachable too: if the V1 arm degrades into a
+        // binding, this returns Some and the server accepts arbitrary traffic.
+        assert!(parse_esp32_frame(&build(0xDEAD_BEEF, CSI_HEADER_V1, 64)).is_none());
+    }
 }
 
 #[cfg(test)]
@@ -3695,7 +3834,9 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
             adr018_flags: wifi_densepose_hardware::Adr018Flags::default(),
             amplitudes: multi_ap_frame.amplitudes.clone(),
             phases: multi_ap_frame.phases.clone(),
-        };
+                    source_mac: None,
+            rx_seq: None,
+};
 
         // ── Step 4b: Update frame history and extract features ───────
         let mut s_write_pre = state.write().await;
@@ -3884,7 +4025,9 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
         adr018_flags: wifi_densepose_hardware::Adr018Flags::default(),
         amplitudes: vec![signal_pct],
         phases: vec![0.0],
-    };
+            source_mac: None,
+        rx_seq: None,
+};
 
     let mut s = state.write().await;
     // Update frame history before extracting features.
@@ -4260,6 +4403,8 @@ fn generate_simulated_frame(tick: u64) -> Esp32Frame {
         adr018_flags: wifi_densepose_hardware::Adr018Flags::default(),
         amplitudes,
         phases,
+        source_mac: None,
+        rx_seq: None,
     }
 }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -11122,7 +11122,13 @@ async fn config_get_room(State(state): State<SharedState>) -> Json<serde_json::V
     let nodes: Vec<RoomNode> = s
         .node_positions_config
         .iter()
-        .map(|(&id, p)| {
+        .enumerate()
+        .map(|(idx, p)| {
+            // #1791 made node_positions_config a POSITIONAL Vec rather than a
+            // map keyed by node_id, so identity here is the list index. Kept
+            // consistent with that convention deliberately: the Room Builder
+            // must describe the same binding the fusion path actually uses.
+            let id = idx as u8;
             let saved_node = saved.nodes.iter().find(|n| n.id == id);
             let label = saved_node.and_then(|n| n.label.clone());
             // Storey is carried on the persisted config, not on the live
@@ -11378,13 +11384,12 @@ async fn config_set_room(
     // ingestion is dead code -- excluded would once again mean nothing
     // more than "not approved".
     s.excluded_emitters = excluded_emitter_macs(&config);
-    s.node_positions_config.clear();
     let max_id = config.nodes.iter().map(|n| n.id).max().unwrap_or(0);
     let mut positions = vec![[0.0f32, 0.0, 0.0]; max_id as usize + 1];
     for n in &config.nodes {
-        s.node_positions_config.insert(n.id, [n.x, n.y, n.z]);
         positions[n.id as usize] = [n.x, n.y, n.z];
     }
+    s.node_positions_config = positions.clone();
     s.multistatic_fuser.set_node_positions(positions);
     let data_dir = s.data_dir.clone();
     drop(s);


### PR DESCRIPTION
#1791 landed node_positions_config as a positional Vec<[f32;3]> keyed by
active-node rank, not the HashMap<u8,[f32;3]> the Room Builder handlers carried
in this stack, so they stopped compiling once rebased onto current main.

Read path enumerates and derives the id from the index, matching the convention
the fusion path uses. Write path builds the vector indexed BY node id before
assigning, so a sparse id set still lands each node in the right slot rather
than shifting everything after a gap.

---

**Stacked**, eight commits — it carries the Room Builder work and the per-link metrics as well as its own. Merge the earlier PRs in the stack first (#1822/#1824 room builder, #1828 links) and this shrinks accordingly.

Rebased onto current `main`. Conflicts were additive and resolved by keeping both sides; one real fix was needed because #1791 changed `node_positions_config` from a `HashMap<u8,[f32;3]>` to a positional `Vec`, which the Room Builder handlers in this stack were written against. 329 server tests pass.