### PR TITLE
feat(firmware): OTA tooling that verifies the node actually took the image

### DIFF
--- a/firmware/esp32-csi-node/fleet_ota.sh
+++ b/firmware/esp32-csi-node/fleet_ota.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Roll an OTA image across a fleet, ONE node at a time, verifying each before
+# touching the next.
+#
+# Sequential and fail-fast by design. A parallel push puts every node at risk
+# simultaneously, and a node that does not come back needs physical access --
+# so this stops at the first node that fails to verify rather than continuing
+# into a fleet-wide outage. The nodes it has not reached yet are left alone.
+#
+# Node addresses are discovered from the running server rather than hard-coded,
+# so this works on any fleet without editing the script.
+#
+# Usage:
+#   export RUVIEW_OTA_PSK_FILE=/path/to/ota_psk.txt
+#   ./fleet_ota.sh                                   # discover from the server
+#   ./fleet_ota.sh --nodes "0:10.0.0.5 1:10.0.0.6"   # or name them explicitly
+#
+# Options:
+#   --server URL     server to discover nodes from (default http://127.0.0.1:3000)
+#   --nodes "LIST"   explicit "id:ip id:ip ..." instead of discovery
+#   --bin PATH       image to push (default build/esp32-csi-node.bin)
+#   --version STR    version to verify against (default: contents of version.txt)
+#   --first ID       roll this node first; use a board you can recover
+#   --settle SECS    pause between nodes (default 20)
+set -u
+
+SERVER="http://127.0.0.1:3000"
+NODES=""
+BIN="build/esp32-csi-node.bin"
+VER=""
+FIRST=""
+SETTLE=20
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --server)  SERVER="$2"; shift 2 ;;
+    --nodes)   NODES="$2";  shift 2 ;;
+    --bin)     BIN="$2";    shift 2 ;;
+    --version) VER="$2";    shift 2 ;;
+    --first)   FIRST="$2";  shift 2 ;;
+    --settle)  SETTLE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,26p' "$0"; exit 0 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+cd "$(dirname "$0")"
+
+if [ -z "${RUVIEW_OTA_PSK_FILE:-}" ] || [ ! -f "$RUVIEW_OTA_PSK_FILE" ]; then
+  echo "set RUVIEW_OTA_PSK_FILE to the file holding the OTA PSK" >&2
+  echo "(a path, not the key itself -- an environment variable holding the key" >&2
+  echo " is visible in a process listing, and that key can replace firmware)" >&2
+  exit 2
+fi
+
+[ -z "$VER" ] && [ -f version.txt ] && VER="$(tr -d '\r\n' < version.txt)"
+if [ -z "$VER" ]; then
+  echo "no --version given and version.txt is missing or empty" >&2
+  exit 2
+fi
+if [ ! -f "$BIN" ]; then
+  echo "image not found: $BIN (build it first)" >&2
+  exit 2
+fi
+
+# Discover from the server unless the caller named the nodes. /api/v1/nodes
+# reports node_id and address for everything currently reporting, which is
+# exactly the set worth updating -- a node the server has never heard from
+# cannot be reached over the network anyway.
+if [ -z "$NODES" ]; then
+  NODES=$(python -c "
+import json,sys,urllib.request
+try:
+    d=json.load(urllib.request.urlopen('$SERVER/api/v1/nodes', timeout=10))
+except Exception as e:
+    sys.exit('could not reach $SERVER: %s' % e)
+ns=d.get('nodes', d) if isinstance(d, dict) else d
+out=[f\"{n['node_id']}:{n['ip']}\" for n in ns if n.get('ip')]
+if not out: sys.exit('server reported no nodes with an address')
+print(' '.join(sorted(out, key=lambda s: int(s.split(':')[0]))))
+") || exit 1
+  echo "discovered $(echo "$NODES" | wc -w) nodes from $SERVER"
+fi
+
+# Roll a recoverable board first when asked. If the image is bad, it lands
+# where it is cheapest to fix rather than on whichever node sorts lowest.
+if [ -n "$FIRST" ]; then
+  head=""; rest=""
+  for e in $NODES; do
+    case "$e" in "$FIRST":*) head="$e" ;; *) rest="$rest $e" ;; esac
+  done
+  [ -n "$head" ] && NODES="$head$rest"
+fi
+
+echo "rolling $VER from $BIN"
+ok=0; fail=0
+for entry in $NODES; do
+  id="${entry%%:*}"; ip="${entry##*:}"
+  echo "=============== node $id ($ip) ==============="
+  if python ota_push.py --node "$ip" --bin "$BIN" --expect-version "$VER"; then
+    ok=$((ok+1))
+    # Settle before the next node so a struggling board is not masked by the
+    # next upload competing for the same airtime.
+    sleep "$SETTLE"
+  else
+    fail=$((fail+1))
+    echo "ABORTING: node $id ($ip) did not verify. $ok done, $fail failed." >&2
+    echo "Remaining nodes were NOT touched." >&2
+    exit 1
+  fi
+done
+echo "fleet roll complete: $ok verified, $fail failed"

--- a/firmware/esp32-csi-node/ota_push.py
+++ b/firmware/esp32-csi-node/ota_push.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Push an OTA image to one CSI node and prove the node came up on it.
+
+The PSK is read from the file named by RUVIEW_OTA_PSK_FILE (or --psk-file) and
+never appears in argv or in output — an environment variable holding it would
+be visible in a process listing, and that key can replace firmware.
+
+Verification is the point of this script, not the upload. "OTA returned 200" is
+not evidence: /ota/status is polled until the node reports the EXPECTED version
+from a DIFFERENT partition than it started on. A version string that did not
+move means the update did not take, however healthy the response looked.
+
+Usage:
+  export RUVIEW_OTA_PSK_FILE=/path/to/ota_psk.txt
+  python ota_push.py --node <node-ip> --bin build/esp32-csi-node.bin \
+      --expect-version "$(cat version.txt)"
+"""
+import argparse, json, os, sys, time, urllib.error, urllib.request
+
+PORT = 8032
+
+
+def psk(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+def req(url, key, data=None, timeout=30, ctype="application/octet-stream"):
+    r = urllib.request.Request(url, data=data)
+    r.add_header("Authorization", "Bearer " + key)
+    if data is not None:
+        r.add_header("Content-Type", ctype)
+    with urllib.request.urlopen(r, timeout=timeout) as resp:
+        return resp.status, resp.read().decode("utf-8", "replace")
+
+
+def status(ip, key, timeout=10):
+    try:
+        _, body = req(f"http://{ip}:{PORT}/ota/status", key, timeout=timeout)
+        return json.loads(body)
+    except Exception as e:
+        return {"_error": str(e)}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--node", required=True)
+    ap.add_argument("--bin", required=True)
+    ap.add_argument("--expect-version", required=True)
+    ap.add_argument("--psk-file", default=os.environ.get("RUVIEW_OTA_PSK_FILE"))
+    ap.add_argument("--wait", type=int, default=180,
+                    help="seconds to wait for the node to return")
+    a = ap.parse_args()
+
+    if not a.psk_file or not os.path.isfile(a.psk_file):
+        print("no PSK file: pass --psk-file or set RUVIEW_OTA_PSK_FILE", file=sys.stderr)
+        return 2
+    key = psk(a.psk_file)
+
+    with open(a.bin, "rb") as f:
+        image = f.read()
+    if not image or image[0] != 0xE9:
+        print(f"refusing to push: {a.bin} does not start with 0xE9", file=sys.stderr)
+        return 2
+
+    before = status(a.node, key)
+    if "_error" in before:
+        print(f"{a.node}: unreachable before push: {before['_error']}", file=sys.stderr)
+        return 1
+    print(f"{a.node} BEFORE  version={before.get('version')!r} "
+          f"running={before.get('running_partition')!r} "
+          f"next={before.get('next_partition')!r}")
+
+    if before.get("version") == a.expect_version:
+        print(f"{a.node}: already on {a.expect_version}; nothing to do")
+        return 0
+
+    print(f"{a.node} pushing {len(image)} bytes ...")
+    t0 = time.time()
+    try:
+        code, body = req(f"http://{a.node}:{PORT}/ota", key, data=image, timeout=300)
+        print(f"{a.node} upload http {code} in {time.time()-t0:.0f}s: {body.strip()[:200]}")
+    except urllib.error.HTTPError as e:
+        print(f"{a.node} upload FAILED http {e.code}: {e.read()[:200]!r}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        # A node that reboots the instant it finishes writing can drop the
+        # response. That is not a failure by itself -- the version check below
+        # is what decides.
+        print(f"{a.node} upload connection ended: {e} (continuing to verify)")
+
+    deadline = time.time() + a.wait
+    last = None
+    while time.time() < deadline:
+        time.sleep(5)
+        s = status(a.node, key, timeout=5)
+        if "_error" not in s:
+            last = s
+            if s.get("version") == a.expect_version:
+                moved = s.get("running_partition") != before.get("running_partition")
+                print(f"{a.node} AFTER   version={s.get('version')!r} "
+                      f"running={s.get('running_partition')!r} "
+                      f"(partition changed: {moved})")
+                print(f"{a.node} VERIFIED on {a.expect_version} "
+                      f"after {time.time()-t0:.0f}s")
+                return 0
+    print(f"{a.node} NOT VERIFIED within {a.wait}s; last status={last}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two scripts for pushing firmware over the air to a fleet, both built around one
idea: "the OTA endpoint returned 200" is not evidence that anything changed.

ota_push.py pushes to one node and then polls /ota/status until the node
reports the EXPECTED version from a DIFFERENT partition than it started on. A
version string that did not move means the update did not take, however healthy
the response looked -- and a node that reboots the instant it finishes writing
can drop the HTTP response entirely, so the upload result alone cannot be
trusted either way. It also refuses to push a file that does not start with
0xE9 rather than discovering that after the write.

fleet_ota.sh rolls an image across the fleet ONE node at a time and stops at
the first node that fails to verify. Sequential and fail-fast is deliberate: a
parallel push puts every node at risk simultaneously, and a node that does not
come back needs physical access. On failure the nodes it has not reached are
left alone. --first lets you start with a board you can recover, so a bad image
lands where it is cheapest to fix.

Node addresses are discovered from /api/v1/nodes rather than hard-coded, so
this works on any fleet with no edits; --nodes overrides for a fleet the server
has not seen. The version defaults to the contents of version.txt so the check
cannot drift from what was built.

The PSK is taken from a FILE named by RUVIEW_OTA_PSK_FILE, never from argv or
an environment variable holding the key itself -- both are visible in a process
listing, and that key can replace firmware. Both scripts refuse to run without
it rather than falling back to something permissive.

---

Verified against a live nine-node fleet: discovery returns all nine from
`/api/v1/nodes` with nothing hard-coded, both guards fire (missing
`RUVIEW_OTA_PSK_FILE`, missing image), and `bash -n` is clean. The roll itself
was used to move nine boards through two firmware versions today, one node at a
time, with the verify step catching each before the next was touched.

No hard-coded addresses, paths, or versions remain in either file.
