### PR TITLE
fix(calibration): harden empty room bootstrap integrity

### DIFF
--- a/docs/adr/ADR-355-local-empty-room-bootstrap-prior.md
+++ b/docs/adr/ADR-355-local-empty-room-bootstrap-prior.md
@@ -54,6 +54,14 @@ evidence or numeric heart and breathing rates. Explicit calibration replaces
 it with fresh statistics. Cancelling an unfinished capture restores a valid
 prior. Administrator scoped reset removes it.
 
+A restored image may receive one operator confirmed held out empty refinement.
+The server measures 12 fresh, source bound runtime residuals at one second
+spacing and requires zero stale samples and zero numeric vital samples. It
+persists only the scalar residuals. The new boundary is the larger of the
+existing threshold and 110 percent of the held out 95th percentile, capped at
+125 percent of the prior threshold. The one use marker persists in the model,
+so repeated requests cannot ratchet the threshold upward.
+
 The status endpoint reports the learned runtime window, residual threshold,
 reference count, current background conformance, and the negative only
 authority boundary. A restored model never resumes collection and never
@@ -94,6 +102,9 @@ occupied sequences. Empty data is never relabeled as human training.
 7. `POST /api/v1/calibration/start?source_node_id=N` selects a live source for
    deterministic single link capture. A missing or stale selection fails
    without disabling the active bootstrap prior.
+8. `POST /api/v1/calibration/bootstrap/refine?confirmed_empty=true&source_node_id=N`
+   performs the bounded one time held out refinement. It requires administrator
+   authority when transport authentication is enabled.
 
 ## Measured installation evidence
 
@@ -118,3 +129,6 @@ vitals. Twelve fresh empty samples must contain no numeric vital signs.
 Starting a new room calibration must replace the prior and begin at frame zero.
 When several radios are live, selecting Node 5 must leave Nodes 3 and 7 out of
 the source set for the entire capture.
+After restart, a confirmed empty holdout may refine the restored boundary once.
+The stored snapshot must reject a second refinement and must continue to deny
+calibrated evidence and numeric vital authority.

--- a/docs/adr/ADR-355-local-empty-room-bootstrap-prior.md
+++ b/docs/adr/ADR-355-local-empty-room-bootstrap-prior.md
@@ -25,8 +25,10 @@ prior only after two server controlled stages:
 
 1. Normal calibration reaches both 1,000 accepted frames and 600 seconds.
    The frame target represents twenty complete fifty frame runtime windows.
-   Collection binds to the first accepted ESP32 source and rejects frames from
-   other radios for that single link model.
+   A caller may select one currently live ESP32 source. The server checks its
+   freshness before replacing an active bootstrap prior, binds collection to
+   that source, and rejects frames from other radios. When no source is
+   selected, the first accepted ESP32 source preserves legacy behavior.
 2. Promotion observes 12 new samples spaced by at least one second. Each
    sample has a four second bounded acquisition timeout. At least 10 must
    resolve empty, all ticks must be fresh, and none may publish numeric vital
@@ -89,6 +91,9 @@ occupied sequences. Empty data is never relabeled as human training.
    gate as `sensing_update`. When the bootstrap background matches, it emits
    absent state, zero people, null numeric rates, and an explicit abstention
    reason instead of forwarding raw edge candidates.
+7. `POST /api/v1/calibration/start?source_node_id=N` selects a live source for
+   deterministic single link capture. A missing or stale selection fails
+   without disabling the active bootstrap prior.
 
 ## Measured installation evidence
 
@@ -111,3 +116,5 @@ and data directory. Status must report `binding_mode=bootstrap_only`, zero
 collection frames, and false authority for calibrated evidence and numeric
 vitals. Twelve fresh empty samples must contain no numeric vital signs.
 Starting a new room calibration must replace the prior and begin at frame zero.
+When several radios are live, selecting Node 5 must leave Nodes 3 and 7 out of
+the source set for the entire capture.

--- a/docs/adr/ADR-356-rate-truthful-csi-and-reliability-gated-adaptation.md
+++ b/docs/adr/ADR-356-rate-truthful-csi-and-reliability-gated-adaptation.md
@@ -1,0 +1,151 @@
+# ADR 356: Rate truthful CSI and reliability gated room adaptation
+
+Status: Accepted
+
+Date: 2026-09-05
+
+## Context
+
+RuView mixed three different notions of time. ESP32 firmware requested a packet
+rate, the server observed a delivered rate, and several server paths still used
+fixed 2 Hz, 10 Hz, or 20 Hz assumptions. One feature named
+`dominant_freq_hz` was not a temporal frequency at all. It was the index of the
+strongest subcarrier multiplied by 0.05. A second defect compared a newly
+inserted frame with itself, forcing that motion delta to zero.
+
+These errors can move a spectral peak into the breathing or heartbeat band and
+produce plausible but false values. They also make models sensitive to WiFi
+traffic and processor scheduling rather than physical motion.
+
+ESP-IDF documents that `wifi_csi_info_t.first_word_invalid` marks the first four
+CSI bytes invalid because of a hardware limitation. It also documents that the
+CSI receive callback runs in the WiFi task and should hand work to a lower
+priority task rather than perform lengthy processing. RuView serialized the
+invalid bytes unchanged and fed the original buffer to edge processing.
+
+Recent work suggests four useful directions with different maturity:
+
+1. OpenCSI represents each link as a dimensionless residual against its own
+   quiet period temporal standard deviation and exposes baseline maturity. Its
+   reported transfer results are limited to binary presence.
+2. MORIC derives motion centered delay and Doppler views to reduce dependence
+   on static environment specific CSI structure.
+3. Parameter efficient CSI crowd counting combines self supervised pretraining,
+   small room adapters, and a stateful counting machine.
+4. WiFi JEPA masks complete radio links and predicts their latent embeddings,
+   using real and ray traced CSI for pose representation learning.
+
+The papers report promising external results. None is measured RuView evidence,
+and none authorizes deployment without leakage free occupied and empty held out
+evaluation.
+
+## Decision
+
+### Firmware ingestion
+
+1. When ESP-IDF marks the first CSI word invalid, zero the first four serialized
+   CSI bytes while retaining the fixed packet shape.
+2. Set ADR-018 byte 19 bit 5 to record that sanitation occurred.
+3. Feed edge DSP from the sanitized serialized payload, never the original
+   invalid driver buffer.
+4. Keep callback work bounded to sanitation, serialization, and the existing
+   queue handoff. Do not add transforms to the WiFi task.
+
+### Server time model
+
+1. Estimate delivered CSI rate from accepted monotonic frame timestamps after
+   five samples. Use 20 Hz only during startup.
+2. Cap the physical input rate at the firmware contract of 50 Hz so a burst or
+   timestamp artifact cannot retune downstream filters above their supported
+   range.
+3. Reconfigure the vital detector only after a 20 percent rate change. Clear
+   temporal and smoothing state whenever its clock changes. Samples calculated
+   with different clocks must never be blended.
+4. Compute temporal dominant frequency from the recent mean amplitude series
+   with demeaning, a Hann window, and bounded direct Fourier bins from 0.1 Hz to
+   the smaller of 4 Hz or 45 percent of sample rate.
+5. Return zero for short, flat, nonfinite, or spectrally ambiguous windows.
+6. Compare the current frame with the prior frame, not itself, for motion delta.
+7. Export zero sample rate until the estimate is mature. Never present a startup
+   fallback as a measured node property.
+
+### Model compatibility and room reliability
+
+1. Preserve the historical fifth input feature for version 1 adaptive models at
+   the model boundary. Version 2 and later models consume the true temporal
+   frequency. This prevents an existing model from silently receiving a
+   different input distribution after a server update.
+2. A background model is unreliable until it contains at least ten finite,
+   nonnegative residual references. An unreliable model cannot suppress a
+   runtime change and exposes no conformance score.
+3. Expose background maturity, reliability, and a robust residual Z score based
+   on the median and median absolute deviation.
+4. Keep the persisted empty home prior negative only. It cannot authorize
+   calibrated presence, person count, pose, or numeric vitals.
+
+### Model roadmap
+
+The following work remains proposal only:
+
+1. Evaluate an OpenCSI style per link quiet residual normalization for binary
+   presence without replacing absolute magnitude features used for motion.
+2. Evaluate delay and Doppler views after phase sanitation for activity.
+3. Pretrain a frozen multilink encoder and adapt small room specific modules for
+   counting.
+4. Evaluate link masked self supervision for pose only when at least three
+   spatially distinct links and synchronized positive pose labels exist.
+
+Every candidate uses immutable manifests and splits by room, subject,
+recording, and time. It is compared with the frozen baseline under identical
+seeds. Counting includes confusion matrices and mean absolute error. Pose
+includes PCK at 20 centimetres, MPJPE, and the mean pose baseline. A shuffled
+label control must fail.
+
+Promotion requires at least 10 percent held out lift, less than 10 milliseconds
+added p95 inference latency, no more than 20 percent peak memory overhead, zero
+leakage or secret findings, frozen anchor retention, and no regression in empty
+rejection or occupied recall. Promotion remains an explicit maintainer action.
+
+## Consequences
+
+The firmware no longer preserves a known invalid prefix as sensor evidence. The
+server uses an observed physical clock for spectral features and vital filters.
+Existing version 1 adaptive models remain compatible. Sparse background samples
+fail open to observation and fail closed for suppression.
+
+The direct Fourier estimator is intentionally small and bounded to 128 temporal
+samples. It is portable and deterministic, but it is not a replacement for a
+phase sanitized delay and Doppler pipeline.
+
+The largest remaining uncertainty is human recall. Empty home evidence can
+measure false presence but cannot show whether weak occupied signals are being
+suppressed. The fix path is a consented, leakage separated occupied holdout with
+multiple spatial links and synchronized reference labels.
+
+## Research basis
+
+1. Espressif ESP-IDF WiFi CSI programming guide:
+   https://docs.espressif.com/projects/esp-idf/en/v5.5.4/esp32/api-guides/wifi.html
+2. Espressif ESP CSI reference implementation:
+   https://github.com/espressif/esp-csi
+3. OpenCSI:
+   https://arxiv.org/abs/2607.26665
+4. MORIC:
+   https://arxiv.org/abs/2506.12997
+5. Parameter efficient CSI crowd counting:
+   https://arxiv.org/abs/2601.02203
+6. WiFi JEPA:
+   https://arxiv.org/abs/2607.11064
+
+## Acceptance test
+
+Run the firmware serializer host tests and the focused hardware, signal, and
+sensing server Rust suites. The deterministic serializer test must prove the
+first four bytes are zero only when ESP-IDF marks them invalid and bit 5 must
+round trip through the Rust parser. The temporal estimator must recover a
+1.2 Hz synthetic signal within 0.21 Hz, abstain on short and flat inputs, and
+remain below 10 milliseconds p95 on the target Mac. Existing version 1 model
+input must retain the legacy proxy. A background model with nine references
+must never report a match or suppress a runtime change. Physical firmware is
+not qualified until an S3 and C6 boot and stream the sanitized flag without
+watchdog, memory, or transport regressions during a five minute burn in.

--- a/docs/adr/ADR-357-raw-csi-calibration-sample-integrity.md
+++ b/docs/adr/ADR-357-raw-csi-calibration-sample-integrity.md
@@ -1,0 +1,89 @@
+# ADR 357: Raw CSI calibration sample integrity
+
+Status: Accepted
+
+Date: 2026-09-06
+
+## Context
+
+The empty room field model requires 1,000 accepted observations over at least
+600 seconds. The sensing server previously invoked calibration from both the
+raw CSI path and the one second edge vital path. Edge vital packets did not add
+a CSI observation, so that path repeatedly fed the existing history tail. A
+counter could therefore satisfy the frame gate without representing 1,000
+independent CSI packets.
+
+Node liveness also combined edge vital and CSI traffic. A source emitting only
+edge vital summaries could appear live enough to start calibration even though
+it had no fresh raw CSI. Finally, cloning the complete per node history before
+each feed copied as much as 204,800 bytes for a 100 frame, 256 subcarrier
+window even though calibration consumes only the current observation.
+
+The earlier single installation result recorded in ADR 355 predates this
+admission boundary. Its frame count is not accepted as evidence of independent
+CSI coverage. It remains useful only as diagnosis of the failure mode and must
+not be promoted as a production bootstrap prior.
+
+## Decision
+
+1. Only a grid admitted raw CSI packet may advance field calibration. Edge
+   vital packets update their own health and presentation state but never feed
+   the field model.
+2. Each calibration session stores the last admitted wrapping sequence for
+   every contributing node. Duplicate sequences are ignored. Normal forward
+   progress and the `u32::MAX` to zero wrap are accepted.
+3. A backward or ambiguous half range sequence latches that node as faulted for
+   the remainder of the session. Status exposes `sequence_fault_node_ids`, and
+   finalization returns `calibration_sequence_discontinuity`. The operator must
+   cancel and restart the empty room capture.
+4. A requested source may start calibration only when it has a grid admitted
+   raw CSI packet newer than five seconds. General node liveness is not enough.
+   The node endpoint reports both `csi_status` and `csi_last_seen_ms` so clients
+   can explain the gate before the operator begins.
+5. Start, cancel, reset, and process initialization clear sequence admission
+   state. A failed feed does not advance the sequence cursor, so the same
+   packet may be retried after a transient model input failure.
+6. The field bridge receives the current amplitude slice rather than a cloned
+   history. Canonical grid normalization remains unchanged.
+
+## Consequences
+
+Calibration frame count now means unique, forward raw CSI observations within
+one uninterrupted sequence epoch. A vitals only node cannot produce a
+bootstrap model.
+
+One legitimately reordered UDP packet invalidates a ten minute capture. This
+is an intentional fail closed tradeoff because the current wire format has no
+cryptographic boot epoch and cannot distinguish reordering from a device
+restart. A future firmware protocol may add a signed boot identifier and a
+bounded reordering window.
+
+No new raw CSI is persisted. Sequence cursors and fault markers remain bounded
+in memory to active calibration sources. The persisted bootstrap format and
+its negative only authority are unchanged.
+
+## Implementation
+
+1. `NodeState` records a separate accepted CSI arrival clock.
+2. `AppStateInner::maybe_feed_calibration_frame` owns source binding, sequence
+   ordering, fault latching, model feed, and cursor commit.
+3. `field_bridge::maybe_feed_calibration` accepts exactly one current amplitude
+   slice and rejects an empty observation.
+4. Calibration start, status, stop, cancel, reset, and node status expose and
+   enforce the new admission contract.
+
+## Acceptance test
+
+Unit tests must prove first packet acceptance, forward progress, duplicate
+rejection, source isolation, maximum counter wrap, empty input retry, backward
+sequence latching, half range rejection, session clear, status visibility, and
+typed stop refusal.
+
+On physical hardware, begin a Node 5 empty room capture and observe a fresh
+sixty second interval. Calibration frame growth must match unique grid admitted
+Node 5 CSI sequences. Edge vital packets alone must produce zero growth. The
+source must retain `csi_status=active`, sequence faults must remain empty, and
+numeric vital output must remain absent. Complete both the 1,000 frame and 600
+second gates, then run the twelve sample server controlled bootstrap holdout.
+Do not claim human detection improvement until a separate consented occupied
+holdout demonstrates retained recall.

--- a/docs/adr/ADR-357-raw-csi-calibration-sample-integrity.md
+++ b/docs/adr/ADR-357-raw-csi-calibration-sample-integrity.md
@@ -32,9 +32,13 @@ not be promoted as a production bootstrap prior.
 2. Each calibration session stores the last admitted wrapping sequence for
    every contributing node. Duplicate sequences are ignored. Normal forward
    progress and the `u32::MAX` to zero wrap are accepted.
-3. A backward or ambiguous half range sequence latches that node as faulted for
-   the remainder of the session. Status exposes `sequence_fault_node_ids`, and
-   finalization returns `calibration_sequence_discontinuity`. The operator must
+3. A packet one through four sequence values behind the current high water mark
+   is bounded UDP reordering. It is recorded and dropped without feeding the
+   model or moving the high water mark. A backward depth above four, or an
+   ambiguous half range sequence, latches that node as faulted for the remainder
+   of the session. Status exposes the policy, reorder window, per node reorder
+   count, maximum observed depth, and `sequence_fault_node_ids`. Finalization
+   returns `calibration_sequence_discontinuity` after a fault. The operator must
    cancel and restart the empty room capture.
 4. A requested source may start calibration only when it has a grid admitted
    raw CSI packet newer than five seconds. General node liveness is not enough.
@@ -52,13 +56,19 @@ not be promoted as a production bootstrap prior.
 
 Calibration frame count now means unique, forward raw CSI observations within
 one uninterrupted sequence epoch. A vitals only node cannot produce a
-bootstrap model.
+bootstrap model. Late packets never become calibration evidence.
 
-One legitimately reordered UDP packet invalidates a ten minute capture. This
-is an intentional fail closed tradeoff because the current wire format has no
-cryptographic boot epoch and cannot distinguish reordering from a device
-restart. A future firmware protocol may add a signed boot identifier and a
-bounded reordering window.
+A physical Node 5 capture observed sequence 4,119,566 followed by 4,119,563,
+4,119,564, and 4,119,565 in one receive batch, then normal forward progress.
+The window of four covers that measured depth of three with one frame of
+margin. At the firmware acceptance ceiling of 50 Hz, the window represents no
+more than 80 milliseconds. Larger regressions remain failed closed.
+
+The current wire format still has no authenticated boot epoch or stable device
+identity. A restart very early in a session or a same endpoint adversary cannot
+be distinguished cryptographically. A future ADR 018 revision must carry an
+authenticated device identifier and a random per boot identifier before the
+server claims exact restart or identity collision detection.
 
 No new raw CSI is persisted. Sequence cursors and fault markers remain bounded
 in memory to active calibration sources. The persisted bootstrap format and
@@ -77,15 +87,17 @@ its negative only authority are unchanged.
 ## Acceptance test
 
 Unit tests must prove first packet acceptance, forward progress, duplicate
-rejection, source isolation, maximum counter wrap, empty input retry, backward
-sequence latching, half range rejection, session clear, status visibility, and
-typed stop refusal.
+rejection, source isolation, maximum counter wrap, empty input retry, the
+measured depth three reorder pattern without a model feed, depth four
+acceptance, depth five latching, half range rejection, session clear, receipt
+visibility, and typed stop refusal.
 
 On physical hardware, begin a Node 5 empty room capture and observe a fresh
 sixty second interval. Calibration frame growth must match unique grid admitted
 Node 5 CSI sequences. Edge vital packets alone must produce zero growth. The
 source must retain `csi_status=active`, sequence faults must remain empty, and
-numeric vital output must remain absent. Complete both the 1,000 frame and 600
-second gates, then run the twelve sample server controlled bootstrap holdout.
-Do not claim human detection improvement until a separate consented occupied
-holdout demonstrates retained recall.
+numeric vital output must remain absent. Any bounded late packet must appear in
+the reorder receipts while leaving the model count unchanged. Complete both the
+1,000 frame and 600 second gates, then run the twelve sample server controlled
+bootstrap holdout. Do not claim human detection improvement until a separate
+consented occupied holdout demonstrates retained recall.

--- a/docs/adr/ADR-357-raw-csi-calibration-sample-integrity.md
+++ b/docs/adr/ADR-357-raw-csi-calibration-sample-integrity.md
@@ -39,7 +39,9 @@ not be promoted as a production bootstrap prior.
 4. A requested source may start calibration only when it has a grid admitted
    raw CSI packet newer than five seconds. General node liveness is not enough.
    The node endpoint reports both `csi_status` and `csi_last_seen_ms` so clients
-   can explain the gate before the operator begins.
+   can explain the gate before the operator begins. Calibration status reports
+   `last_sequence_by_node` so admission growth and sequence identity can be
+   observed atomically without exposing CSI values.
 5. Start, cancel, reset, and process initialization clear sequence admission
    state. A failed feed does not advance the sequence cursor, so the same
    packet may be retried after a transient model input failure.

--- a/docs/adr/ADR-357-raw-csi-calibration-sample-integrity.md
+++ b/docs/adr/ADR-357-raw-csi-calibration-sample-integrity.md
@@ -26,31 +26,49 @@ not be promoted as a production bootstrap prior.
 
 ## Decision
 
-1. Only a grid admitted raw CSI packet may advance field calibration. Edge
-   vital packets update their own health and presentation state but never feed
-   the field model.
+1. Only a packet on the frozen, model specific CSI grid may advance field
+   calibration. Edge vital packets update their own health and presentation
+   state but never feed the field model. The independent live inference grid
+   remains unchanged.
 2. Each calibration session stores the last admitted wrapping sequence for
    every contributing node. Duplicate sequences are ignored. Normal forward
    progress and the `u32::MAX` to zero wrap are accepted.
-3. A packet one through four sequence values behind the current high water mark
+3. A packet one through sixteen sequence values behind the current high water mark
    is bounded UDP reordering. It is recorded and dropped without feeding the
-   model or moving the high water mark. A backward depth above four, or an
+   model or moving the high water mark. A backward depth above sixteen, or an
    ambiguous half range sequence, latches that node as faulted for the remainder
    of the session. Status exposes the policy, reorder window, per node reorder
    count, maximum observed depth, and `sequence_fault_node_ids`. Finalization
    returns `calibration_sequence_discontinuity` after a fault. The operator must
    cancel and restart the empty room capture.
-4. A requested source may start calibration only when it has a grid admitted
-   raw CSI packet newer than five seconds. General node liveness is not enough.
-   The node endpoint reports both `csi_status` and `csi_last_seen_ms` so clients
-   can explain the gate before the operator begins. Calibration status reports
-   `last_sequence_by_node` so admission growth and sequence identity can be
-   observed atomically without exposing CSI values.
+4. A requested source may start calibration only after a header only, bounded
+   observation window identifies one stable grid. The selected grid needs at
+   least ten seconds of evidence, a measured rate of at least 2 Hz, a latest
+   sample newer than five seconds, and no observed gap of five seconds or more.
+   Calibration status reports the immutable grid, selection evidence, current
+   grid age, and `last_sequence_by_node` without exposing CSI values.
 5. Start, cancel, reset, and process initialization clear sequence admission
    state. A failed feed does not advance the sequence cursor, so the same
    packet may be retried after a transient model input failure.
 6. The field bridge receives the current amplitude slice rather than a cloned
-   history. Canonical grid normalization remains unchanged.
+   history. A separate bounded runtime history retains only that same frozen
+   grid, so the model is never trained on one symbol layout and evaluated on a
+   different layout. Canonical grid normalization remains unchanged.
+7. The exact source grid is stored inside the digest protected bootstrap v2
+   payload. A restored model rebuilds only its matching runtime history. An
+   unbound legacy image cannot become an active startup prior.
+8. Successful finalization clears the selected grid runtime history. Bootstrap
+   promotion waits up to 35 seconds for a complete fresh runtime window before
+   scoring twelve additional samples. This covers a 50 frame window at the 2 Hz
+   admission floor plus ten seconds of bounded jitter. Calibration observations
+   therefore cannot enter the held out decision window.
+9. Stop and promotion require the frozen grid to remain fresh and reject any
+   latched sequence fault immediately before persistence. Bootstrap v2 accepts
+   exactly one source node because the current runtime supports one grid bound
+   field model.
+10. The legacy `--calibrate` startup switch fails closed before opening ports.
+    Grid evidence does not exist at process start, so operators start the server,
+    wait ten seconds, then call the explicit single source calibration API.
 
 ## Consequences
 
@@ -58,11 +76,20 @@ Calibration frame count now means unique, forward raw CSI observations within
 one uninterrupted sequence epoch. A vitals only node cannot produce a
 bootstrap model. Late packets never become calibration evidence.
 
-A physical Node 5 capture observed sequence 4,119,566 followed by 4,119,563,
-4,119,564, and 4,119,565 in one receive batch, then normal forward progress.
-The window of four covers that measured depth of three with one frame of
-margin. At the firmware acceptance ceiling of 50 Hz, the window represents no
-more than 80 milliseconds. Larger regressions remain failed closed.
+One physical Node 5 capture observed sequence 4,119,566 followed by 4,119,563,
+4,119,564, and 4,119,565 in one receive batch. A second independent 90 second
+capture observed bounded late packets at depths 9, 10, and 11. The window of
+sixteen covers the measured maximum with five positions of margin. At the
+firmware acceptance ceiling of 50 Hz, the window represents no more than 320
+milliseconds. Late packets are always dropped. Larger regressions remain
+failed closed.
+
+The same 90 second capture measured three interleaved HT grids on Node 5. The
+64 subcarrier stream delivered 436 frames at 4.84 Hz with a 1.56 second maximum
+gap. The 128 stream delivered 100 frames at 1.11 Hz with a 5.05 second maximum
+gap. The 192 stream delivered 49 frames at 0.54 Hz with an 11.53 second maximum
+gap. Only the 64 grid exceeded the 2 Hz admission floor and stayed inside the
+five second freshness boundary, so the final field model binds to that grid.
 
 The current wire format still has no authenticated boot epoch or stable device
 identity. A restart very early in a session or a same endpoint adversary cannot
@@ -71,33 +98,46 @@ authenticated device identifier and a random per boot identifier before the
 server claims exact restart or identity collision detection.
 
 No new raw CSI is persisted. Sequence cursors and fault markers remain bounded
-in memory to active calibration sources. The persisted bootstrap format and
-its negative only authority are unchanged.
+in memory to active calibration sources. The bootstrap schema advances to v2
+to protect the grid identity while its negative only authority remains
+unchanged.
 
 ## Implementation
 
-1. `NodeState` records a separate accepted CSI arrival clock.
+1. `NodeState` records header only recent grid evidence and a separate bounded
+   field model history.
 2. `AppStateInner::maybe_feed_calibration_frame` owns source binding, sequence
    ordering, fault latching, model feed, and cursor commit.
 3. `field_bridge::maybe_feed_calibration` accepts exactly one current amplitude
    slice and rejects an empty observation.
-4. Calibration start, status, stop, cancel, reset, and node status expose and
-   enforce the new admission contract.
+4. Calibration start, status, stop, cancel, reset, promotion, refinement, and
+   restart enforce the frozen source and grid contract.
+5. `bootstrap_baseline` persists the source grid inside the verified v2 image.
+6. Finalization clears training history, and promotion blocks until the model
+   has a complete fresh scoring window plus twelve separately spaced samples.
+7. Startup calibration without measured grid evidence exits with a typed
+   operator instruction instead of creating a model that can never receive a
+   frame.
 
 ## Acceptance test
 
-Unit tests must prove first packet acceptance, forward progress, duplicate
-rejection, source isolation, maximum counter wrap, empty input retry, the
-measured depth three reorder pattern without a model feed, depth four
-acceptance, depth five latching, half range rejection, session clear, receipt
-visibility, and typed stop refusal.
+Unit tests must prove stable grid selection, rate and gap rejection, first
+packet acceptance, forward progress, duplicate rejection, source and grid
+isolation, maximum counter wrap, empty input retry, measured depth eleven
+reordering without a model feed, depth sixteen acceptance, depth seventeen
+latching, half range rejection, session clear, receipt visibility, protected
+grid persistence, and typed stop refusal.
+Tests must also prove startup flag refusal, missing and stale grid refusal,
+complete holdout isolation, and sequence fault rejection during holdout.
 
 On physical hardware, begin a Node 5 empty room capture and observe a fresh
-sixty second interval. Calibration frame growth must match unique grid admitted
-Node 5 CSI sequences. Edge vital packets alone must produce zero growth. The
-source must retain `csi_status=active`, sequence faults must remain empty, and
-numeric vital output must remain absent. Any bounded late packet must appear in
-the reorder receipts while leaving the model count unchanged. Complete both the
-1,000 frame and 600 second gates, then run the twelve sample server controlled
-bootstrap holdout. Do not claim human detection improvement until a separate
-consented occupied holdout demonstrates retained recall.
+sixty second interval. Calibration frame growth must match unique 64 subcarrier
+Node 5 sequences while the independent global inference grid remains unchanged.
+Edge vital packets and other grids must produce zero growth. The bound grid
+must remain active, sequence faults must remain empty, and numeric vital output
+must remain absent. Any bounded late packet must appear in the reorder receipts
+while leaving the model count unchanged. Complete both the 1,000 frame and 600
+second gates, then run the twelve sample server controlled bootstrap holdout.
+Restart and prove that only the persisted grid rebuilds the runtime history.
+Do not claim human detection improvement until a separate consented occupied
+holdout demonstrates retained recall.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -97,6 +97,7 @@ Statuses: **Proposed** (under discussion), **Accepted** (approved and/or impleme
 | [ADR-350](ADR-350-ruvector-predictive-memory-and-ruvllm-boundary.md) | RuVector predictive memory and RuVLLM authority boundary | Proposed |
 | [ADR-354](ADR-354-forecast-governance-enforcement-in-ruforecast-submodule.md) | fal.ai forecast governance and spend enforcement now real, in the vendored RuForecast submodule | Accepted |
 | [ADR-355](ADR-355-local-empty-room-bootstrap-prior.md) | Local empty room bootstrap prior | Accepted |
+| [ADR-356](ADR-356-rate-truthful-csi-and-reliability-gated-adaptation.md) | Rate truthful CSI and reliability gated room adaptation | Accepted |
 
 ### Platform and UI
 

--- a/firmware/esp32-csi-node/README.md
+++ b/firmware/esp32-csi-node/README.md
@@ -257,9 +257,16 @@ Offset  Size  Field
 12      4     Sequence number (LE u32)
 16      1     RSSI (i8)
 17      1     Noise floor (i8)
-18      2     Reserved
+18      1     PPDU type (ADR-110; zero when tagging is disabled)
+19      1     Flags: bit0=40 MHz, bit2=STBC, bit4=sync valid,
+              bit5=invalid first CSI word zeroed by firmware
 20      N*2   I/Q pairs (n_antennas * n_subcarriers * 2 bytes)
 ```
+
+When ESP-IDF marks `first_word_invalid`, the firmware preserves packet geometry,
+zeros the first four CSI bytes, and sets byte 19 bit 5. The same sanitized bytes
+feed the edge DSP path. This prevents a documented hardware artifact from being
+learned as motion while keeping older readers wire compatible.
 
 ### Vitals Packet (32 bytes)
 

--- a/firmware/esp32-csi-node/main/csi_collector.c
+++ b/firmware/esp32-csi-node/main/csi_collector.c
@@ -263,8 +263,16 @@ size_t csi_serialize_frame(const wifi_csi_info_t *info, uint8_t *buf, size_t buf
     buf[19] = 0;
 #endif
 
-    /* I/Q data */
+    /* I/Q data. ESP-IDF documents that the first four CSI bytes are invalid
+     * when first_word_invalid is set. Never let those hardware artifacts feed
+     * either the host or edge DSP path. Preserve the fixed ADR-018 geometry by
+     * zeroing rather than removing bytes, and mark the sanitation in bit 5. */
     memcpy(&buf[CSI_HEADER_SIZE], info->buf, iq_len);
+    if (info->first_word_invalid && iq_len > 0) {
+        size_t invalid_len = iq_len < 4 ? iq_len : 4;
+        memset(&buf[CSI_HEADER_SIZE], 0, invalid_len);
+        buf[19] |= CSI_FLAG_FIRST_WORD_SANITIZED;
+    }
 
     return frame_size;
 }
@@ -330,13 +338,16 @@ static void wifi_csi_callback(void *ctx, wifi_csi_info_t *info)
      * while the on-device Tier 1/2 pipeline receives a uniform, sustainable
      * stream. Enqueuing every burst frame overloaded the unicore C6 DSP and
      * turned 30-40 callback pps into an irregular approximately 8 Hz subset. */
-    if (info->buf && info->len > 0) {
+    if (frame_len > CSI_HEADER_SIZE) {
         if (s_next_edge_enqueue_us == 0) {
             s_next_edge_enqueue_us = now_us;
         }
 
         if (now_us >= s_next_edge_enqueue_us) {
-            (void)edge_enqueue_csi((const uint8_t *)info->buf, (uint16_t)info->len,
+            /* Reuse the sanitized ADR-018 payload. Feeding info->buf here
+             * would reintroduce first_word_invalid artifacts on device. */
+            (void)edge_enqueue_csi(&frame_buf[CSI_HEADER_SIZE],
+                                   (uint16_t)(frame_len - CSI_HEADER_SIZE),
                                    (int8_t)info->rx_ctrl.rssi, info->rx_ctrl.channel);
 
             /* Preserve the configured sample clock instead of resetting it to

--- a/firmware/esp32-csi-node/main/csi_collector.h
+++ b/firmware/esp32-csi-node/main/csi_collector.h
@@ -17,6 +17,9 @@
 /** ADR-018 header size in bytes. */
 #define CSI_HEADER_SIZE 20
 
+/** ADR-018 byte 19: ESP-IDF reported and firmware sanitized invalid CSI prefix. */
+#define CSI_FLAG_FIRST_WORD_SANITIZED (1U << 5)
+
 /** Maximum frame buffer size (header + 4 antennas * 256 subcarriers * 2 bytes). */
 #define CSI_MAX_FRAME_SIZE (CSI_HEADER_SIZE + 4 * 256 * 2)
 

--- a/firmware/esp32-csi-node/test/Makefile
+++ b/firmware/esp32-csi-node/test/Makefile
@@ -45,10 +45,20 @@ FUZZ_JOBS     ?= 1
 
 .PHONY: all clean run_serialize run_edge run_nvs run_all test_adr110 run_adr110 \
         test_vitals run_vitals test_mmwave_detect run_mmwave_detect host_tests \
-        test_thermal run_thermal
+        test_thermal run_thermal test_csi_sanitize run_csi_sanitize
 
 all: fuzz_serialize fuzz_edge fuzz_nvs test_adr110 test_vitals test_mmwave_detect \
-     test_thermal
+     test_thermal test_csi_sanitize
+
+# --- ESP-IDF invalid first-word sanitation ---
+# Links the production serializer. Function sections and dead stripping keep
+# unrelated device-only callback code out of this host executable.
+test_csi_sanitize: test_csi_sanitize.c $(MAIN_DIR)/csi_collector.c $(STUBS_SRC)
+	cc -std=c99 -Wall -Wextra -Istubs -I$(MAIN_DIR) -ffunction-sections \
+		$^ -Wl,-dead_strip -o $@ -lm
+
+run_csi_sanitize: test_csi_sanitize
+	./test_csi_sanitize
 
 # --- ADR-110 encoding unit tests ---
 # Host-side, no libFuzzer needed — plain C99 deterministic table tests
@@ -93,8 +103,8 @@ test_thermal: test_thermal_hysteresis.c $(MAIN_DIR)/thermal.h
 run_thermal: test_thermal
 	./test_thermal
 
-host_tests: run_adr110 run_vitals run_mmwave_detect run_thermal
-	@echo "Host tests passed (ADR-110 + vitals #998/#996 + mmwave detect #1135 + thermal)"
+host_tests: run_adr110 run_vitals run_mmwave_detect run_thermal run_csi_sanitize
+	@echo "Host tests passed (ADR-110 + CSI sanitation + vitals + mmwave + thermal)"
 
 # --- Serialize fuzzer ---
 # Tests csi_serialize_frame() with random wifi_csi_info_t inputs.
@@ -130,5 +140,6 @@ run_nvs: fuzz_nvs
 run_all: run_serialize run_edge run_nvs
 
 clean:
-	rm -f fuzz_serialize fuzz_edge fuzz_nvs test_adr110 test_vitals
+	rm -f fuzz_serialize fuzz_edge fuzz_nvs test_adr110 test_vitals test_mmwave_detect \
+		test_thermal test_csi_sanitize
 	rm -rf corpus_serialize/ corpus_edge/ corpus_nvs/

--- a/firmware/esp32-csi-node/test/Makefile
+++ b/firmware/esp32-csi-node/test/Makefile
@@ -39,6 +39,15 @@ CFLAGS   = -fsanitize=fuzzer,address,undefined -g -O1 \
 STUBS_SRC = stubs/esp_stubs.c
 MAIN_DIR  = ../main
 
+# GNU ld and Apple's ld spell dead section elimination differently.
+# Keep the host sanitation test portable across the Linux CI runner and macOS.
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+DEAD_STRIP_LDFLAGS := -Wl,-dead_strip
+else
+DEAD_STRIP_LDFLAGS := -Wl,--gc-sections
+endif
+
 # Default fuzz duration (seconds) and jobs
 FUZZ_DURATION ?= 30
 FUZZ_JOBS     ?= 1
@@ -55,7 +64,7 @@ all: fuzz_serialize fuzz_edge fuzz_nvs test_adr110 test_vitals test_mmwave_detec
 # unrelated device-only callback code out of this host executable.
 test_csi_sanitize: test_csi_sanitize.c $(MAIN_DIR)/csi_collector.c $(STUBS_SRC)
 	cc -std=c99 -Wall -Wextra -Istubs -I$(MAIN_DIR) -ffunction-sections \
-		$^ -Wl,-dead_strip -o $@ -lm
+		$^ $(DEAD_STRIP_LDFLAGS) -o $@ -lm
 
 run_csi_sanitize: test_csi_sanitize
 	./test_csi_sanitize

--- a/firmware/esp32-csi-node/test/fuzz_csi_serialize.c
+++ b/firmware/esp32-csi-node/test/fuzz_csi_serialize.c
@@ -90,6 +90,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     info.rx_ctrl.sig_mode      = legacy_inputs & 0x03;
     info.rx_ctrl.cwb           = (legacy_inputs >> 2) & 0x01;
     info.rx_ctrl.stbc          = (legacy_inputs >> 3) & 0x01;
+    info.first_word_invalid    = (test_case & 0x80) != 0;
 
     /* Use remaining fuzz data as I/Q buffer content. */
     uint16_t iq_len;
@@ -135,6 +136,17 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     /* Basic sanity: result must be 0 (error) or <= out_len. */
     if (result > out_len) {
         __builtin_trap();  /* Buffer overflow detected. */
+    }
+    if (result >= CSI_HEADER_SIZE + iq_len && info.first_word_invalid && iq_len > 0) {
+        size_t invalid_len = iq_len < 4 ? iq_len : 4;
+        for (size_t i = 0; i < invalid_len; i++) {
+            if (out_buf[CSI_HEADER_SIZE + i] != 0) {
+                __builtin_trap();  /* Invalid hardware prefix escaped sanitation. */
+            }
+        }
+        if ((out_buf[19] & CSI_FLAG_FIRST_WORD_SANITIZED) == 0) {
+            __builtin_trap();  /* Sanitized payload must carry provenance. */
+        }
     }
 
     /* --- Test case 1: NULL info pointer --- */

--- a/firmware/esp32-csi-node/test/stubs/esp_stubs.h
+++ b/firmware/esp32-csi-node/test/stubs/esp_stubs.h
@@ -90,6 +90,7 @@ typedef struct {
 typedef struct {
     wifi_pkt_rx_ctrl_t rx_ctrl;
     uint8_t            mac[6];
+    bool               first_word_invalid;
     int16_t            len;     /**< Length of the I/Q buffer in bytes. */
     int8_t            *buf;     /**< Pointer to I/Q data. */
 } wifi_csi_info_t;

--- a/firmware/esp32-csi-node/test/test_csi_sanitize.c
+++ b/firmware/esp32-csi-node/test/test_csi_sanitize.c
@@ -1,0 +1,56 @@
+/** Deterministic host test for ESP-IDF first_word_invalid sanitation. */
+
+#include "esp_stubs.h"
+#include "nvs_config.h"
+#include "csi_collector.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+nvs_config_t g_nvs_config;
+
+static void make_info(wifi_csi_info_t *info, int8_t *iq, uint16_t len, bool invalid)
+{
+    memset(info, 0, sizeof(*info));
+    info->rx_ctrl.channel = 6;
+    info->rx_ctrl.rssi = -42;
+    info->rx_ctrl.noise_floor = -91;
+    info->len = (int16_t)len;
+    info->buf = iq;
+    info->first_word_invalid = invalid;
+}
+
+int main(void)
+{
+    int8_t iq[] = {1, 2, 3, 4, 5, 6, 7, 8};
+    uint8_t frame[CSI_MAX_FRAME_SIZE];
+    wifi_csi_info_t info;
+
+    make_info(&info, iq, sizeof(iq), true);
+    size_t len = csi_serialize_frame(&info, frame, sizeof(frame));
+    assert(len == CSI_HEADER_SIZE + sizeof(iq));
+    assert(frame[CSI_HEADER_SIZE] == 0);
+    assert(frame[CSI_HEADER_SIZE + 1] == 0);
+    assert(frame[CSI_HEADER_SIZE + 2] == 0);
+    assert(frame[CSI_HEADER_SIZE + 3] == 0);
+    assert(frame[CSI_HEADER_SIZE + 4] == 5);
+    assert((frame[19] & CSI_FLAG_FIRST_WORD_SANITIZED) != 0);
+
+    make_info(&info, iq, sizeof(iq), false);
+    len = csi_serialize_frame(&info, frame, sizeof(frame));
+    assert(len == CSI_HEADER_SIZE + sizeof(iq));
+    assert(memcmp(&frame[CSI_HEADER_SIZE], iq, sizeof(iq)) == 0);
+    assert((frame[19] & CSI_FLAG_FIRST_WORD_SANITIZED) == 0);
+
+    int8_t short_iq[] = {9, 10};
+    make_info(&info, short_iq, sizeof(short_iq), true);
+    len = csi_serialize_frame(&info, frame, sizeof(frame));
+    assert(len == CSI_HEADER_SIZE + sizeof(short_iq));
+    assert(frame[CSI_HEADER_SIZE] == 0);
+    assert(frame[CSI_HEADER_SIZE + 1] == 0);
+    assert((frame[19] & CSI_FLAG_FIRST_WORD_SANITIZED) != 0);
+
+    puts("CSI invalid-prefix sanitation: PASS");
+    return 0;
+}

--- a/v2/crates/wifi-densepose-hardware/src/csi_frame.rs
+++ b/v2/crates/wifi-densepose-hardware/src/csi_frame.rs
@@ -145,13 +145,16 @@ impl PpduType {
 ///   bit 2   : STBC
 ///   bit 3   : LDPC (reserved — not yet populated by firmware)
 ///   bit 4   : 802.15.4 time-sync valid (C6 only)
-///   bit 5-7 : reserved
+///   bit 5   : ESP-IDF invalid first CSI word was zeroed by firmware
+///   bit 6-7 : reserved
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Adr018Flags {
     pub bw40: bool,
     pub stbc: bool,
     pub ldpc: bool,
     pub ieee802154_sync_valid: bool,
+    #[serde(default)]
+    pub first_word_sanitized: bool,
 }
 
 impl Adr018Flags {
@@ -161,6 +164,7 @@ impl Adr018Flags {
             stbc: (b & 0x04) != 0,
             ldpc: (b & 0x08) != 0,
             ieee802154_sync_valid: (b & 0x10) != 0,
+            first_word_sanitized: (b & 0x20) != 0,
         }
     }
     pub fn to_byte(self) -> u8 {
@@ -169,6 +173,7 @@ impl Adr018Flags {
         if self.stbc { b |= 0x04; }
         if self.ldpc { b |= 0x08; }
         if self.ieee802154_sync_valid { b |= 0x10; }
+        if self.first_word_sanitized { b |= 0x20; }
         b
     }
 }

--- a/v2/crates/wifi-densepose-hardware/src/esp32_parser.rs
+++ b/v2/crates/wifi-densepose-hardware/src/esp32_parser.rs
@@ -413,15 +413,16 @@ mod tests {
 
     #[test]
     fn adr110_flags_round_trip_all_bits() {
-        // All known flag bits set: bw40 (0x01) + STBC (0x04) + LDPC (0x08) + 15.4-sync (0x10) = 0x1D
-        let data = build_test_frame_with_he(6, 1, &[(0, 0); 56], 1, 0x1D);
+        // All known flag bits set: bw40 + STBC + LDPC + sync + sanitized prefix = 0x3D.
+        let data = build_test_frame_with_he(6, 1, &[(0, 0); 56], 1, 0x3D);
         let (frame, _) = Esp32CsiParser::parse_frame(&data).unwrap();
         assert!(frame.metadata.adr018_flags.bw40);
         assert!(frame.metadata.adr018_flags.stbc);
         assert!(frame.metadata.adr018_flags.ldpc);
         assert!(frame.metadata.adr018_flags.ieee802154_sync_valid);
+        assert!(frame.metadata.adr018_flags.first_word_sanitized);
         // Round-trip the encoder
-        assert_eq!(frame.metadata.adr018_flags.to_byte(), 0x1D);
+        assert_eq!(frame.metadata.adr018_flags.to_byte(), 0x3D);
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -139,6 +139,39 @@ pub fn features_from_runtime(feat: &serde_json::Value, amps: &[f64]) -> [f64; N_
     ]
 }
 
+/// Preserve the fifth feature's historical meaning for models trained before
+/// the server began measuring temporal frequency from a frame window.
+///
+/// Version 1 models learned a proxy equal to the strongest subcarrier index
+/// multiplied by 0.05. Version 2 and later models consume the measured
+/// temporal frequency in hertz. Keeping this translation at the model boundary
+/// prevents a server upgrade from silently changing an existing model's input
+/// distribution.
+pub fn compatible_dominant_frequency(
+    model_version: u32,
+    temporal_frequency_hz: f64,
+    amplitudes: &[f64],
+) -> f64 {
+    if model_version >= 2 {
+        return if temporal_frequency_hz.is_finite() {
+            temporal_frequency_hz.max(0.0)
+        } else {
+            0.0
+        };
+    }
+
+    amplitudes
+        .iter()
+        .enumerate()
+        .filter(|(_, amplitude)| amplitude.is_finite())
+        .max_by(|(_, left), (_, right)| {
+            left.partial_cmp(right)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|(index, _)| index as f64 * 0.05)
+        .unwrap_or(0.0)
+}
+
 /// Compute statistical features from raw subcarrier amplitudes.
 fn subcarrier_stats(amps: &[f64]) -> (f64, f64, f64, f64, f64, f64, f64, f64) {
     if amps.is_empty() {
@@ -641,4 +674,22 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
 /// Default path for the saved adaptive model.
 pub fn model_path() -> PathBuf {
     PathBuf::from("data/adaptive_model.json")
+}
+
+#[cfg(test)]
+mod compatibility_tests {
+    use super::compatible_dominant_frequency;
+
+    #[test]
+    fn version_one_keeps_legacy_subcarrier_proxy() {
+        let amplitudes = [1.0, 2.0, 8.0, 3.0];
+        assert_eq!(compatible_dominant_frequency(1, 1.25, &amplitudes), 0.10);
+    }
+
+    #[test]
+    fn version_two_uses_measured_temporal_frequency() {
+        let amplitudes = [1.0, 20.0, 2.0];
+        assert_eq!(compatible_dominant_frequency(2, 1.25, &amplitudes), 1.25);
+        assert_eq!(compatible_dominant_frequency(2, f64::NAN, &amplitudes), 0.0);
+    }
 }

--- a/v2/crates/wifi-densepose-sensing-server/src/bootstrap_baseline.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/bootstrap_baseline.rs
@@ -16,7 +16,7 @@ use wifi_densepose_signal::ruvsense::field_model::{
     FieldModel, FieldModelError, FieldModelSnapshotV1,
 };
 
-pub const BOOTSTRAP_BASELINE_SCHEMA: &str = "ruview.bootstrap-empty-field-model.v1";
+pub const BOOTSTRAP_BASELINE_SCHEMA: &str = "ruview.bootstrap-empty-field-model.v2";
 pub const BOOTSTRAP_BASELINE_AUTHORITY: &str = "bootstrap_only";
 pub const BOOTSTRAP_VALIDATION_SAMPLES: usize = 12;
 pub const BOOTSTRAP_VALIDATION_MIN_EMPTY: usize = 10;
@@ -24,13 +24,25 @@ pub const BOOTSTRAP_VALIDATION_MIN_SPACING_MS: u64 = 1_000;
 pub const BOOTSTRAP_VALIDATION_SAMPLE_TIMEOUT_MS: u64 = 4_000;
 const BOOTSTRAP_MAX_FILE_BYTES: u64 = 1_048_576;
 
+/// Exact CSI layout used to train the persisted empty room model.
+///
+/// Restoring code must require incoming frames to match this binding before
+/// the bootstrap image can influence inference.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BootstrapCsiGrid {
+    pub n_subcarriers: u16,
+    pub ppdu_type: u8,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-struct BootstrapPayloadV1 {
+struct BootstrapPayloadV2 {
     schema: String,
     authority: String,
     installation_binding_sha256: String,
     source_node_ids: Vec<u8>,
+    source_grid: BootstrapCsiGrid,
     source_model_id: String,
     created_at_unix_ms: u64,
     expires_at_unix_ms: u64,
@@ -39,14 +51,14 @@ struct BootstrapPayloadV1 {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-struct BootstrapImageV1 {
-    payload: BootstrapPayloadV1,
+struct BootstrapImageV2 {
+    payload: BootstrapPayloadV2,
     content_sha256: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct BootstrapImageRawV1 {
+struct BootstrapImageRawV2 {
     payload: Box<RawValue>,
     content_sha256: String,
 }
@@ -55,6 +67,7 @@ struct BootstrapImageRawV1 {
 pub struct BootstrapBaselineMetadata {
     pub authority: &'static str,
     pub source_node_ids: Vec<u8>,
+    pub source_grid: BootstrapCsiGrid,
     pub source_model_id: String,
     pub created_at_unix_ms: u64,
     pub expires_at_unix_ms: u64,
@@ -139,6 +152,7 @@ pub fn store(
     path: &Path,
     installation_id: &str,
     source_node_ids: &[u8],
+    source_grid: BootstrapCsiGrid,
     source_model_id: &str,
     created_at_unix_ms: u64,
     field_model: &FieldModel,
@@ -146,11 +160,12 @@ pub fn store(
     let snapshot = field_model.export_snapshot()?;
     let calibrated_at_ms = snapshot.modes.calibrated_at_us / 1_000;
     let expiry_ms = (snapshot.config.baseline_expiry_s * 1_000.0) as u64;
-    let payload = BootstrapPayloadV1 {
+    let payload = BootstrapPayloadV2 {
         schema: BOOTSTRAP_BASELINE_SCHEMA.to_string(),
         authority: BOOTSTRAP_BASELINE_AUTHORITY.to_string(),
         installation_binding_sha256: installation_binding(installation_id)?,
         source_node_ids: source_node_ids.to_vec(),
+        source_grid,
         source_model_id: source_model_id.to_string(),
         created_at_unix_ms,
         expires_at_unix_ms: calibrated_at_ms.saturating_add(expiry_ms),
@@ -158,7 +173,7 @@ pub fn store(
     };
     validate_payload(&payload, installation_id, created_at_unix_ms)?;
     let content_sha256 = payload_digest(&payload)?;
-    let image = BootstrapImageV1 {
+    let image = BootstrapImageV2 {
         payload,
         content_sha256,
     };
@@ -194,13 +209,13 @@ pub fn load(
     // Verify the exact payload bytes written by storage before decoding the
     // floating point model. Equivalent JSON number spellings may serialize
     // differently, so decode and reserialize is not an integrity contract.
-    let raw_image: BootstrapImageRawV1 = serde_json::from_slice(&bytes)?;
+    let raw_image: BootstrapImageRawV2 = serde_json::from_slice(&bytes)?;
     if hex_sha256(raw_image.payload.get().as_bytes()) != raw_image.content_sha256 {
         return Err(BootstrapBaselineError::DigestMismatch);
     }
-    let payload: BootstrapPayloadV1 = serde_json::from_str(raw_image.payload.get())?;
+    let payload: BootstrapPayloadV2 = serde_json::from_str(raw_image.payload.get())?;
     validate_payload(&payload, installation_id, current_unix_ms)?;
-    let image = BootstrapImageV1 {
+    let image = BootstrapImageV2 {
         payload,
         content_sha256: raw_image.content_sha256,
     };
@@ -226,7 +241,7 @@ pub fn remove(path: &Path) -> Result<bool, BootstrapBaselineError> {
 }
 
 fn validate_payload(
-    payload: &BootstrapPayloadV1,
+    payload: &BootstrapPayloadV2,
     installation_id: &str,
     current_unix_ms: u64,
 ) -> Result<(), BootstrapBaselineError> {
@@ -234,17 +249,14 @@ fn validate_payload(
         || payload.authority != BOOTSTRAP_BASELINE_AUTHORITY
         || payload.source_model_id.is_empty()
         || payload.source_model_id.len() > 128
-        || payload.source_node_ids.is_empty()
-        || payload.source_node_ids.len() > 16
-        || payload
-            .source_node_ids
-            .windows(2)
-            .any(|pair| pair[0] >= pair[1])
+        || payload.source_node_ids.len() != 1
+        || !(1..=2_048).contains(&payload.source_grid.n_subcarriers)
+        || payload.source_grid.ppdu_type > 3
         || payload.created_at_unix_ms == 0
         || payload.expires_at_unix_ms <= payload.created_at_unix_ms
     {
         return Err(BootstrapBaselineError::Malformed(
-            "invalid schema, authority, identity, node set, or lifetime".into(),
+            "invalid schema, authority, identity, node set, source grid, or lifetime".into(),
         ));
     }
     if payload.installation_binding_sha256 != installation_binding(installation_id)? {
@@ -256,14 +268,15 @@ fn validate_payload(
     Ok(())
 }
 
-fn payload_digest(payload: &BootstrapPayloadV1) -> Result<String, serde_json::Error> {
+fn payload_digest(payload: &BootstrapPayloadV2) -> Result<String, serde_json::Error> {
     Ok(hex_sha256(&serde_json::to_vec(payload)?))
 }
 
-fn metadata(image: &BootstrapImageV1) -> BootstrapBaselineMetadata {
+fn metadata(image: &BootstrapImageV2) -> BootstrapBaselineMetadata {
     BootstrapBaselineMetadata {
         authority: BOOTSTRAP_BASELINE_AUTHORITY,
         source_node_ids: image.payload.source_node_ids.clone(),
+        source_grid: image.payload.source_grid,
         source_model_id: image.payload.source_model_id.clone(),
         created_at_unix_ms: image.payload.created_at_unix_ms,
         expires_at_unix_ms: image.payload.expires_at_unix_ms,
@@ -315,6 +328,11 @@ mod tests {
     use super::*;
     use wifi_densepose_signal::ruvsense::field_model::FieldModelConfig;
 
+    const TEST_GRID: BootstrapCsiGrid = BootstrapCsiGrid {
+        n_subcarriers: 192,
+        ppdu_type: 2,
+    };
+
     fn completed_model(now_us: u64) -> FieldModel {
         let mut model = FieldModel::new(FieldModelConfig {
             n_links: 1,
@@ -340,10 +358,11 @@ mod tests {
         let path = path_in(dir.path());
         let now_ms = 1_000_000;
         let model = completed_model(now_ms * 1_000);
-        let stored = store(&path, "home-a", &[5], "model", now_ms, &model).unwrap();
+        let stored = store(&path, "home-a", &[5], TEST_GRID, "model", now_ms, &model).unwrap();
         let text = String::from_utf8(fs::read(&path).unwrap()).unwrap();
         assert!(!text.contains("home-a"));
         assert!(!text.contains("raw_csi"));
+        assert_eq!(stored.source_grid, TEST_GRID);
 
         let (restored, loaded) = load(&path, "home-a", now_ms + 1).unwrap();
         assert_eq!(stored, loaded);
@@ -363,18 +382,18 @@ mod tests {
         let path = path_in(dir.path());
         let now_ms = 1_000_000;
         let model = completed_model(now_ms * 1_000);
-        store(&path, "home-a", &[5], "model", now_ms, &model).unwrap();
+        store(&path, "home-a", &[5], TEST_GRID, "model", now_ms, &model).unwrap();
 
         let mut image: serde_json::Value =
             serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        image["payload"]["source_model_id"] = serde_json::json!("forged");
+        image["payload"]["source_grid"]["n_subcarriers"] = serde_json::json!(64);
         fs::write(&path, serde_json::to_vec(&image).unwrap()).unwrap();
         assert!(matches!(
             load(&path, "home-a", now_ms + 1),
             Err(BootstrapBaselineError::DigestMismatch)
         ));
 
-        store(&path, "home-a", &[5], "model", now_ms, &model).unwrap();
+        store(&path, "home-a", &[5], TEST_GRID, "model", now_ms, &model).unwrap();
         assert!(matches!(
             load(&path, "home-a", now_ms + 3_600_001),
             Err(BootstrapBaselineError::Expired)
@@ -385,12 +404,89 @@ mod tests {
     }
 
     #[test]
+    fn store_rejects_invalid_source_grid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = path_in(dir.path());
+        let now_ms = 1_000_000;
+        let model = completed_model(now_ms * 1_000);
+
+        for source_grid in [
+            BootstrapCsiGrid {
+                n_subcarriers: 0,
+                ppdu_type: 0,
+            },
+            BootstrapCsiGrid {
+                n_subcarriers: 2_049,
+                ppdu_type: 0,
+            },
+            BootstrapCsiGrid {
+                n_subcarriers: 192,
+                ppdu_type: 4,
+            },
+        ] {
+            assert!(matches!(
+                store(&path, "home-a", &[5], source_grid, "model", now_ms, &model,),
+                Err(BootstrapBaselineError::Malformed(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn store_requires_exactly_one_source_node() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = path_in(dir.path());
+        let now_ms = 1_000_000;
+        let model = completed_model(now_ms * 1_000);
+
+        for source_node_ids in [&[][..], &[5, 7][..]] {
+            assert!(matches!(
+                store(
+                    &path,
+                    "home-a",
+                    source_node_ids,
+                    TEST_GRID,
+                    "model",
+                    now_ms,
+                    &model,
+                ),
+                Err(BootstrapBaselineError::Malformed(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn source_grid_is_required_when_loading_a_v2_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = path_in(dir.path());
+        let now_ms = 1_000_000;
+        let model = completed_model(now_ms * 1_000);
+        store(&path, "home-a", &[5], TEST_GRID, "model", now_ms, &model).unwrap();
+
+        let mut image: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        image["payload"]
+            .as_object_mut()
+            .unwrap()
+            .remove("source_grid");
+        let payload = serde_json::to_vec(&image["payload"]).unwrap();
+        let rewritten = format!(
+            "{{\"payload\":{},\"content_sha256\":\"{}\"}}",
+            String::from_utf8(payload.clone()).unwrap(),
+            hex_sha256(&payload)
+        );
+        fs::write(&path, rewritten).unwrap();
+
+        assert!(matches!(
+            load(&path, "home-a", now_ms + 1),
+            Err(BootstrapBaselineError::Json(_))
+        ));
+    }
+
+    #[test]
     fn promotion_gate_requires_twelve_fresh_samples_and_zero_vitals() {
         assert_eq!(BOOTSTRAP_VALIDATION_MIN_SPACING_MS, 1_000);
         assert_eq!(BOOTSTRAP_VALIDATION_SAMPLE_TIMEOUT_MS, 4_000);
-        assert!(
-            BOOTSTRAP_VALIDATION_SAMPLE_TIMEOUT_MS >= BOOTSTRAP_VALIDATION_MIN_SPACING_MS
-        );
+        assert!(BOOTSTRAP_VALIDATION_SAMPLE_TIMEOUT_MS >= BOOTSTRAP_VALIDATION_MIN_SPACING_MS);
         let passing = vec![
             BootstrapValidationSample {
                 fresh_tick: true,
@@ -415,10 +511,10 @@ mod tests {
         let path = path_in(dir.path());
         let now_ms = 1_000_000;
         let model = completed_model(now_ms * 1_000);
-        store(&path, "home-a", &[5], "model", now_ms, &model).unwrap();
+        store(&path, "home-a", &[5], TEST_GRID, "model", now_ms, &model).unwrap();
 
         let original = fs::read_to_string(&path).unwrap();
-        let image: BootstrapImageRawV1 = serde_json::from_str(&original).unwrap();
+        let image: BootstrapImageRawV2 = serde_json::from_str(&original).unwrap();
         let rewritten_payload = image.payload.get().replacen(
             "\"min_calibration_duration_s\":0.0",
             "\"min_calibration_duration_s\":0.00",

--- a/v2/crates/wifi-densepose-sensing-server/src/csi.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/csi.rs
@@ -11,6 +11,141 @@ use crate::vital_signs::VitalSigns;
 
 const EDGE_MAX_PERSONS: u8 = 4;
 
+/// Estimate a real temporal motion frequency from recent CSI amplitude
+/// history. Each frame is reduced to its mean amplitude, detrended, Hann
+/// windowed, and evaluated on exact DFT bins.
+pub fn estimate_temporal_dominant_frequency_hz(
+    frame_history: &VecDeque<Vec<f64>>,
+    sample_rate_hz: f64,
+) -> f64 {
+    if !sample_rate_hz.is_finite() || sample_rate_hz <= 0.0 {
+        return 0.0;
+    }
+
+    let recent_frames: Vec<&Vec<f64>> = frame_history
+        .iter()
+        .rev()
+        .take(128)
+        .collect();
+    if recent_frames
+        .iter()
+        .any(|frame| frame.is_empty() || frame.iter().any(|value| !value.is_finite()))
+    {
+        return 0.0;
+    }
+    let samples: Vec<f64> = recent_frames
+        .into_iter()
+        .rev()
+        .map(|frame| frame.iter().sum::<f64>() / frame.len() as f64)
+        .collect();
+    let n = samples.len();
+    if n < 16 {
+        return 0.0;
+    }
+
+    let mean = samples.iter().sum::<f64>() / n as f64;
+    let upper_hz = 4.0_f64.min(sample_rate_hz * 0.45);
+    if upper_hz < 0.1 {
+        return 0.0;
+    }
+
+    let mut powers = Vec::new();
+    for bin in 1..=(n / 2) {
+        let frequency_hz = bin as f64 * sample_rate_hz / n as f64;
+        if !(0.1..=upper_hz).contains(&frequency_hz) {
+            continue;
+        }
+        let mut real = 0.0;
+        let mut imag = 0.0;
+        let angle_step = 2.0 * std::f64::consts::PI * bin as f64 / n as f64;
+        let (step_sin, step_cos) = angle_step.sin_cos();
+        let mut angle_cos = 1.0;
+        let mut angle_sin = 0.0;
+        for (index, sample) in samples.iter().enumerate() {
+            let window =
+                0.5 * (1.0 - (2.0 * std::f64::consts::PI * index as f64 / (n - 1) as f64).cos());
+            let value = (sample - mean) * window;
+            real += value * angle_cos;
+            imag -= value * angle_sin;
+            let next_cos = angle_cos * step_cos - angle_sin * step_sin;
+            angle_sin = angle_sin * step_cos + angle_cos * step_sin;
+            angle_cos = next_cos;
+        }
+        powers.push((frequency_hz, real * real + imag * imag));
+    }
+    if powers.is_empty() {
+        return 0.0;
+    }
+    let mean_power = powers.iter().map(|(_, power)| power).sum::<f64>() / powers.len() as f64;
+    let (peak_hz, peak_power) = powers
+        .into_iter()
+        .max_by(|left, right| {
+            left.1
+                .partial_cmp(&right.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .unwrap_or((0.0, 0.0));
+    if mean_power <= f64::EPSILON || peak_power / mean_power < 2.0 {
+        0.0
+    } else {
+        peak_hz
+    }
+}
+
+#[cfg(test)]
+mod temporal_frequency_tests {
+    use super::*;
+
+    #[test]
+    fn recovers_temporal_frequency_in_hertz() {
+        let sample_rate_hz = 20.0;
+        let target_hz = 1.2;
+        let mut history = VecDeque::new();
+        for sample in 0..100 {
+            let t = sample as f64 / sample_rate_hz;
+            let value = 20.0 + 2.0 * (2.0 * std::f64::consts::PI * target_hz * t).sin();
+            history.push_back(vec![value; 56]);
+        }
+        let measured = estimate_temporal_dominant_frequency_hz(&history, sample_rate_hz);
+        assert!((measured - target_hz).abs() <= 0.21, "measured {measured} Hz");
+    }
+
+    #[test]
+    fn abstains_on_short_or_flat_history() {
+        let short = VecDeque::from(vec![vec![20.0; 56]; 15]);
+        assert_eq!(estimate_temporal_dominant_frequency_hz(&short, 20.0), 0.0);
+        let flat = VecDeque::from(vec![vec![20.0; 56]; 100]);
+        assert_eq!(estimate_temporal_dominant_frequency_hz(&flat, 20.0), 0.0);
+        let mut corrupt = flat;
+        corrupt[50][4] = f64::NAN;
+        assert_eq!(estimate_temporal_dominant_frequency_hz(&corrupt, 20.0), 0.0);
+    }
+
+    #[test]
+    fn temporal_frequency_p95_stays_below_server_budget() {
+        let sample_rate_hz = 50.0;
+        let mut history = VecDeque::new();
+        for sample in 0..128 {
+            let t = sample as f64 / sample_rate_hz;
+            let value = 20.0 + 2.0 * (2.0 * std::f64::consts::PI * 1.2 * t).sin();
+            history.push_back(vec![value; 256]);
+        }
+        let mut timings = Vec::with_capacity(1_000);
+        for _ in 0..1_000 {
+            let start = std::time::Instant::now();
+            std::hint::black_box(estimate_temporal_dominant_frequency_hz(
+                std::hint::black_box(&history),
+                sample_rate_hz,
+            ));
+            timings.push(start.elapsed());
+        }
+        timings.sort_unstable();
+        let p95 = timings[949];
+        eprintln!("temporal dominant frequency p95: {p95:?}");
+        assert!(p95 < std::time::Duration::from_millis(10), "p95 {p95:?}");
+    }
+}
+
 /// Person count is supporting evidence, never an independent occupancy claim.
 /// Return zero and mark invalid for contradictory or out-of-range firmware.
 fn sanitize_edge_person_count(presence: bool, raw: u8) -> (u8, bool) {
@@ -469,14 +604,7 @@ pub fn extract_features_from_frame(
         0.0
     };
 
-    let peak_idx = frame
-        .amplitudes
-        .iter()
-        .enumerate()
-        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(i, _)| i)
-        .unwrap_or(0);
-    let dominant_freq_hz = peak_idx as f64 * 0.05;
+    let dominant_freq_hz = estimate_temporal_dominant_frequency_hz(frame_history, sample_rate_hz);
 
     let threshold = mean_amp * 1.2;
     let change_points = frame
@@ -485,7 +613,9 @@ pub fn extract_features_from_frame(
         .filter(|w| (w[0] < threshold) != (w[1] < threshold))
         .count();
 
-    let temporal_motion_score = if let Some(prev_frame) = frame_history.back() {
+    // The caller appends the current frame before extraction, so the true
+    // predecessor is the second item from the back.
+    let temporal_motion_score = if let Some(prev_frame) = frame_history.iter().rev().nth(1) {
         let n_cmp = n_sub.min(prev_frame.len());
         if n_cmp > 0 {
             let diff_energy: f64 = (0..n_cmp)
@@ -636,13 +766,18 @@ pub fn adaptive_override(
             .back()
             .map(|v| v.as_slice())
             .unwrap_or(&[]);
+        let dominant_frequency = adaptive_classifier::compatible_dominant_frequency(
+            model.version,
+            features.dominant_freq_hz,
+            amps,
+        );
         let feat_arr = adaptive_classifier::features_from_runtime(
             &serde_json::json!({
                 "variance": features.variance,
                 "motion_band_power": features.motion_band_power,
                 "breathing_band_power": features.breathing_band_power,
                 "spectral_power": features.spectral_power,
-                "dominant_freq_hz": features.dominant_freq_hz,
+                "dominant_freq_hz": dominant_frequency,
                 "change_points": features.change_points,
                 "mean_rssi": features.mean_rssi,
             }),

--- a/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
@@ -283,31 +283,36 @@ pub fn calibrated_occupancy(
     })
 }
 
-/// Feed the latest frame to the FieldModel during calibration collection.
+/// Feed the current CSI frame to the FieldModel during calibration.
 ///
 /// Acts while the model is `Uncalibrated` or `Collecting`. The first fed frame
 /// flips a freshly-started (`Uncalibrated`) model to `Collecting` inside
 /// `feed_calibration`; without accepting the `Uncalibrated` state here the two
 /// gates deadlock and the frame count never leaves 0 (calibration/start yields
-/// an `Uncalibrated` model that nothing would ever advance). Wraps the latest
-/// frame as a single-link observation (n_links=1) and feeds it.
-pub fn maybe_feed_calibration(field: &mut FieldModel, frame_history: &VecDeque<Vec<f64>>) {
+/// an `Uncalibrated` model that nothing would ever advance). Edge-vitals
+/// packets have no CSI observation and must never call this helper. The caller
+/// owns the stateful sequence admission gate. Wraps the current frame as a
+/// single-link observation (n_links=1) and feeds it.
+pub fn maybe_feed_calibration(field: &mut FieldModel, amplitudes: &[f64]) -> bool {
     if !matches!(
         field.status(),
         CalibrationStatus::Uncalibrated | CalibrationStatus::Collecting
-    ) {
-        return;
+    ) || amplitudes.is_empty()
+    {
+        return false;
     }
-    if let Some(latest) = frame_history.back() {
-        // Resample the raw amplitude vector onto the FieldModel's canonical
-        // 56-tone grid before feeding. Real HT40 nodes stream 128-wide frames;
-        // feeding those raw made every `feed_calibration` fail DimensionMismatch
-        // (swallowed at debug level), pinning frame_count at 0 even after the
-        // status-gate deadlock was fixed. Single-link observation: [1][56].
-        let canonical = CALIB_NORMALIZER.resample_to_canonical(latest);
-        let observations = vec![canonical];
-        if let Err(e) = field.feed_calibration(&observations) {
+    // Resample the raw amplitude vector onto the FieldModel's canonical
+    // 56-tone grid before feeding. Real HT40 nodes stream 128-wide frames;
+    // feeding those raw made every `feed_calibration` fail DimensionMismatch
+    // (swallowed at debug level), pinning frame_count at 0 even after the
+    // status-gate deadlock was fixed. Single-link observation: [1][56].
+    let canonical = CALIB_NORMALIZER.resample_to_canonical(amplitudes);
+    let observations = vec![canonical];
+    match field.feed_calibration(&observations) {
+        Ok(()) => true,
+        Err(e) => {
             tracing::debug!("FieldModel calibration feed: {e}");
+            false
         }
     }
 }
@@ -418,10 +423,7 @@ mod tests {
 
         // n_subcarriers defaults to 56; one single-link frame of that width.
         let frame = vec![0.5_f64; 56];
-        let mut history: VecDeque<Vec<f64>> = VecDeque::new();
-        history.push_back(frame);
-
-        maybe_feed_calibration(&mut field, &history);
+        assert!(maybe_feed_calibration(&mut field, &frame));
 
         assert_eq!(
             field.status(),
@@ -434,8 +436,8 @@ mod tests {
             "frame count must advance past 0"
         );
 
-        // Subsequent frames keep accumulating while Collecting.
-        maybe_feed_calibration(&mut field, &history);
+        // A subsequent unique frame keeps accumulating while Collecting.
+        assert!(maybe_feed_calibration(&mut field, &frame));
         assert_eq!(field.calibration_frame_count(), 2);
     }
 
@@ -450,10 +452,7 @@ mod tests {
 
         // 128-wide frame (HT40), NOT the model's 56 — would DimensionMismatch raw.
         let wide = vec![0.5_f64; 128];
-        let mut history: VecDeque<Vec<f64>> = VecDeque::new();
-        history.push_back(wide);
-
-        maybe_feed_calibration(&mut field, &history);
+        assert!(maybe_feed_calibration(&mut field, &wide));
 
         assert_eq!(
             field.status(),
@@ -465,6 +464,13 @@ mod tests {
             1,
             "wide frame must accumulate, not be silently dropped"
         );
+    }
+
+    #[test]
+    fn maybe_feed_calibration_rejects_an_empty_observation() {
+        let mut field = FieldModel::new(single_link_config()).expect("field model");
+        assert!(!maybe_feed_calibration(&mut field, &[]));
+        assert_eq!(field.calibration_frame_count(), 0);
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
@@ -149,6 +149,18 @@ pub fn single_link_config() -> FieldModelConfig {
     }
 }
 
+/// Resolve the model status at the observation wall clock. `FieldModel::status`
+/// records the state at collection or restore time and does not advance as a
+/// long-running server crosses the stale and expiry boundaries.
+pub fn calibration_status_at(field: &FieldModel, observed_at_us: u64) -> CalibrationStatus {
+    match field.status() {
+        CalibrationStatus::Uncalibrated | CalibrationStatus::Collecting => field.status(),
+        CalibrationStatus::Fresh | CalibrationStatus::Stale | CalibrationStatus::Expired => {
+            field.check_freshness(observed_at_us)
+        }
+    }
+}
+
 /// Estimate occupancy using the FieldModel when calibrated, falling back
 /// to the score-based heuristic otherwise.
 ///
@@ -158,10 +170,11 @@ pub fn single_link_config() -> FieldModelConfig {
 pub fn occupancy_or_fallback(
     field: &FieldModel,
     frame_history: &VecDeque<Vec<f64>>,
+    observed_at_us: u64,
     smoothed_score: f64,
     prev_count: usize,
 ) -> usize {
-    match field.status() {
+    match calibration_status_at(field, observed_at_us) {
         CalibrationStatus::Fresh | CalibrationStatus::Stale => {
             let frames: Vec<Vec<f64>> = frame_history
                 .iter()
@@ -470,6 +483,36 @@ mod tests {
         assert_eq!(
             calibrated_occupancy(&field, &VecDeque::new(), 1_500_000),
             None
+        );
+    }
+
+    #[test]
+    fn occupancy_falls_back_after_expiry_without_a_process_restart() {
+        let field = fresh_test_model();
+        let baseline = field.modes().unwrap().baseline[0].clone();
+        let history: VecDeque<Vec<f64>> =
+            (0..OCCUPANCY_WINDOW).map(|_| baseline.clone()).collect();
+
+        assert_eq!(field.status(), CalibrationStatus::Fresh);
+        assert_eq!(
+            calibration_status_at(&field, 1_500_000),
+            CalibrationStatus::Fresh
+        );
+        assert_eq!(
+            occupancy_or_fallback(&field, &history, 1_500_000, 0.0, 0),
+            0,
+            "a fresh field model may resolve its learned baseline as empty"
+        );
+
+        assert_eq!(field.status(), CalibrationStatus::Fresh);
+        assert_eq!(
+            calibration_status_at(&field, 4_000_000),
+            CalibrationStatus::Expired
+        );
+        assert_eq!(
+            occupancy_or_fallback(&field, &history, 4_000_000, 0.0, 0),
+            score_to_person_count(0.0, 0),
+            "an expired in-memory model must fall back even though its cached status is fresh"
         );
     }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/field_bridge.rs
@@ -47,6 +47,9 @@ const MAX_SINGLE_LINK_OCCUPANCY: usize = 3;
 pub struct BootstrapBackgroundMatch {
     pub matches_empty: bool,
     pub score: Option<f64>,
+    pub normalized_residual_z: Option<f64>,
+    pub maturity: f64,
+    pub reliable: bool,
     pub residual_energy: f64,
     pub residual_energy_threshold: f64,
     pub window_size: usize,
@@ -227,6 +230,9 @@ pub fn bootstrap_background_match(
     Some(BootstrapBackgroundMatch {
         matches_empty: result.matches_empty,
         score: result.score,
+        normalized_residual_z: result.normalized_residual_z,
+        maturity: result.maturity,
+        reliable: result.reliable,
         residual_energy: result.residual_energy,
         residual_energy_threshold: result.residual_energy_threshold,
         window_size: result.window_size,
@@ -502,6 +508,9 @@ mod tests {
             .expect("background score");
         assert!(background.matches_empty);
         assert_eq!(background.reference_window_count, 12);
+        assert!(background.reliable);
+        assert_eq!(background.maturity, 0.6);
+        assert!(background.normalized_residual_z.is_some());
         assert!(background
             .score
             .is_some_and(|score| (0.5..=1.0).contains(&score)));
@@ -530,5 +539,6 @@ mod tests {
             .expect("shifted background result");
         assert!(!shifted_background.matches_empty);
         assert_eq!(shifted_background.score, Some(0.0));
+        assert!(shifted_background.reliable);
     }
 }

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -6159,6 +6159,14 @@ mod bootstrap_vital_publication_tests {
         assert!(!calibration_source_accepts(&sources, 3));
     }
 
+    #[test]
+    fn explicit_single_link_source_rejects_other_live_nodes() {
+        let sources = std::collections::BTreeSet::from([5]);
+        assert!(calibration_source_accepts(&sources, 5));
+        assert!(!calibration_source_accepts(&sources, 3));
+        assert!(!calibration_source_accepts(&sources, 7));
+    }
+
     fn strong_candidates() -> VitalSigns {
         VitalSigns {
             breathing_rate_bpm: Some(15.0),
@@ -6249,8 +6257,33 @@ mod bootstrap_vital_publication_tests {
 
 // ── Field model calibration endpoints (eigenvalue person counting) ──────────
 
-async fn calibration_start(State(state): State<SharedState>) -> Json<serde_json::Value> {
+#[derive(Debug, Default, Deserialize)]
+struct CalibrationStartQuery {
+    /// Optional explicit single-link source. When omitted, the first accepted
+    /// ESP32 packet preserves the legacy binding behavior.
+    source_node_id: Option<u8>,
+}
+
+async fn calibration_start(
+    State(state): State<SharedState>,
+    Query(query): Query<CalibrationStartQuery>,
+) -> Json<serde_json::Value> {
     let mut s = state.write().await;
+    if let Some(source_node_id) = query.source_node_id {
+        let now = std::time::Instant::now();
+        let source_is_live = s.node_states.get(&source_node_id).is_some_and(|node| {
+            node.last_frame_time
+                .is_some_and(|seen| now.saturating_duration_since(seen) < ESP32_OFFLINE_TIMEOUT)
+        });
+        if !source_is_live {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "calibration_source_unavailable",
+                "error": "The requested calibration source is missing or stale.",
+                "source_node_id": source_node_id,
+            }));
+        }
+    }
     if s.bootstrap_baseline_active {
         s.field_model = None;
         s.bootstrap_baseline_active = false;
@@ -6279,10 +6312,14 @@ async fn calibration_start(State(state): State<SharedState>) -> Json<serde_json:
             s.field_model = Some(fm);
             s.calibration_model_id = Some(opaque_calibration_model_id());
             s.calibration_source_node_ids.clear();
+            if let Some(source_node_id) = query.source_node_id {
+                s.calibration_source_node_ids.insert(source_node_id);
+            }
             Json(serde_json::json!({
                 "success": true,
                 "message": "Calibration started — keep room empty while frames accumulate.",
                 "model_id": s.calibration_model_id,
+                "source_node_ids": s.calibration_source_node_ids,
             }))
         }
         // ADR-080 #2: FieldModel init error chain stays server-side only.

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -915,10 +915,10 @@ const NOVELTY_SKETCH_VERSION: u16 = 1;
 /// bursts whose intra-burst arrival deltas are tens of microseconds apart —
 /// a 36 µs delta yields `1/dt ≈ 27 kHz`, which the old `< 1 s` guard let
 /// straight into the EMA and inflated `csi_fps_ema` by 1–3 orders of
-/// magnitude (issue #1180). We reject any delta implying more than 200 fps
-/// (4× the physical ceiling, leaving slack for benign arrival jitter); such
-/// deltas are burst artifacts, not distinct production intervals.
+/// magnitude (issue #1180). We reject sub-5 ms deltas as burst artifacts and
+/// cap accepted estimates to the firmware's 50 fps physical ceiling.
 pub(crate) const MIN_PLAUSIBLE_CSI_DT_SEC: f64 = 0.005;
+pub(crate) const MAX_PHYSICAL_CSI_FPS: f64 = 50.0;
 
 /// ADR-110 iter 18 — EMA update for per-node CSI fps tracking.
 ///
@@ -934,7 +934,7 @@ pub(crate) fn update_csi_fps_ema(prev_fps: f64, dt_sec: f64) -> Option<f64> {
     if !(dt_sec >= MIN_PLAUSIBLE_CSI_DT_SEC && dt_sec < 1.0) {
         return None;
     }
-    let instantaneous = 1.0 / dt_sec;
+    let instantaneous = (1.0 / dt_sec).min(MAX_PHYSICAL_CSI_FPS);
     // y[n] = y[n-1] + (x - y[n-1]) / 8
     Some(prev_fps + (instantaneous - prev_fps) / 8.0)
 }
@@ -984,6 +984,15 @@ mod fps_ema_tests {
     }
 
     #[test]
+    fn accepted_burst_edge_is_capped_to_firmware_ceiling() {
+        let mut fps = 50.0;
+        for _ in 0..32 {
+            fps = update_csi_fps_ema(fps, 0.005).unwrap();
+        }
+        assert!(fps <= 50.0, "reported {fps} Hz above firmware ceiling");
+    }
+
+    #[test]
     fn burst_interleaved_with_nominal_stays_in_band() {
         // A true ~40 fps node whose frames arrive in sub-ms bursts: feeding
         // only the plausible (nominal-cadence) deltas keeps the EMA near the
@@ -1004,6 +1013,18 @@ mod fps_ema_tests {
 }
 
 impl NodeState {
+    /// Measured sample rate only after enough inter-frame deltas have warmed
+    /// the EMA. The physical ceiling is enforced again at the consumption
+    /// boundary so restored or malformed state cannot overclock DSP math.
+    fn measured_sample_rate_hz(&self) -> Option<f64> {
+        (self.csi_fps_samples >= 5 && self.csi_fps_ema.is_finite())
+            .then(|| self.csi_fps_ema.clamp(1.0, MAX_PHYSICAL_CSI_FPS))
+    }
+
+    fn effective_sample_rate_hz(&self) -> f64 {
+        self.measured_sample_rate_hz().unwrap_or(20.0)
+    }
+
     /// ADR-110 §A0.12 timestamp recovery: given a CSI frame's node-local
     /// `esp_timer_get_time()` snapshot, return the mesh-aligned epoch
     /// computed from this node's most recent sync packet — or `None`
@@ -1051,7 +1072,7 @@ impl NodeState {
         // samples; until then fall back to the 20 Hz firmware ceiling. The
         // §A0.12 capture showed real bench fps ≈ 10, so the measured value
         // is significantly more accurate than the constant fallback.
-        let fps = if self.csi_fps_samples >= 5 { self.csi_fps_ema } else { 20.0 };
+        let fps = self.effective_sample_rate_hz();
         Some(sync.mesh_aligned_us_for_sequence(frame_sequence, fps))
     }
 
@@ -1099,7 +1120,7 @@ impl NodeState {
             is_valid: sync.flags.is_valid,
             smoothed: sync.flags.smoothed_used,
             sequence: sync.sequence,
-            csi_fps_ema: self.csi_fps_ema,
+            csi_fps_ema: self.effective_sample_rate_hz(),
             csi_fps_samples: self.csi_fps_samples,
             staleness_ms: self.latest_sync_at.map(|t| t.elapsed().as_millis() as u64),
         })
@@ -1163,7 +1184,7 @@ impl NodeState {
             hr_buffer: VecDeque::with_capacity(8),
             br_buffer: VecDeque::with_capacity(8),
             rssi_history: VecDeque::new(),
-            vital_detector: VitalSignDetector::new(10.0),
+            vital_detector: VitalSignDetector::new(20.0),
             latest_vitals: VitalSigns::default(),
             last_frame_time: None,
             edge_vitals: None,
@@ -1349,7 +1370,7 @@ fn build_node_features(
                 },
                 rssi_dbm: ns.rssi_history.back().copied().unwrap_or(0.0),
                 last_seen_ms,
-                frame_rate_hz: 0.0, // Computed elsewhere; not yet plumbed here.
+                frame_rate_hz: ns.measured_sample_rate_hz().unwrap_or(0.0),
                 stale,
                 novelty_score: ns.last_novelty_score,
             }
@@ -2768,15 +2789,9 @@ fn extract_features_from_frame(
         0.0
     };
 
-    // ── Dominant frequency via peak subcarrier index ──
-    let peak_idx = frame
-        .amplitudes
-        .iter()
-        .enumerate()
-        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(i, _)| i)
-        .unwrap_or(0);
-    let dominant_freq_hz = peak_idx as f64 * 0.05;
+    // A subcarrier index is a spatial-frequency bin, not temporal hertz.
+    let dominant_freq_hz =
+        csi::estimate_temporal_dominant_frequency_hz(frame_history, sample_rate_hz);
 
     // ── Change point detection (threshold-crossing count in current frame) ──
     let threshold = mean_amp * 1.2;
@@ -2789,7 +2804,9 @@ fn extract_features_from_frame(
     // ── Motion score: sliding-window temporal difference ──
     // Compare current frame against the most recent historical frame.
     // The difference is normalised by the mean amplitude to be scale-invariant.
-    let temporal_motion_score = if let Some(prev_frame) = frame_history.back() {
+    // Callers append the current frame first, making the true predecessor the
+    // second item from the back.
+    let temporal_motion_score = if let Some(prev_frame) = frame_history.iter().rev().nth(1) {
         let n_cmp = n_sub.min(prev_frame.len());
         if n_cmp > 0 {
             let diff_energy: f64 = (0..n_cmp)
@@ -3022,13 +3039,18 @@ fn adaptive_override(
             .back()
             .map(|v| v.as_slice())
             .unwrap_or(&[]);
+        let dominant_frequency = adaptive_classifier::compatible_dominant_frequency(
+            model.version,
+            features.dominant_freq_hz,
+            amps,
+        );
         let feat_arr = adaptive_classifier::features_from_runtime(
             &serde_json::json!({
                 "variance": features.variance,
                 "motion_band_power": features.motion_band_power,
                 "breathing_band_power": features.breathing_band_power,
                 "spectral_power": features.spectral_power,
-                "dominant_freq_hz": features.dominant_freq_hz,
+                "dominant_freq_hz": dominant_frequency,
                 "change_points": features.change_points,
                 "mean_rssi": features.mean_rssi,
             }),
@@ -6452,6 +6474,9 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
                 "state": if result.matches_empty { "matched" } else { "changed" },
                 "matches_empty": result.matches_empty,
                 "score": result.score,
+                "normalized_residual_z": result.normalized_residual_z,
+                "maturity": result.maturity,
+                "reliable": result.reliable,
                 "residual_energy": result.residual_energy,
                 "residual_energy_threshold": result.residual_energy_threshold,
                 "window_size": result.window_size,
@@ -8044,7 +8069,7 @@ async fn udp_receiver_task(
                         ns.frame_history.pop_front();
                     }
 
-                    let sample_rate_hz = 1000.0 / 500.0_f64;
+                    let sample_rate_hz = ns.effective_sample_rate_hz();
                     let (
                         features,
                         mut classification,
@@ -8057,13 +8082,19 @@ async fn udp_receiver_task(
                     // Adaptive override using cloned model (safe, no raw pointers).
                     if let Some(ref model) = adaptive_model_clone {
                         let amps = ns.frame_history.back().map(|v| v.as_slice()).unwrap_or(&[]);
+                        let dominant_frequency =
+                            adaptive_classifier::compatible_dominant_frequency(
+                                model.version,
+                                features.dominant_freq_hz,
+                                amps,
+                            );
                         let feat_arr = adaptive_classifier::features_from_runtime(
                             &serde_json::json!({
                                 "variance": features.variance,
                                 "motion_band_power": features.motion_band_power,
                                 "breathing_band_power": features.breathing_band_power,
                                 "spectral_power": features.spectral_power,
-                                "dominant_freq_hz": features.dominant_freq_hz,
+                                "dominant_freq_hz": dominant_frequency,
                                 "change_points": features.change_points,
                                 "mean_rssi": features.mean_rssi,
                             }),
@@ -8079,6 +8110,18 @@ async fn udp_receiver_task(
                     ns.rssi_history.push_back(features.mean_rssi);
                     if ns.rssi_history.len() > 60 {
                         ns.rssi_history.pop_front();
+                    }
+
+                    if ns.csi_fps_samples >= 5
+                        && ns.vital_detector.reconfigure_sample_rate(sample_rate_hz)
+                    {
+                        // Never smooth estimates computed against two clocks.
+                        ns.smoothed_hr = 0.0;
+                        ns.smoothed_br = 0.0;
+                        ns.smoothed_hr_conf = 0.0;
+                        ns.smoothed_br_conf = 0.0;
+                        ns.hr_buffer.clear();
+                        ns.br_buffer.clear();
                     }
 
                     let raw_vitals = ns
@@ -10618,6 +10661,20 @@ mod sync_snapshot_helper_tests {
         assert_eq!(snap.sequence, 20);
         assert!((snap.csi_fps_ema - 10.5).abs() < 1e-9);
         assert_eq!(snap.csi_fps_samples, 42);
+    }
+
+    #[test]
+    fn exported_node_rate_is_mature_and_physically_bounded() {
+        let mut ns = NodeState::new();
+        assert_eq!(ns.measured_sample_rate_hz(), None);
+
+        ns.csi_fps_ema = 74.0;
+        ns.csi_fps_samples = 5;
+        assert_eq!(ns.measured_sample_rate_hz(), Some(50.0));
+
+        ns.latest_sync = Some(populated_sync(9));
+        ns.latest_sync_at = Some(std::time::Instant::now());
+        assert_eq!(ns.sync_snapshot().unwrap().csi_fps_ema, 50.0);
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1730,12 +1730,38 @@ mod adr323_pose_physics_http_tests {
 const ESP32_OFFLINE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 impl AppStateInner {
+    fn field_model_status_at(&self, observed_at_unix_ms: u64) -> Option<CalibrationStatus> {
+        self.field_model.as_ref().map(|model| {
+            field_bridge::calibration_status_at(model, observed_at_unix_ms.saturating_mul(1_000))
+        })
+    }
+
+    fn field_model_active_at(&self, observed_at_unix_ms: u64) -> bool {
+        self.field_model_status_at(observed_at_unix_ms)
+            .is_some_and(|status| status != CalibrationStatus::Expired)
+    }
+
+    fn bootstrap_baseline_active_at(&self, observed_at_unix_ms: u64) -> bool {
+        self.bootstrap_baseline_active && self.field_model_active_at(observed_at_unix_ms)
+    }
+
+    fn explicit_calibration_fresh_at(&self, observed_at_unix_ms: u64) -> bool {
+        !self.bootstrap_baseline_active
+            && self.field_model_status_at(observed_at_unix_ms) == Some(CalibrationStatus::Fresh)
+    }
+
     /// Return the effective data source, accounting for ESP32 frame timeout.
     /// If the source is "esp32" but no frame has arrived in 5 seconds, returns
     /// "esp32:offline" so the UI can distinguish active vs stale connections.
     /// Person count: eigenvalue-based if field model is calibrated, else heuristic.
     /// Uses global frame_history if populated, otherwise the freshest per-node history.
-    fn person_count(&self) -> usize {
+    fn person_count_at(&self, observed_at_unix_ms: u64) -> usize {
+        // A persisted bootstrap model has negative-only authority. Its only
+        // allowed occupancy effect is the explicit empty-background suppression
+        // in `bootstrap_empty_prior_applies`; it must never infer positive count.
+        if self.bootstrap_baseline_active {
+            return score_to_person_count(self.smoothed_person_score, self.prev_person_count);
+        }
         match self.field_model.as_ref() {
             Some(fm) => {
                 // A single-link model may score only the source node it was
@@ -1769,12 +1795,17 @@ impl AppStateInner {
                 field_bridge::occupancy_or_fallback(
                     fm,
                     history,
+                    observed_at_unix_ms.saturating_mul(1_000),
                     self.smoothed_person_score,
                     self.prev_person_count,
                 )
             }
             None => score_to_person_count(self.smoothed_person_score, self.prev_person_count),
         }
+    }
+
+    fn person_count(&self) -> usize {
+        self.person_count_at(chrono::Utc::now().timestamp_millis().max(0) as u64)
     }
 
     /// A restored startup image has negative-only authority. It may suppress
@@ -1952,6 +1983,95 @@ impl AppStateInner {
             )
             .expect("default pose physics configuration is valid"),
         }
+    }
+}
+
+#[cfg(test)]
+mod calibration_expiry_tests {
+    use super::*;
+    use wifi_densepose_signal::ruvsense::field_model::FieldModelConfig;
+
+    fn finalized_model(calibrated_at_unix_ms: u64) -> FieldModel {
+        let mut model = FieldModel::new(FieldModelConfig {
+            n_links: 1,
+            n_subcarriers: 56,
+            n_modes: 3,
+            min_calibration_frames: 10,
+            min_calibration_duration_s: 0.0,
+            baseline_expiry_s: 2.0,
+        })
+        .unwrap();
+        for frame_index in 0..20 {
+            let frame = (0..56)
+                .map(|subcarrier| {
+                    10.0 + subcarrier as f64 * 0.01
+                        + (frame_index as f64 * 0.1 + subcarrier as f64 * 0.03).sin() * 0.01
+                })
+                .collect();
+            model.feed_calibration(&[frame]).unwrap();
+        }
+        model
+            .finalize_calibration(calibrated_at_unix_ms.saturating_mul(1_000), 7)
+            .unwrap();
+        model
+    }
+
+    fn state_with_model(bootstrap: bool) -> AppStateInner {
+        let model = finalized_model(1_000);
+        let baseline = model.modes().unwrap().baseline[0].clone();
+        let mut state = AppStateInner::minimal();
+        state.frame_history = (0..50).map(|_| baseline.clone()).collect();
+        state.field_model = Some(model);
+        state.bootstrap_baseline_active = bootstrap;
+        if bootstrap {
+            state.bootstrap_baseline = Some(BootstrapBaselineMetadata {
+                authority: bootstrap_baseline::BOOTSTRAP_BASELINE_AUTHORITY,
+                source_node_ids: vec![5],
+                source_model_id: "test-model".to_string(),
+                created_at_unix_ms: 1_000,
+                expires_at_unix_ms: 3_000,
+                content_sha256: "00".repeat(32),
+            });
+        }
+        state
+    }
+
+    #[test]
+    fn bootstrap_field_model_remains_negative_only_for_person_count() {
+        let runtime = state_with_model(false);
+        assert_eq!(runtime.person_count_at(1_500), 0);
+
+        let bootstrap = state_with_model(true);
+        assert_eq!(
+            bootstrap.person_count_at(1_500),
+            score_to_person_count(0.0, 0),
+            "a bootstrap prior must not derive a positive or negative count through the runtime model path"
+        );
+    }
+
+    #[tokio::test]
+    async fn long_running_expiry_is_not_reported_active_for_runtime_or_bootstrap() {
+        let runtime = Arc::new(RwLock::new(state_with_model(false)));
+        let Json(runtime_status) = calibration_status(State(runtime)).await;
+        assert_eq!(runtime_status["active"], false);
+        assert_eq!(runtime_status["status"], "expired");
+        assert_eq!(runtime_status["binding_mode"], "none");
+
+        let bootstrap = Arc::new(RwLock::new(state_with_model(true)));
+        let Json(bootstrap_status) = calibration_status(State(bootstrap)).await;
+        assert_eq!(bootstrap_status["active"], false);
+        assert_eq!(bootstrap_status["status"], "expired");
+        assert_eq!(bootstrap_status["binding_mode"], "none");
+        assert_eq!(bootstrap_status["bootstrap_baseline"]["stored"], true);
+        assert_eq!(bootstrap_status["bootstrap_baseline"]["active"], false);
+        assert_eq!(
+            bootstrap_status["bootstrap_baseline"]["calibrated_evidence_authorized"],
+            false
+        );
+        assert_eq!(
+            bootstrap_status["bootstrap_baseline"]["numeric_vitals_authorized"],
+            false
+        );
     }
 }
 
@@ -6319,7 +6439,9 @@ async fn calibration_start(
     }
     // Guard: don't discard an in-progress or fresh calibration
     if let Some(ref fm) = s.field_model {
-        match fm.status() {
+        let observed_at_us =
+            (chrono::Utc::now().timestamp_millis().max(0) as u64).saturating_mul(1_000);
+        match field_bridge::calibration_status_at(fm, observed_at_us) {
             CalibrationStatus::Collecting => {
                 return Json(serde_json::json!({
                     "success": false,
@@ -6423,6 +6545,9 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
 async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
     let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let effective_status = s.field_model_status_at(observed_at_unix_ms);
+    let active = s.field_model_active_at(observed_at_unix_ms);
+    let bootstrap_active = s.bootstrap_baseline_active_at(observed_at_unix_ms);
     let bootstrap_background_match = s.bootstrap_background_match(observed_at_unix_ms);
     let runtime_reference = s.field_model.as_ref().and_then(|model| {
         model.modes().map(|modes| serde_json::json!({
@@ -6434,21 +6559,22 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
             "raw_calibration_frames_persisted": false,
         }))
     });
-    let (active, status, frame_count, min_frames, elapsed_s, frames_per_second, min_duration_s) =
-        s.field_model.as_ref().map_or(
-            (false, "none".to_string(), 0, 0, 0.0, 0.0, 0.0),
-            |model| {
-                (
-                    true,
-                    format!("{:?}", model.status()).to_lowercase(),
-                    model.calibration_frame_count(),
-                    model.min_calibration_frames(),
-                    model.calibration_elapsed_s(),
-                    model.calibration_frames_per_second(),
-                    model.min_calibration_duration_s(),
-                )
-            },
-        );
+    let (frame_count, min_frames, elapsed_s, frames_per_second, min_duration_s) = s
+        .field_model
+        .as_ref()
+        .map_or((0, 0, 0.0, 0.0, 0.0), |model| {
+            (
+                model.calibration_frame_count(),
+                model.min_calibration_frames(),
+                model.calibration_elapsed_s(),
+                model.calibration_frames_per_second(),
+                model.min_calibration_duration_s(),
+            )
+        });
+    let status = effective_status.map_or_else(
+        || "none".to_string(),
+        |status| format!("{status:?}").to_lowercase(),
+    );
     Json(serde_json::json!({
         "active": active,
         "status": status,
@@ -6460,10 +6586,10 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
         "model_id": s.calibration_model_id,
         "source_node_ids": s.calibration_source_node_ids,
         "runtime_reference": runtime_reference,
-        "binding_mode": if s.bootstrap_baseline_active { "bootstrap_only" } else if active { "runtime" } else { "none" },
+        "binding_mode": if bootstrap_active { "bootstrap_only" } else if active { "runtime" } else { "none" },
         "bootstrap_baseline": s.bootstrap_baseline.as_ref().map(|metadata| serde_json::json!({
             "stored": true,
-            "active": s.bootstrap_baseline_active,
+            "active": bootstrap_active,
             "authority": metadata.authority,
             "source_node_ids": metadata.source_node_ids,
             "source_model_id": metadata.source_model_id,
@@ -6502,11 +6628,8 @@ async fn calibration_promote_bootstrap(
 ) -> Json<serde_json::Value> {
     let expected_model_id = {
         let s = state.read().await;
-        if s.bootstrap_baseline_active
-            || !s.field_model.as_ref().is_some_and(|model| {
-                matches!(model.status(), CalibrationStatus::Fresh)
-            })
-        {
+        let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+        if s.bootstrap_baseline_active || !s.explicit_calibration_fresh_at(observed_at_unix_ms) {
             return Json(serde_json::json!({
                 "success": false,
                 "error_code": "calibration_not_finalized",
@@ -6540,8 +6663,9 @@ async fn calibration_promote_bootstrap(
         while tokio::time::Instant::now() < interval_deadline {
             let observed = {
                 let s = state.read().await;
+                let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
                 if s.calibration_model_id.as_deref() != Some(expected_model_id.as_str())
-                    || s.bootstrap_baseline_active
+                    || !s.explicit_calibration_fresh_at(observed_at_unix_ms)
                 {
                     None
                 } else {
@@ -6581,8 +6705,9 @@ async fn calibration_promote_bootstrap(
     }
 
     let mut s = state.write().await;
+    let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
     if s.calibration_model_id.as_deref() != Some(expected_model_id.as_str())
-        || s.bootstrap_baseline_active
+        || !s.explicit_calibration_fresh_at(observed_at_unix_ms)
     {
         return Json(serde_json::json!({
             "success": false,
@@ -6661,7 +6786,11 @@ async fn calibration_refine_bootstrap(
 
     let (expected_model_id, expected_digest, source_node_id) = {
         let s = state.read().await;
-        let Some(metadata) = s.bootstrap_baseline.as_ref().filter(|_| s.bootstrap_baseline_active)
+        let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+        let Some(metadata) = s
+            .bootstrap_baseline
+            .as_ref()
+            .filter(|_| s.bootstrap_baseline_active_at(observed_at_unix_ms))
         else {
             return Json(serde_json::json!({
                 "success": false,
@@ -6706,7 +6835,8 @@ async fn calibration_refine_bootstrap(
         while tokio::time::Instant::now() < interval_deadline {
             observed = {
                 let s = state.read().await;
-                let identity_matches = s.bootstrap_baseline_active
+                let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+                let identity_matches = s.bootstrap_baseline_active_at(observed_at_unix_ms)
                     && s.bootstrap_baseline.as_ref().is_some_and(|metadata| {
                         metadata.source_model_id == expected_model_id
                             && metadata.content_sha256 == expected_digest
@@ -6771,7 +6901,8 @@ async fn calibration_refine_bootstrap(
     }
 
     let mut s = state.write().await;
-    let identity_matches = s.bootstrap_baseline_active
+    let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let identity_matches = s.bootstrap_baseline_active_at(observed_at_unix_ms)
         && s.bootstrap_baseline.as_ref().is_some_and(|metadata| {
             metadata.source_model_id == expected_model_id
                 && metadata.content_sha256 == expected_digest
@@ -6951,11 +7082,10 @@ fn chrono_timestamp() -> u64 {
 
 async fn vital_signs_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
-    let person_count = s.person_count();
-    let explicit_calibration_fresh = !s.bootstrap_baseline_active
-        && s.field_model
-            .as_ref()
-            .is_some_and(|model| matches!(model.status(), CalibrationStatus::Fresh));
+    let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let person_count = s.person_count_at(observed_at_unix_ms);
+    let explicit_calibration_fresh =
+        s.explicit_calibration_fresh_at(observed_at_unix_ms);
     let published = vitals_for_publication(
         &s.latest_vitals,
         explicit_calibration_fresh,
@@ -7036,11 +7166,9 @@ async fn edge_registry_endpoint(
 /// GET /api/v1/edge-vitals — latest edge vitals from ESP32 (ADR-039).
 async fn edge_vitals_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
-    let explicit_single_occupant = !s.bootstrap_baseline_active
-        && s.field_model
-            .as_ref()
-            .is_some_and(|model| matches!(model.status(), CalibrationStatus::Fresh))
-        && s.person_count() == 1;
+    let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let explicit_single_occupant = s.explicit_calibration_fresh_at(observed_at_unix_ms)
+        && s.person_count_at(observed_at_unix_ms) == 1;
     if !explicit_single_occupant {
         return Json(serde_json::json!({
             "status": "abstained",
@@ -7654,7 +7782,10 @@ async fn udp_receiver_task(
                                 // #803: don't let the saturating activity score
                                 // discard count-aware per-node estimates.
                                 let count =
-                                    aggregate_person_count(s.person_count(), &s.node_states);
+                                    aggregate_person_count(
+                                        s.person_count_at(observed_at_unix_ms),
+                                        &s.node_states,
+                                    );
                                 s.prev_person_count = count;
                                 count.max(1) // presence=true => at least 1
                             }
@@ -7791,10 +7922,8 @@ async fn udp_receiver_task(
                         heartbeat_confidence: if vitals.presence { 0.7 } else { 0.0 },
                         signal_quality: vitals.presence_score as f64,
                     };
-                    let explicit_calibration_fresh = !s.bootstrap_baseline_active
-                        && s.field_model.as_ref().is_some_and(|model| {
-                            matches!(model.status(), CalibrationStatus::Fresh)
-                        });
+                    let explicit_calibration_fresh =
+                        s.explicit_calibration_fresh_at(observed_at_unix_ms);
                     let published_vitals = vitals_for_publication(
                         &vital_candidates,
                         explicit_calibration_fresh,
@@ -8201,7 +8330,10 @@ async fn udp_receiver_task(
                                 // #803: don't let the saturating activity score
                                 // discard count-aware per-node estimates.
                                 let count =
-                                    aggregate_person_count(s.person_count(), &s.node_states);
+                                    aggregate_person_count(
+                                        s.person_count_at(observed_at_unix_ms),
+                                        &s.node_states,
+                                    );
                                 s.prev_person_count = count;
                                 count.max(1)
                             }
@@ -8314,10 +8446,8 @@ async fn udp_receiver_task(
                     } else {
                         debounce_room_classification(&mut s, &room_inference)
                     };
-                    let explicit_calibration_fresh = !s.bootstrap_baseline_active
-                        && s.field_model.as_ref().is_some_and(|model| {
-                            matches!(model.status(), CalibrationStatus::Fresh)
-                        });
+                    let explicit_calibration_fresh =
+                        s.explicit_calibration_fresh_at(observed_at_unix_ms);
                     let published_vitals = vitals_for_publication(
                         &vitals,
                         explicit_calibration_fresh,

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -849,6 +849,9 @@ struct NodeState {
     latest_sync: Option<wifi_densepose_hardware::SyncPacket>,
     /// Last time a sync packet from this node was received (for staleness).
     latest_sync_at: Option<std::time::Instant>,
+    /// Arrival time of the newest grid-admitted raw CSI frame. Edge-vitals
+    /// packets intentionally do not refresh this clock.
+    latest_accepted_csi_at: Option<std::time::Instant>,
     /// Sequence number of the newest CSI frame admitted to `frame_history`.
     /// Kept alongside the history so multistatic fusion can timestamp the
     /// exact sample it consumes, rather than the host's UDP arrival time.
@@ -1161,6 +1164,7 @@ impl NodeState {
         sync_valid: bool,
         now: std::time::Instant,
     ) -> bool {
+        self.latest_accepted_csi_at = Some(now);
         self.latest_csi_sequence = Some(sequence);
         self.latest_csi_sync_valid = sync_valid;
         self.observe_csi_frame_arrival(now)
@@ -1190,6 +1194,7 @@ impl NodeState {
             edge_vitals: None,
             latest_sync: None,
             latest_sync_at: None,
+            latest_accepted_csi_at: None,
             latest_csi_sequence: None,
             latest_csi_sync_valid: false,
             csi_fps_ema: 20.0,
@@ -1627,6 +1632,12 @@ struct AppStateInner {
     calibration_model_id: Option<String>,
     /// Nodes that actually contributed frames to the current calibration.
     calibration_source_node_ids: std::collections::BTreeSet<u8>,
+    /// Last admitted raw CSI sequence per contributing node. Edge-vitals
+    /// packets do not carry a new CSI observation and cannot advance this map.
+    calibration_last_sequences: HashMap<u8, u32>,
+    /// Nodes whose sequence moved backward during the current session. Without
+    /// a wire boot epoch, the session must stay failed closed after regression.
+    calibration_sequence_fault_node_ids: std::collections::BTreeSet<u8>,
     // ── ADR-044 §5.2: adaptive rolling-p95 normalization ─────────────────────
     /// Rolling P95 of `FeatureInfo.variance` over the last ~30 s (600 frames @ 20 Hz).
     pub(crate) p95_variance: RollingP95,
@@ -1729,7 +1740,74 @@ mod adr323_pose_physics_http_tests {
 /// If no ESP32 frame arrives within this duration, source reverts to offline.
 const ESP32_OFFLINE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CalibrationSequenceOrder {
+    First,
+    Forward,
+    Duplicate,
+    Regression,
+}
+
+fn calibration_sequence_order(previous: Option<u32>, sequence: u32) -> CalibrationSequenceOrder {
+    let Some(previous) = previous else {
+        return CalibrationSequenceOrder::First;
+    };
+    let delta = sequence.wrapping_sub(previous);
+    if delta == 0 {
+        CalibrationSequenceOrder::Duplicate
+    } else if delta < (1_u32 << 31) {
+        CalibrationSequenceOrder::Forward
+    } else {
+        CalibrationSequenceOrder::Regression
+    }
+}
+
 impl AppStateInner {
+    /// Admit at most one raw CSI observation per forward node sequence into
+    /// the current calibration session. This stateful boundary prevents a
+    /// caller from advancing the model with a replayed history tail.
+    fn maybe_feed_calibration_frame(
+        &mut self,
+        node_id: u8,
+        sequence: u32,
+        amplitudes: &[f64],
+    ) -> bool {
+        if !calibration_source_accepts(&self.calibration_source_node_ids, node_id)
+            || self.calibration_sequence_fault_node_ids.contains(&node_id)
+        {
+            return false;
+        }
+        let previous_sequence = self.calibration_last_sequences.get(&node_id).copied();
+        match calibration_sequence_order(previous_sequence, sequence) {
+            CalibrationSequenceOrder::Duplicate => return false,
+            CalibrationSequenceOrder::Regression => {
+                self.calibration_sequence_fault_node_ids.insert(node_id);
+                warn!(
+                    node_id,
+                    previous_sequence,
+                    sequence,
+                    "Calibration source sequence regressed; restart the empty-room capture"
+                );
+                return false;
+            }
+            CalibrationSequenceOrder::First | CalibrationSequenceOrder::Forward => {}
+        }
+        let accepted = self
+            .field_model
+            .as_mut()
+            .is_some_and(|field| field_bridge::maybe_feed_calibration(field, amplitudes));
+        if accepted {
+            self.calibration_source_node_ids.insert(node_id);
+            self.calibration_last_sequences.insert(node_id, sequence);
+        }
+        accepted
+    }
+
+    fn clear_calibration_sequence_state(&mut self) {
+        self.calibration_last_sequences.clear();
+        self.calibration_sequence_fault_node_ids.clear();
+    }
+
     fn field_model_status_at(&self, observed_at_unix_ms: u64) -> Option<CalibrationStatus> {
         self.field_model.as_ref().map(|model| {
             field_bridge::calibration_status_at(model, observed_at_unix_ms.saturating_mul(1_000))
@@ -1972,6 +2050,8 @@ impl AppStateInner {
             bootstrap_baseline_active: false,
             calibration_model_id: None,
             calibration_source_node_ids: std::collections::BTreeSet::new(),
+            calibration_last_sequences: HashMap::new(),
+            calibration_sequence_fault_node_ids: std::collections::BTreeSet::new(),
             p95_variance: RollingP95::new(600, 60),
             p95_motion_band_power: RollingP95::new(600, 60),
             p95_spectral_power: RollingP95::new(600, 60),
@@ -6288,6 +6368,11 @@ fn calibration_source_accepts(
     source_node_ids.is_empty() || source_node_ids.contains(&node_id)
 }
 
+fn calibration_source_has_fresh_csi(node: &NodeState, now: std::time::Instant) -> bool {
+    node.latest_accepted_csi_at
+        .is_some_and(|seen| now.saturating_duration_since(seen) < ESP32_OFFLINE_TIMEOUT)
+}
+
 #[cfg(test)]
 mod bootstrap_vital_publication_tests {
     use super::*;
@@ -6307,6 +6392,148 @@ mod bootstrap_vital_publication_tests {
         assert!(calibration_source_accepts(&sources, 5));
         assert!(!calibration_source_accepts(&sources, 3));
         assert!(!calibration_source_accepts(&sources, 7));
+    }
+
+    #[test]
+    fn edge_vitals_liveness_cannot_authorize_raw_csi_calibration() {
+        let now = std::time::Instant::now();
+        let mut node = NodeState::new();
+        node.last_frame_time = Some(now);
+        assert!(!calibration_source_has_fresh_csi(&node, now));
+
+        node.observe_accepted_csi_frame(9, false, now);
+        assert!(calibration_source_has_fresh_csi(&node, now));
+        assert!(!calibration_source_has_fresh_csi(
+            &node,
+            now + ESP32_OFFLINE_TIMEOUT
+        ));
+    }
+
+    #[test]
+    fn calibration_session_counts_each_unique_bound_csi_sequence_once() {
+        let mut state = AppStateInner::minimal();
+        state.field_model = Some(
+            FieldModel::new(field_bridge::single_link_config()).expect("field model"),
+        );
+        state.calibration_source_node_ids.insert(5);
+
+        let first = vec![0.25; 56];
+        assert!(state.maybe_feed_calibration_frame(5, 41, &first));
+        assert!(!state.maybe_feed_calibration_frame(5, 41, &first));
+
+        let second = vec![0.5; 56];
+        assert!(state.maybe_feed_calibration_frame(5, 42, &second));
+        assert!(!state.maybe_feed_calibration_frame(3, 43, &second));
+
+        let model = state.field_model.as_ref().expect("field model remains active");
+        assert_eq!(model.calibration_frame_count(), 2);
+        assert_eq!(state.calibration_last_sequences.get(&5), Some(&42));
+        assert!(!state.calibration_last_sequences.contains_key(&3));
+    }
+
+    #[test]
+    fn calibration_sequence_regression_latches_session_failure() {
+        let mut state = AppStateInner::minimal();
+        state.field_model = Some(
+            FieldModel::new(field_bridge::single_link_config()).expect("field model"),
+        );
+        state.calibration_source_node_ids.insert(5);
+        let frame = vec![0.25; 56];
+
+        assert!(state.maybe_feed_calibration_frame(5, 10, &frame));
+        assert!(state.maybe_feed_calibration_frame(5, 11, &frame));
+        assert!(!state.maybe_feed_calibration_frame(5, 10, &frame));
+        assert!(!state.maybe_feed_calibration_frame(5, 12, &frame));
+        assert!(state.calibration_sequence_fault_node_ids.contains(&5));
+        assert_eq!(
+            state
+                .field_model
+                .as_ref()
+                .expect("field model")
+                .calibration_frame_count(),
+            2
+        );
+
+        state.clear_calibration_sequence_state();
+        assert!(state.calibration_sequence_fault_node_ids.is_empty());
+        assert!(state.calibration_last_sequences.is_empty());
+    }
+
+    #[test]
+    fn calibration_sequence_wraps_and_failed_empty_input_can_retry() {
+        let mut state = AppStateInner::minimal();
+        state.field_model = Some(
+            FieldModel::new(field_bridge::single_link_config()).expect("field model"),
+        );
+        state.calibration_source_node_ids.insert(5);
+        let frame = vec![0.25; 56];
+
+        assert!(!state.maybe_feed_calibration_frame(5, u32::MAX, &[]));
+        assert!(state.calibration_last_sequences.is_empty());
+        assert!(state.maybe_feed_calibration_frame(5, u32::MAX, &frame));
+        assert!(state.maybe_feed_calibration_frame(5, 0, &frame));
+        assert!(!state.maybe_feed_calibration_frame(5, 0, &frame));
+        assert!(state.maybe_feed_calibration_frame(5, 1, &frame));
+        assert_eq!(
+            state
+                .field_model
+                .as_ref()
+                .expect("field model")
+                .calibration_frame_count(),
+            3
+        );
+    }
+
+    #[test]
+    fn calibration_sequence_order_rejects_backward_and_half_range() {
+        assert_eq!(
+            calibration_sequence_order(None, 7),
+            CalibrationSequenceOrder::First
+        );
+        assert_eq!(
+            calibration_sequence_order(Some(7), 8),
+            CalibrationSequenceOrder::Forward
+        );
+        assert_eq!(
+            calibration_sequence_order(Some(8), 8),
+            CalibrationSequenceOrder::Duplicate
+        );
+        assert_eq!(
+            calibration_sequence_order(Some(8), 7),
+            CalibrationSequenceOrder::Regression
+        );
+        assert_eq!(
+            calibration_sequence_order(Some(0), 1_u32 << 31),
+            CalibrationSequenceOrder::Regression
+        );
+        assert_eq!(
+            calibration_sequence_order(Some(u32::MAX), 0),
+            CalibrationSequenceOrder::Forward
+        );
+    }
+
+    #[tokio::test]
+    async fn calibration_status_and_stop_fail_closed_after_sequence_regression() {
+        let mut inner = AppStateInner::minimal();
+        inner.field_model = Some(
+            FieldModel::new(field_bridge::single_link_config()).expect("field model"),
+        );
+        inner.calibration_model_id = Some("cal-model-test".to_string());
+        inner.calibration_source_node_ids.insert(5);
+        inner.calibration_sequence_fault_node_ids.insert(5);
+        let state = Arc::new(RwLock::new(inner));
+
+        let Json(status) = calibration_status(State(state.clone())).await;
+        assert_eq!(status["sequence_fault_node_ids"], serde_json::json!([5]));
+
+        let Json(stopped) = calibration_stop(State(state)).await;
+        assert_eq!(stopped["success"], false);
+        assert_eq!(
+            stopped["error_code"],
+            "calibration_sequence_discontinuity"
+        );
+        assert_eq!(stopped["model_id"], "cal-model-test");
+        assert_eq!(stopped["source_node_ids"], serde_json::json!([5]));
     }
 
     fn strong_candidates() -> VitalSigns {
@@ -6420,15 +6647,15 @@ async fn calibration_start(
     let mut s = state.write().await;
     if let Some(source_node_id) = query.source_node_id {
         let now = std::time::Instant::now();
-        let source_is_live = s.node_states.get(&source_node_id).is_some_and(|node| {
-            node.last_frame_time
-                .is_some_and(|seen| now.saturating_duration_since(seen) < ESP32_OFFLINE_TIMEOUT)
-        });
+        let source_is_live = s
+            .node_states
+            .get(&source_node_id)
+            .is_some_and(|node| calibration_source_has_fresh_csi(node, now));
         if !source_is_live {
             return Json(serde_json::json!({
                 "success": false,
                 "error_code": "calibration_source_unavailable",
-                "error": "The requested calibration source is missing or stale.",
+                "error": "The requested calibration source is missing or has no fresh raw CSI.",
                 "source_node_id": source_node_id,
             }));
         }
@@ -6463,6 +6690,7 @@ async fn calibration_start(
             s.field_model = Some(fm);
             s.calibration_model_id = Some(opaque_calibration_model_id());
             s.calibration_source_node_ids.clear();
+            s.clear_calibration_sequence_state();
             if let Some(source_node_id) = query.source_node_id {
                 s.calibration_source_node_ids.insert(source_node_id);
             }
@@ -6482,6 +6710,16 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
     let mut s = state.write().await;
     let model_id = s.calibration_model_id.clone();
     let source_node_ids: Vec<u8> = s.calibration_source_node_ids.iter().copied().collect();
+    if !s.calibration_sequence_fault_node_ids.is_empty() {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "calibration_sequence_discontinuity",
+            "error": "Raw CSI sequence moved backward during capture. Cancel and restart the empty-room calibration.",
+            "model_id": model_id,
+            "source_node_ids": source_node_ids,
+            "sequence_fault_node_ids": s.calibration_sequence_fault_node_ids,
+        }));
+    }
     if let Some(ref mut fm) = s.field_model {
         // Guard: finalizing before enough empty-room frames have accumulated
         // is a client-side sequencing error, not a server fault. Return a
@@ -6585,6 +6823,7 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
         "min_duration_s": min_duration_s,
         "model_id": s.calibration_model_id,
         "source_node_ids": s.calibration_source_node_ids,
+        "sequence_fault_node_ids": s.calibration_sequence_fault_node_ids,
         "runtime_reference": runtime_reference,
         "binding_mode": if bootstrap_active { "bootstrap_only" } else if active { "runtime" } else { "none" },
         "bootstrap_baseline": s.bootstrap_baseline.as_ref().map(|metadata| serde_json::json!({
@@ -7016,6 +7255,7 @@ async fn calibration_cancel(State(state): State<SharedState>) -> Json<serde_json
     s.field_model = None;
     s.calibration_model_id = None;
     s.calibration_source_node_ids.clear();
+    s.clear_calibration_sequence_state();
     if let Some(installation_id) = s.installation_id.clone() {
         let path = bootstrap_baseline::path_in(&s.data_dir);
         if let Ok((model, metadata)) = bootstrap_baseline::load(
@@ -7040,6 +7280,7 @@ async fn calibration_reset(State(state): State<SharedState>) -> Json<serde_json:
     s.field_model = None;
     s.calibration_model_id = None;
     s.calibration_source_node_ids.clear();
+    s.clear_calibration_sequence_state();
     s.bootstrap_baseline_active = false;
     let path = bootstrap_baseline::path_in(&s.data_dir);
     let bootstrap_removed = match bootstrap_baseline::remove(&path) {
@@ -7440,8 +7681,18 @@ async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Va
                 .last_frame_time
                 .map(|t| now.duration_since(t).as_millis() as u64)
                 .unwrap_or(999999);
+            let csi_elapsed_ms = ns
+                .latest_accepted_csi_at
+                .map(|t| now.saturating_duration_since(t).as_millis() as u64);
             let stale = elapsed_ms > 5000;
             let status = if stale { "stale" } else { "active" };
+            let csi_status = if csi_elapsed_ms.is_some_and(|age| {
+                age < ESP32_OFFLINE_TIMEOUT.as_millis() as u64
+            }) {
+                "active"
+            } else {
+                "stale"
+            };
             let rssi = ns.rssi_history.back().copied().unwrap_or(-90.0);
             let bootstrap_empty = s.bootstrap_baseline_active
                 && s.bootstrap_baseline.as_ref().is_some_and(|metadata| {
@@ -7458,6 +7709,9 @@ async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Va
                 "node_id": id,
                 "status": status,
                 "last_seen_ms": elapsed_ms,
+                "csi_status": csi_status,
+                "csi_last_seen_ms": csi_elapsed_ms,
+                "csi_sequence": ns.latest_csi_sequence,
                 "rssi_dbm": rssi,
                 "motion_level": if bootstrap_empty { "absent" } else { &ns.current_motion_level },
                 "person_count": if bootstrap_empty { 0 } else { ns.prev_person_count },
@@ -7812,30 +8066,6 @@ async fn udp_receiver_task(
                             .map(|d| d.as_millis() as i64)
                             .unwrap_or(0);
                         sref.engine_bridge.observe_cycle(&sref.node_states, now_ms);
-                    }
-
-                    // Feed field model calibration if active (use per-node history for ESP32).
-                    if let Some(frame_history) = s
-                        .node_states
-                        .get(&node_id)
-                        .map(|ns| ns.frame_history.clone())
-                    {
-                        let source_allowed =
-                            calibration_source_accepts(&s.calibration_source_node_ids, node_id);
-                        let accepted = if source_allowed {
-                            if let Some(ref mut fm) = s.field_model {
-                                let before = fm.calibration_frame_count();
-                                field_bridge::maybe_feed_calibration(fm, &frame_history);
-                                fm.calibration_frame_count() > before
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        };
-                        if accepted {
-                            s.calibration_source_node_ids.insert(node_id);
-                        }
                     }
 
                     // Build nodes array with all active nodes.
@@ -8362,29 +8592,13 @@ async fn udp_receiver_task(
                         sref.engine_bridge.observe_cycle(&sref.node_states, now_ms);
                     }
 
-                    // Feed field model calibration if active (use per-node history for ESP32).
-                    if let Some(frame_history) = s
-                        .node_states
-                        .get(&node_id)
-                        .map(|ns| ns.frame_history.clone())
-                    {
-                        let source_allowed =
-                            calibration_source_accepts(&s.calibration_source_node_ids, node_id);
-                        let accepted = if source_allowed {
-                            if let Some(ref mut fm) = s.field_model {
-                                let before = fm.calibration_frame_count();
-                                field_bridge::maybe_feed_calibration(fm, &frame_history);
-                                fm.calibration_frame_count() > before
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        };
-                        if accepted {
-                            s.calibration_source_node_ids.insert(node_id);
-                        }
-                    }
+                    // Feed only this grid-admitted raw CSI observation. The
+                    // session boundary deduplicates its wrapping sequence.
+                    s.maybe_feed_calibration_frame(
+                        node_id,
+                        frame.sequence,
+                        &frame.amplitudes,
+                    );
 
                     // Build nodes array with all active nodes. ADR-141 output
                     // gating (review finding 1c): when the governed engine
@@ -10157,6 +10371,8 @@ async fn main() {
         bootstrap_baseline_active,
         calibration_model_id: args.calibrate.then(opaque_calibration_model_id),
         calibration_source_node_ids: std::collections::BTreeSet::new(),
+        calibration_last_sequences: HashMap::new(),
+        calibration_sequence_fault_node_ids: std::collections::BTreeSet::new(),
         // ADR-044 §5.2: rolling-P95 over ~30 s at 20 Hz; warm-up after 60 samples.
         p95_variance: RollingP95::new(600, 60),
         p95_motion_band_power: RollingP95::new(600, 60),

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -329,6 +329,59 @@ impl Esp32Frame {
     }
 }
 
+/// Exact CSI symbol grid used by one field model. Subcarrier count alone is
+/// insufficient because HT-LTF and HE-LTF use different tone layouts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct CsiGridKey {
+    n_subcarriers: u16,
+    ppdu_type: u8,
+}
+
+impl CsiGridKey {
+    fn from_frame(frame: &Esp32Frame) -> Self {
+        Self {
+            n_subcarriers: frame.n_subcarriers,
+            ppdu_type: frame.ppdu_type.to_byte(),
+        }
+    }
+
+    fn as_bootstrap_grid(self) -> bootstrap_baseline::BootstrapCsiGrid {
+        bootstrap_baseline::BootstrapCsiGrid {
+            n_subcarriers: self.n_subcarriers,
+            ppdu_type: self.ppdu_type,
+        }
+    }
+
+    fn from_bootstrap_grid(grid: bootstrap_baseline::BootstrapCsiGrid) -> Self {
+        Self {
+            n_subcarriers: grid.n_subcarriers,
+            ppdu_type: grid.ppdu_type,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RawGridObservation {
+    grid: CsiGridKey,
+    observed_at: std::time::Instant,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+struct CalibrationGridEvidence {
+    sample_count: usize,
+    span_s: f64,
+    rate_hz: f64,
+    max_gap_s: f64,
+    latest_age_s: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CalibrationGridBinding {
+    source_node_id: u8,
+    grid: CsiGridKey,
+    evidence: Option<CalibrationGridEvidence>,
+}
+
 /// Sensing update broadcast to WebSocket clients
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SensingUpdate {
@@ -886,6 +939,15 @@ struct NodeState {
     /// the two symbol grids in `frame_history` corrupts variance/baseline
     /// statistics. See [`NodeState::accept_grid`].
     active_grid: Option<(u16, wifi_densepose_hardware::PpduType)>,
+    /// Header-only recent raw grid observations used to choose one stable,
+    /// comparable calibration stream. No CSI amplitudes are retained here.
+    raw_grid_observations: VecDeque<RawGridObservation>,
+    /// Runtime history for the exact grid bound into the active field model.
+    /// This must not reuse `frame_history`, whose independent inference grid
+    /// may be wider and therefore not bin-comparable.
+    field_model_history: VecDeque<Vec<f64>>,
+    field_model_latest_sequence: Option<u32>,
+    field_model_latest_seen: Option<std::time::Instant>,
 }
 
 /// Default EMA alpha for temporal keypoint smoothing (RuVector Phase 2).
@@ -909,6 +971,14 @@ const NOVELTY_HISTORY_CAPACITY: usize = 64;
 /// ADR-084 Pass 3 — feature-vector schema version. Bump on changes to
 /// subcarrier ordering / normalisation so banks reject stale data.
 const NOVELTY_SKETCH_VERSION: u16 = 1;
+/// Recent header-only evidence window used to choose a stable field-model
+/// stream. The rate floor is 20% above the 1,000 / 600 s completion minimum.
+const CALIBRATION_GRID_EVIDENCE_WINDOW: std::time::Duration =
+    std::time::Duration::from_secs(20);
+const CALIBRATION_GRID_EVIDENCE_CAPACITY: usize = 1_024;
+const CALIBRATION_GRID_MIN_SPAN_S: f64 = 10.0;
+const CALIBRATION_GRID_MIN_RATE_HZ: f64 = 2.0;
+const CALIBRATION_GRID_MAX_GAP_S: f64 = 5.0;
 
 /// Lower plausibility floor (seconds) for a CSI inter-frame delta.
 ///
@@ -1212,7 +1282,127 @@ impl NodeState {
             ),
             last_novelty_score: None,
             active_grid: None,
+            raw_grid_observations: VecDeque::with_capacity(
+                CALIBRATION_GRID_EVIDENCE_CAPACITY,
+            ),
+            field_model_history: VecDeque::with_capacity(FRAME_HISTORY_CAPACITY),
+            field_model_latest_sequence: None,
+            field_model_latest_seen: None,
         }
+    }
+
+    fn observe_raw_grid(&mut self, grid: CsiGridKey, now: std::time::Instant) {
+        while self
+            .raw_grid_observations
+            .front()
+            .is_some_and(|sample| {
+                now.saturating_duration_since(sample.observed_at)
+                    > CALIBRATION_GRID_EVIDENCE_WINDOW
+            })
+        {
+            self.raw_grid_observations.pop_front();
+        }
+        if self.raw_grid_observations.len() == CALIBRATION_GRID_EVIDENCE_CAPACITY {
+            self.raw_grid_observations.pop_front();
+        }
+        self.raw_grid_observations.push_back(RawGridObservation {
+            grid,
+            observed_at: now,
+        });
+    }
+
+    fn calibration_grid_candidates(
+        &self,
+        now: std::time::Instant,
+    ) -> Vec<(CsiGridKey, CalibrationGridEvidence)> {
+        let mut grouped: Vec<(CsiGridKey, Vec<std::time::Instant>)> = Vec::new();
+        for sample in self.raw_grid_observations.iter().filter(|sample| {
+            now.saturating_duration_since(sample.observed_at)
+                <= CALIBRATION_GRID_EVIDENCE_WINDOW
+        }) {
+            if let Some((_, arrivals)) = grouped
+                .iter_mut()
+                .find(|(candidate, _)| *candidate == sample.grid)
+            {
+                arrivals.push(sample.observed_at);
+            } else {
+                grouped.push((sample.grid, vec![sample.observed_at]));
+            }
+        }
+        grouped
+            .into_iter()
+            .filter_map(|(grid, arrivals)| {
+                let first = *arrivals.first()?;
+                let last = *arrivals.last()?;
+                let span_s = last.saturating_duration_since(first).as_secs_f64();
+                let latest_age_s = now.saturating_duration_since(last).as_secs_f64();
+                let mut max_gap_s = latest_age_s;
+                for pair in arrivals.windows(2) {
+                    max_gap_s = max_gap_s.max(
+                        pair[1]
+                            .saturating_duration_since(pair[0])
+                            .as_secs_f64(),
+                    );
+                }
+                let rate_hz = if span_s > 0.0 {
+                    arrivals.len().saturating_sub(1) as f64 / span_s
+                } else {
+                    0.0
+                };
+                Some((
+                    grid,
+                    CalibrationGridEvidence {
+                        sample_count: arrivals.len(),
+                        span_s,
+                        rate_hz,
+                        max_gap_s,
+                        latest_age_s,
+                    },
+                ))
+            })
+            .collect()
+    }
+
+    fn select_calibration_grid(
+        &self,
+        now: std::time::Instant,
+    ) -> Option<(CsiGridKey, CalibrationGridEvidence)> {
+        self.calibration_grid_candidates(now)
+            .into_iter()
+            .filter(|(grid, evidence)| {
+                grid.ppdu_type <= 3
+                    && evidence.span_s >= CALIBRATION_GRID_MIN_SPAN_S
+                    && evidence.rate_hz >= CALIBRATION_GRID_MIN_RATE_HZ
+                    && evidence.max_gap_s < CALIBRATION_GRID_MAX_GAP_S
+                    && evidence.latest_age_s < CALIBRATION_GRID_MAX_GAP_S
+            })
+            .min_by(|(left_grid, left), (right_grid, right)| {
+                left.max_gap_s
+                    .total_cmp(&right.max_gap_s)
+                    .then_with(|| right.rate_hz.total_cmp(&left.rate_hz))
+                    .then_with(|| right_grid.n_subcarriers.cmp(&left_grid.n_subcarriers))
+                    .then_with(|| left_grid.ppdu_type.cmp(&right_grid.ppdu_type))
+            })
+    }
+
+    fn clear_field_model_history(&mut self) {
+        self.field_model_history.clear();
+        self.field_model_latest_sequence = None;
+        self.field_model_latest_seen = None;
+    }
+
+    fn push_field_model_frame(
+        &mut self,
+        sequence: u32,
+        amplitudes: &[f64],
+        now: std::time::Instant,
+    ) {
+        self.field_model_history.push_back(amplitudes.to_vec());
+        if self.field_model_history.len() > FRAME_HISTORY_CAPACITY {
+            self.field_model_history.pop_front();
+        }
+        self.field_model_latest_sequence = Some(sequence);
+        self.field_model_latest_seen = Some(now);
     }
 
     /// ADR-110 / issue #1005 grid gate: decide whether a frame on `grid`
@@ -1632,6 +1822,9 @@ struct AppStateInner {
     calibration_model_id: Option<String>,
     /// Nodes that actually contributed frames to the current calibration.
     calibration_source_node_ids: std::collections::BTreeSet<u8>,
+    /// Immutable source and CSI symbol grid selected from recent header-only
+    /// evidence for the current field model.
+    calibration_grid_binding: Option<CalibrationGridBinding>,
     /// Last admitted raw CSI sequence per contributing node. Edge-vitals
     /// packets do not carry a new CSI observation and cannot advance this map.
     calibration_last_sequences: HashMap<u8, u32>,
@@ -1754,11 +1947,12 @@ enum CalibrationSequenceOrder {
     Discontinuity,
 }
 
-/// Live Node 5 evidence observed a same-source receive batch ordered as high
-/// water mark, then minus three, minus two, minus one. Four covers that
-/// measured UDP reorder with one frame of margin. At the firmware's 50 Hz
-/// ceiling it spans at most 80 ms; larger backward jumps stay failed closed.
-const CALIBRATION_SEQUENCE_REORDER_WINDOW: u32 = 4;
+/// Two independent live Node 5 captures observed bounded same-source UDP
+/// reordering through depth eleven. Sixteen covers that measured maximum with
+/// five positions of margin. At the firmware's 50 Hz ceiling it spans at most
+/// 320 ms; larger backward jumps stay failed closed. Late packets inside this
+/// window are always dropped and never become model evidence.
+const CALIBRATION_SEQUENCE_REORDER_WINDOW: u32 = 16;
 
 fn calibration_sequence_order(previous: Option<u32>, sequence: u32) -> CalibrationSequenceOrder {
     let Some(previous) = previous else {
@@ -1786,10 +1980,16 @@ impl AppStateInner {
     fn maybe_feed_calibration_frame(
         &mut self,
         node_id: u8,
+        grid: CsiGridKey,
         sequence: u32,
         amplitudes: &[f64],
+        observed_at: std::time::Instant,
     ) -> bool {
-        if !calibration_source_accepts(&self.calibration_source_node_ids, node_id)
+        let binding_matches = self.calibration_grid_binding.is_some_and(|binding| {
+            binding.source_node_id == node_id && binding.grid == grid
+        });
+        if !binding_matches
+            || !calibration_source_accepts(&self.calibration_source_node_ids, node_id)
             || self.calibration_sequence_fault_node_ids.contains(&node_id)
         {
             return false;
@@ -1827,13 +2027,25 @@ impl AppStateInner {
             }
             CalibrationSequenceOrder::First | CalibrationSequenceOrder::Forward => {}
         }
-        let accepted = self
-            .field_model
-            .as_mut()
-            .is_some_and(|field| field_bridge::maybe_feed_calibration(field, amplitudes));
+        let accepted = self.field_model.as_mut().is_some_and(|field| {
+            if matches!(
+                field.status(),
+                CalibrationStatus::Uncalibrated | CalibrationStatus::Collecting
+            ) {
+                field_bridge::maybe_feed_calibration(field, amplitudes)
+            } else {
+                field.check_freshness(
+                    (chrono::Utc::now().timestamp_millis().max(0) as u64)
+                        .saturating_mul(1_000),
+                ) == CalibrationStatus::Fresh
+            }
+        });
         if accepted {
             self.calibration_source_node_ids.insert(node_id);
             self.calibration_last_sequences.insert(node_id, sequence);
+            if let Some(node) = self.node_states.get_mut(&node_id) {
+                node.push_field_model_frame(sequence, amplitudes, observed_at);
+            }
         }
         accepted
     }
@@ -1843,6 +2055,51 @@ impl AppStateInner {
         self.calibration_reordered_packets.clear();
         self.calibration_max_reorder_depth.clear();
         self.calibration_sequence_fault_node_ids.clear();
+    }
+
+    fn clear_field_model_binding(&mut self) {
+        self.calibration_grid_binding = None;
+        for node in self.node_states.values_mut() {
+            node.clear_field_model_history();
+        }
+    }
+
+    fn calibration_grid_is_fresh(
+        &self,
+        binding: CalibrationGridBinding,
+        now: std::time::Instant,
+    ) -> bool {
+        !self
+            .calibration_sequence_fault_node_ids
+            .contains(&binding.source_node_id)
+            && self
+                .node_states
+                .get(&binding.source_node_id)
+                .and_then(|node| node.field_model_latest_seen)
+                .is_some_and(|seen| {
+                    now.saturating_duration_since(seen) < ESP32_OFFLINE_TIMEOUT
+                })
+    }
+
+    fn field_model_holdout_ready(
+        &self,
+        binding: CalibrationGridBinding,
+        required_window_size: usize,
+        now: std::time::Instant,
+    ) -> bool {
+        self.calibration_grid_binding.is_some_and(|current| {
+            current.source_node_id == binding.source_node_id && current.grid == binding.grid
+        }) && self.calibration_grid_is_fresh(binding, now)
+            && self
+                .node_states
+                .get(&binding.source_node_id)
+                .is_some_and(|node| node.field_model_history.len() >= required_window_size)
+    }
+
+    fn begin_field_model_holdout(&mut self, binding: CalibrationGridBinding) {
+        if let Some(node) = self.node_states.get_mut(&binding.source_node_id) {
+            node.clear_field_model_history();
+        }
     }
 
     fn field_model_status_at(&self, observed_at_unix_ms: u64) -> Option<CalibrationStatus> {
@@ -1895,7 +2152,7 @@ impl AppStateInner {
                 let history = if let Some(node_id) = bound_source_node_id {
                     self.node_states
                         .get(&node_id)
-                        .map(|state| &state.frame_history)
+                        .map(|state| &state.field_model_history)
                         .unwrap_or(&self.frame_history)
                 } else if !self.frame_history.is_empty() {
                     &self.frame_history
@@ -1945,7 +2202,23 @@ impl AppStateInner {
         let [source_node_id] = metadata.source_node_ids.as_slice() else {
             return None;
         };
-        let history = &self.node_states.get(source_node_id)?.frame_history;
+        let binding = self.calibration_grid_binding?;
+        if binding.source_node_id != *source_node_id
+            || binding.grid != CsiGridKey::from_bootstrap_grid(metadata.source_grid)
+            || self
+                .calibration_sequence_fault_node_ids
+                .contains(source_node_id)
+        {
+            return None;
+        }
+        let node = self.node_states.get(source_node_id)?;
+        if !node.field_model_latest_seen.is_some_and(|seen| {
+            std::time::Instant::now().saturating_duration_since(seen)
+                < ESP32_OFFLINE_TIMEOUT
+        }) {
+            return None;
+        }
+        let history = &node.field_model_history;
         field_bridge::bootstrap_background_match(
             field_model,
             history,
@@ -2004,6 +2277,10 @@ impl AppStateInner {
 /// Number of frames retained in `frame_history` for temporal analysis.
 /// At 500 ms ticks this covers ~50 seconds; at 100 ms ticks ~10 seconds.
 const FRAME_HISTORY_CAPACITY: usize = 100;
+/// A qualified grid may run at the 2 Hz admission floor. Rebuilding a 50 frame
+/// runtime scoring window then needs 25 seconds, so promotion grants ten more
+/// seconds for ordinary bounded jitter before failing closed.
+const BOOTSTRAP_HOLDOUT_PREWARM_TIMEOUT_MS: u64 = 35_000;
 
 type SharedState = Arc<RwLock<AppStateInner>>;
 
@@ -2087,6 +2364,7 @@ impl AppStateInner {
             bootstrap_baseline_active: false,
             calibration_model_id: None,
             calibration_source_node_ids: std::collections::BTreeSet::new(),
+            calibration_grid_binding: None,
             calibration_last_sequences: HashMap::new(),
             calibration_reordered_packets: HashMap::new(),
             calibration_max_reorder_depth: HashMap::new(),
@@ -2140,12 +2418,30 @@ mod calibration_expiry_tests {
         let baseline = model.modes().unwrap().baseline[0].clone();
         let mut state = AppStateInner::minimal();
         state.frame_history = (0..50).map(|_| baseline.clone()).collect();
+        let mut node = NodeState::new();
+        node.field_model_history = (0..50).map(|_| baseline.clone()).collect();
+        node.field_model_latest_sequence = Some(50);
+        node.field_model_latest_seen = Some(std::time::Instant::now());
+        state.node_states.insert(5, node);
+        state.calibration_source_node_ids.insert(5);
+        state.calibration_grid_binding = Some(CalibrationGridBinding {
+            source_node_id: 5,
+            grid: CsiGridKey {
+                n_subcarriers: 64,
+                ppdu_type: 0,
+            },
+            evidence: None,
+        });
         state.field_model = Some(model);
         state.bootstrap_baseline_active = bootstrap;
         if bootstrap {
             state.bootstrap_baseline = Some(BootstrapBaselineMetadata {
                 authority: bootstrap_baseline::BOOTSTRAP_BASELINE_AUTHORITY,
                 source_node_ids: vec![5],
+                source_grid: bootstrap_baseline::BootstrapCsiGrid {
+                    n_subcarriers: 64,
+                    ppdu_type: 0,
+                },
                 source_model_id: "test-model".to_string(),
                 created_at_unix_ms: 1_000,
                 expires_at_unix_ms: 3_000,
@@ -6416,6 +6712,38 @@ fn calibration_source_has_fresh_csi(node: &NodeState, now: std::time::Instant) -
 mod bootstrap_vital_publication_tests {
     use super::*;
 
+    fn test_grid() -> CsiGridKey {
+        CsiGridKey {
+            n_subcarriers: 64,
+            ppdu_type: 0,
+        }
+    }
+
+    fn bind_test_calibration(state: &mut AppStateInner) {
+        state.calibration_source_node_ids.insert(5);
+        state.calibration_grid_binding = Some(CalibrationGridBinding {
+            source_node_id: 5,
+            grid: test_grid(),
+            evidence: None,
+        });
+        state.node_states.entry(5).or_insert_with(NodeState::new);
+    }
+
+    fn feed_test_frame(
+        state: &mut AppStateInner,
+        node_id: u8,
+        sequence: u32,
+        amplitudes: &[f64],
+    ) -> bool {
+        state.maybe_feed_calibration_frame(
+            node_id,
+            test_grid(),
+            sequence,
+            amplitudes,
+            std::time::Instant::now(),
+        )
+    }
+
     #[test]
     fn single_link_calibration_binds_to_first_source() {
         let mut sources = std::collections::BTreeSet::new();
@@ -6449,20 +6777,135 @@ mod bootstrap_vital_publication_tests {
     }
 
     #[test]
+    fn calibration_grid_selection_prefers_stable_rate_qualified_stream() {
+        let start = std::time::Instant::now();
+        let mut node = NodeState::new();
+        let stable = CsiGridKey {
+            n_subcarriers: 64,
+            ppdu_type: 0,
+        };
+        let sparse = CsiGridKey {
+            n_subcarriers: 192,
+            ppdu_type: 0,
+        };
+        for index in 0..=48 {
+            node.observe_raw_grid(
+                stable,
+                start + std::time::Duration::from_millis(index * 250),
+            );
+        }
+        for index in 0..=6 {
+            node.observe_raw_grid(
+                sparse,
+                start + std::time::Duration::from_secs(index * 2),
+            );
+        }
+        let (selected, evidence) = node
+            .select_calibration_grid(start + std::time::Duration::from_secs(12))
+            .expect("stable grid is eligible");
+        assert_eq!(selected, stable);
+        assert!(evidence.rate_hz >= 3.9);
+        assert!(evidence.max_gap_s < 5.0);
+    }
+
+    #[tokio::test]
+    async fn calibration_start_requires_evidence_then_binds_the_qualified_grid() {
+        let mut inner = AppStateInner::minimal();
+        inner.node_states.insert(5, NodeState::new());
+        let state = Arc::new(RwLock::new(inner));
+
+        let Json(unavailable) = calibration_start(
+            State(state.clone()),
+            Query(CalibrationStartQuery {
+                source_node_id: Some(5),
+            }),
+        )
+        .await;
+        assert_eq!(unavailable["success"], false);
+        assert_eq!(unavailable["error_code"], "calibration_grid_unavailable");
+        {
+            let state = state.read().await;
+            assert!(state.field_model.is_none());
+            assert!(state.calibration_model_id.is_none());
+            assert!(state.calibration_source_node_ids.is_empty());
+            assert!(state.calibration_grid_binding.is_none());
+        }
+
+        let now = std::time::Instant::now();
+        let start = now - std::time::Duration::from_secs(10);
+        {
+            let mut state = state.write().await;
+            let node = state.node_states.get_mut(&5).expect("node");
+            for index in 0..=40 {
+                node.observe_raw_grid(
+                    test_grid(),
+                    start + std::time::Duration::from_millis(index * 250),
+                );
+            }
+        }
+        let Json(started) = calibration_start(
+            State(state.clone()),
+            Query(CalibrationStartQuery {
+                source_node_id: Some(5),
+            }),
+        )
+        .await;
+        assert_eq!(started["success"], true);
+        assert_eq!(started["source_node_ids"], serde_json::json!([5]));
+        assert_eq!(started["source_grid"]["n_subcarriers"], 64);
+        assert_eq!(started["source_grid"]["ppdu_type"], 0);
+        let state = state.read().await;
+        assert!(state.field_model.is_some());
+        assert!(state.calibration_model_id.is_some());
+        assert_eq!(state.calibration_source_node_ids, [5].into_iter().collect());
+        assert_eq!(
+            state.calibration_grid_binding.map(|binding| binding.grid),
+            Some(test_grid())
+        );
+    }
+
+    #[test]
+    fn non_bound_grid_never_enters_field_model_history() {
+        let mut state = AppStateInner::minimal();
+        state.field_model = Some(
+            FieldModel::new(field_bridge::single_link_config()).expect("field model"),
+        );
+        bind_test_calibration(&mut state);
+        let wrong_grid = CsiGridKey {
+            n_subcarriers: 192,
+            ppdu_type: 0,
+        };
+        assert!(!state.maybe_feed_calibration_frame(
+            5,
+            wrong_grid,
+            41,
+            &[0.25; 192],
+            std::time::Instant::now(),
+        ));
+        assert!(state
+            .node_states
+            .get(&5)
+            .expect("node")
+            .field_model_history
+            .is_empty());
+        assert!(state.calibration_last_sequences.is_empty());
+    }
+
+    #[test]
     fn calibration_session_counts_each_unique_bound_csi_sequence_once() {
         let mut state = AppStateInner::minimal();
         state.field_model = Some(
             FieldModel::new(field_bridge::single_link_config()).expect("field model"),
         );
-        state.calibration_source_node_ids.insert(5);
+        bind_test_calibration(&mut state);
 
         let first = vec![0.25; 56];
-        assert!(state.maybe_feed_calibration_frame(5, 41, &first));
-        assert!(!state.maybe_feed_calibration_frame(5, 41, &first));
+        assert!(feed_test_frame(&mut state, 5, 41, &first));
+        assert!(!feed_test_frame(&mut state, 5, 41, &first));
 
         let second = vec![0.5; 56];
-        assert!(state.maybe_feed_calibration_frame(5, 42, &second));
-        assert!(!state.maybe_feed_calibration_frame(3, 43, &second));
+        assert!(feed_test_frame(&mut state, 5, 42, &second));
+        assert!(!feed_test_frame(&mut state, 3, 43, &second));
 
         let model = state.field_model.as_ref().expect("field model remains active");
         assert_eq!(model.calibration_frame_count(), 2);
@@ -6476,17 +6919,17 @@ mod bootstrap_vital_publication_tests {
         state.field_model = Some(
             FieldModel::new(field_bridge::single_link_config()).expect("field model"),
         );
-        state.calibration_source_node_ids.insert(5);
+        bind_test_calibration(&mut state);
         let frame = vec![0.25; 56];
 
-        assert!(state.maybe_feed_calibration_frame(5, 4_119_566, &frame));
-        assert!(!state.maybe_feed_calibration_frame(5, 4_119_563, &frame));
-        assert!(!state.maybe_feed_calibration_frame(5, 4_119_564, &frame));
-        assert!(!state.maybe_feed_calibration_frame(5, 4_119_565, &frame));
-        assert!(state.maybe_feed_calibration_frame(5, 4_119_567, &frame));
+        assert!(feed_test_frame(&mut state, 5, 4_119_566, &frame));
+        assert!(!feed_test_frame(&mut state, 5, 4_119_555, &frame));
+        assert!(!feed_test_frame(&mut state, 5, 4_119_556, &frame));
+        assert!(!feed_test_frame(&mut state, 5, 4_119_557, &frame));
+        assert!(feed_test_frame(&mut state, 5, 4_119_567, &frame));
         assert!(state.calibration_sequence_fault_node_ids.is_empty());
         assert_eq!(state.calibration_reordered_packets.get(&5), Some(&3));
-        assert_eq!(state.calibration_max_reorder_depth.get(&5), Some(&3));
+        assert_eq!(state.calibration_max_reorder_depth.get(&5), Some(&11));
         assert_eq!(
             state
                 .field_model
@@ -6503,12 +6946,12 @@ mod bootstrap_vital_publication_tests {
         state.field_model = Some(
             FieldModel::new(field_bridge::single_link_config()).expect("field model"),
         );
-        state.calibration_source_node_ids.insert(5);
+        bind_test_calibration(&mut state);
         let frame = vec![0.25; 56];
 
-        assert!(state.maybe_feed_calibration_frame(5, 100, &frame));
-        assert!(!state.maybe_feed_calibration_frame(5, 95, &frame));
-        assert!(!state.maybe_feed_calibration_frame(5, 101, &frame));
+        assert!(feed_test_frame(&mut state, 5, 100, &frame));
+        assert!(!feed_test_frame(&mut state, 5, 83, &frame));
+        assert!(!feed_test_frame(&mut state, 5, 101, &frame));
         assert!(state.calibration_sequence_fault_node_ids.contains(&5));
         assert_eq!(
             state
@@ -6532,15 +6975,15 @@ mod bootstrap_vital_publication_tests {
         state.field_model = Some(
             FieldModel::new(field_bridge::single_link_config()).expect("field model"),
         );
-        state.calibration_source_node_ids.insert(5);
+        bind_test_calibration(&mut state);
         let frame = vec![0.25; 56];
 
-        assert!(!state.maybe_feed_calibration_frame(5, u32::MAX, &[]));
+        assert!(!feed_test_frame(&mut state, 5, u32::MAX, &[]));
         assert!(state.calibration_last_sequences.is_empty());
-        assert!(state.maybe_feed_calibration_frame(5, u32::MAX, &frame));
-        assert!(state.maybe_feed_calibration_frame(5, 0, &frame));
-        assert!(!state.maybe_feed_calibration_frame(5, 0, &frame));
-        assert!(state.maybe_feed_calibration_frame(5, 1, &frame));
+        assert!(feed_test_frame(&mut state, 5, u32::MAX, &frame));
+        assert!(feed_test_frame(&mut state, 5, 0, &frame));
+        assert!(!feed_test_frame(&mut state, 5, 0, &frame));
+        assert!(feed_test_frame(&mut state, 5, 1, &frame));
         assert_eq!(
             state
                 .field_model
@@ -6570,11 +7013,11 @@ mod bootstrap_vital_publication_tests {
             CalibrationSequenceOrder::Reordered(1)
         );
         assert_eq!(
-            calibration_sequence_order(Some(8), 4),
-            CalibrationSequenceOrder::Reordered(4)
+            calibration_sequence_order(Some(32), 16),
+            CalibrationSequenceOrder::Reordered(16)
         );
         assert_eq!(
-            calibration_sequence_order(Some(8), 3),
+            calibration_sequence_order(Some(32), 15),
             CalibrationSequenceOrder::Discontinuity
         );
         assert_eq!(
@@ -6603,7 +7046,7 @@ mod bootstrap_vital_publication_tests {
 
         let Json(status) = calibration_status(State(state.clone())).await;
         assert_eq!(status["last_sequence_by_node"]["5"], 41);
-        assert_eq!(status["reorder_window_sequences"], 4);
+        assert_eq!(status["reorder_window_sequences"], 16);
         assert_eq!(status["reordered_packets_by_node"]["5"], 3);
         assert_eq!(status["max_reorder_depth_by_node"]["5"], 3);
         assert_eq!(status["sequence_fault_node_ids"], serde_json::json!([5]));
@@ -6618,6 +7061,77 @@ mod bootstrap_vital_publication_tests {
         assert_eq!(stopped["source_node_ids"], serde_json::json!([5]));
         assert_eq!(stopped["reordered_packets_by_node"]["5"], 3);
         assert_eq!(stopped["max_reorder_depth_by_node"]["5"], 3);
+    }
+
+    #[tokio::test]
+    async fn calibration_stop_rejects_missing_or_stale_grid_identity() {
+        let mut inner = AppStateInner::minimal();
+        inner.field_model = Some(
+            FieldModel::new(field_bridge::single_link_config()).expect("field model"),
+        );
+        inner.calibration_model_id = Some("cal-model-test".to_string());
+        inner.calibration_source_node_ids.insert(5);
+        let state = Arc::new(RwLock::new(inner));
+
+        let Json(missing) = calibration_stop(State(state.clone())).await;
+        assert_eq!(missing["success"], false);
+        assert_eq!(missing["error_code"], "calibration_grid_identity_missing");
+
+        {
+            let mut state = state.write().await;
+            state.calibration_grid_binding = Some(CalibrationGridBinding {
+                source_node_id: 5,
+                grid: test_grid(),
+                evidence: None,
+            });
+            state.node_states.insert(5, NodeState::new());
+        }
+        let Json(stale) = calibration_stop(State(state)).await;
+        assert_eq!(stale["success"], false);
+        assert_eq!(stale["error_code"], "calibration_grid_stale");
+    }
+
+    #[test]
+    fn post_finalize_holdout_excludes_training_history_and_sequence_faults() {
+        let mut state = AppStateInner::minimal();
+        bind_test_calibration(&mut state);
+        let binding = state.calibration_grid_binding.expect("binding");
+        let now = std::time::Instant::now();
+        {
+            let node = state.node_states.get_mut(&5).expect("node");
+            for sequence in 0..50 {
+                node.push_field_model_frame(sequence, &[0.25; 64], now);
+            }
+        }
+        assert!(state.field_model_holdout_ready(binding, 50, now));
+
+        state.begin_field_model_holdout(binding);
+        assert!(state
+            .node_states
+            .get(&5)
+            .expect("node")
+            .field_model_history
+            .is_empty());
+        assert!(!state.field_model_holdout_ready(binding, 50, now));
+
+        {
+            let node = state.node_states.get_mut(&5).expect("node");
+            for sequence in 50..100 {
+                node.push_field_model_frame(sequence, &[0.5; 64], now);
+            }
+        }
+        assert!(state.field_model_holdout_ready(binding, 50, now));
+        state.calibration_sequence_fault_node_ids.insert(5);
+        assert!(!state.field_model_holdout_ready(binding, 50, now));
+    }
+
+    #[test]
+    fn startup_calibration_flag_fails_closed_before_state_creation() {
+        assert!(validate_startup_calibration_request(false).is_ok());
+        let error = validate_startup_calibration_request(true).expect_err("must fail closed");
+        assert!(error.contains("--calibrate"));
+        assert!(error.contains("10 seconds"));
+        assert!(error.contains("source_node_id"));
     }
 
     fn strong_candidates() -> VitalSigns {
@@ -6729,21 +7243,62 @@ async fn calibration_start(
     Query(query): Query<CalibrationStartQuery>,
 ) -> Json<serde_json::Value> {
     let mut s = state.write().await;
-    if let Some(source_node_id) = query.source_node_id {
-        let now = std::time::Instant::now();
-        let source_is_live = s
-            .node_states
-            .get(&source_node_id)
-            .is_some_and(|node| calibration_source_has_fresh_csi(node, now));
-        if !source_is_live {
+    let now = std::time::Instant::now();
+    let selected_binding = if let Some(source_node_id) = query.source_node_id {
+        let Some(node) = s.node_states.get(&source_node_id) else {
             return Json(serde_json::json!({
                 "success": false,
                 "error_code": "calibration_source_unavailable",
-                "error": "The requested calibration source is missing or has no fresh raw CSI.",
+                "error": "The requested calibration source is missing.",
                 "source_node_id": source_node_id,
             }));
+        };
+        let candidates = node.calibration_grid_candidates(now);
+        let Some((grid, evidence)) = node.select_calibration_grid(now) else {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "calibration_grid_unavailable",
+                "error": "No raw CSI grid has at least 10 seconds of evidence, a 2 Hz measured rate, and a maximum gap below 5 seconds.",
+                "source_node_id": source_node_id,
+                "candidates": candidates.into_iter().map(|(grid, evidence)| serde_json::json!({
+                    "grid": grid,
+                    "evidence": evidence,
+                })).collect::<Vec<_>>(),
+            }));
+        };
+        CalibrationGridBinding {
+            source_node_id,
+            grid,
+            evidence: Some(evidence),
         }
-    }
+    } else {
+        let eligible: Vec<CalibrationGridBinding> = s
+            .node_states
+            .iter()
+            .filter_map(|(&source_node_id, node)| {
+                node.select_calibration_grid(now).map(|(grid, evidence)| {
+                    CalibrationGridBinding {
+                        source_node_id,
+                        grid,
+                        evidence: Some(evidence),
+                    }
+                })
+            })
+            .collect();
+        let [binding] = eligible.as_slice() else {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "calibration_source_required",
+                "error": "Choose exactly one eligible ESP32 source for room calibration.",
+                "eligible_sources": eligible.iter().map(|binding| serde_json::json!({
+                    "source_node_id": binding.source_node_id,
+                    "grid": binding.grid,
+                    "evidence": binding.evidence,
+                })).collect::<Vec<_>>(),
+            }));
+        };
+        *binding
+    };
     if s.bootstrap_baseline_active {
         s.field_model = None;
         s.bootstrap_baseline_active = false;
@@ -6774,15 +7329,18 @@ async fn calibration_start(
             s.field_model = Some(fm);
             s.calibration_model_id = Some(opaque_calibration_model_id());
             s.calibration_source_node_ids.clear();
+            s.clear_field_model_binding();
             s.clear_calibration_sequence_state();
-            if let Some(source_node_id) = query.source_node_id {
-                s.calibration_source_node_ids.insert(source_node_id);
-            }
+            s.calibration_source_node_ids
+                .insert(selected_binding.source_node_id);
+            s.calibration_grid_binding = Some(selected_binding);
             Json(serde_json::json!({
                 "success": true,
                 "message": "Calibration started — keep room empty while frames accumulate.",
                 "model_id": s.calibration_model_id,
                 "source_node_ids": s.calibration_source_node_ids,
+                "source_grid": selected_binding.grid,
+                "grid_evidence": selected_binding.evidence,
             }))
         }
         // ADR-080 #2: FieldModel init error chain stays server-side only.
@@ -6794,6 +7352,7 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
     let mut s = state.write().await;
     let model_id = s.calibration_model_id.clone();
     let source_node_ids: Vec<u8> = s.calibration_source_node_ids.iter().copied().collect();
+    let source_grid = s.calibration_grid_binding.map(|binding| binding.grid);
     let reordered_packets_by_node = s.calibration_reordered_packets.clone();
     let max_reorder_depth_by_node = s.calibration_max_reorder_depth.clone();
     if !s.calibration_sequence_fault_node_ids.is_empty() {
@@ -6803,9 +7362,41 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
             "error": "Raw CSI sequence moved backward beyond the bounded UDP reorder window. Cancel and restart the empty-room calibration.",
             "model_id": model_id,
             "source_node_ids": source_node_ids,
+            "source_grid": source_grid,
             "reordered_packets_by_node": reordered_packets_by_node,
             "max_reorder_depth_by_node": max_reorder_depth_by_node,
             "sequence_fault_node_ids": s.calibration_sequence_fault_node_ids,
+        }));
+    }
+    let Some(binding) = s.calibration_grid_binding else {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "calibration_grid_identity_missing",
+            "error": "The active calibration has no frozen CSI grid identity. Cancel and restart the empty room capture.",
+            "model_id": model_id,
+            "source_node_ids": source_node_ids,
+        }));
+    };
+    if source_node_ids.as_slice() != [binding.source_node_id]
+        || !s.calibration_grid_is_fresh(binding, std::time::Instant::now())
+    {
+        let latest_seen_ms = s
+            .node_states
+            .get(&binding.source_node_id)
+            .and_then(|node| node.field_model_latest_seen)
+            .map(|seen| {
+                std::time::Instant::now()
+                    .saturating_duration_since(seen)
+                    .as_millis() as u64
+            });
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "calibration_grid_stale",
+            "error": "The frozen calibration CSI grid is stale or no longer matches its source. Restore the source and retry before finalizing.",
+            "model_id": model_id,
+            "source_node_ids": source_node_ids,
+            "source_grid": source_grid,
+            "latest_seen_ms": latest_seen_ms,
         }));
     }
     if let Some(ref mut fm) = s.field_model {
@@ -6846,15 +7437,20 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
             Ok(modes) => {
                 let baseline = modes.baseline_eigenvalue_count;
                 let variance_explained = modes.variance_explained;
+                let holdout_window_size = modes.baseline_runtime_window_size;
+                let final_frame_count = fm.calibration_frame_count();
+                s.begin_field_model_holdout(binding);
                 info!("Field model calibrated: baseline_eigenvalues={baseline}, variance_explained={variance_explained:.2}");
                 Json(serde_json::json!({
                     "success": true,
                     "baseline_eigenvalue_count": baseline,
                     "variance_explained": variance_explained,
-                    "frame_count": fm.calibration_frame_count(),
+                    "frame_count": final_frame_count,
                     "elapsed_s": elapsed_s,
+                    "holdout_window_size": holdout_window_size,
                     "model_id": model_id,
                     "source_node_ids": source_node_ids,
+                    "source_grid": source_grid,
                     "reordered_packets_by_node": reordered_packets_by_node,
                     "max_reorder_depth_by_node": max_reorder_depth_by_node,
                 }))
@@ -6872,6 +7468,7 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
 
 async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
+    let now = std::time::Instant::now();
     let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
     let effective_status = s.field_model_status_at(observed_at_unix_ms);
     let active = s.field_model_active_at(observed_at_unix_ms);
@@ -6903,6 +7500,23 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
         || "none".to_string(),
         |status| format!("{status:?}").to_lowercase(),
     );
+    let grid_binding = s.calibration_grid_binding.map(|binding| {
+        let node = s.node_states.get(&binding.source_node_id);
+        let latest_seen_ms = node
+            .and_then(|node| node.field_model_latest_seen)
+            .map(|seen| now.saturating_duration_since(seen).as_millis() as u64);
+        serde_json::json!({
+            "source_node_id": binding.source_node_id,
+            "grid": binding.grid,
+            "selection_evidence": binding.evidence,
+            "latest_seen_ms": latest_seen_ms,
+            "runtime_history_frames": node.map_or(0, |node| node.field_model_history.len()),
+            "runtime_history_capacity": FRAME_HISTORY_CAPACITY,
+            "status": if latest_seen_ms.is_some_and(|age| age < ESP32_OFFLINE_TIMEOUT.as_millis() as u64)
+                && !s.calibration_sequence_fault_node_ids.contains(&binding.source_node_id)
+            { "active" } else { "stale" },
+        })
+    });
     Json(serde_json::json!({
         "active": active,
         "status": status,
@@ -6913,6 +7527,7 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
         "min_duration_s": min_duration_s,
         "model_id": s.calibration_model_id,
         "source_node_ids": s.calibration_source_node_ids,
+        "grid_binding": grid_binding,
         "last_sequence_by_node": s.calibration_last_sequences,
         "sequence_policy": "forward_only_with_bounded_udp_reorder_drop_v1",
         "reorder_window_sequences": CALIBRATION_SEQUENCE_REORDER_WINDOW,
@@ -6926,6 +7541,7 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
             "active": bootstrap_active,
             "authority": metadata.authority,
             "source_node_ids": metadata.source_node_ids,
+            "source_grid": metadata.source_grid,
             "source_model_id": metadata.source_model_id,
             "created_at_unix_ms": metadata.created_at_unix_ms,
             "expires_at_unix_ms": metadata.expires_at_unix_ms,
@@ -6960,7 +7576,7 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
 async fn calibration_promote_bootstrap(
     State(state): State<SharedState>,
 ) -> Json<serde_json::Value> {
-    let expected_model_id = {
+    let (expected_model_id, expected_binding, holdout_window_size) = {
         let s = state.read().await;
         let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
         if s.bootstrap_baseline_active || !s.explicit_calibration_fresh_at(observed_at_unix_ms) {
@@ -6970,7 +7586,7 @@ async fn calibration_promote_bootstrap(
                 "error": "Finalize an explicit room calibration before validating a startup baseline.",
             }));
         }
-        match s.calibration_model_id.clone() {
+        let model_id = match s.calibration_model_id.clone() {
             Some(model_id) => model_id,
             None => {
                 return Json(serde_json::json!({
@@ -6979,11 +7595,101 @@ async fn calibration_promote_bootstrap(
                     "error": "The active calibration has no server generated model identity.",
                 }));
             }
+        };
+        let Some(binding) = s.calibration_grid_binding else {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "calibration_grid_identity_missing",
+                "error": "The completed calibration has no frozen CSI grid identity.",
+            }));
+        };
+        if s.calibration_sequence_fault_node_ids
+            .contains(&binding.source_node_id)
+        {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "calibration_sequence_discontinuity",
+                "error": "The calibration CSI sequence faulted before validation. The model was not stored.",
+            }));
         }
+        let Some(runtime_window_size) = s
+            .field_model
+            .as_ref()
+            .and_then(|model| model.modes())
+            .and_then(|modes| modes.baseline_runtime_window_size)
+            .filter(|window_size| *window_size > 0 && *window_size <= FRAME_HISTORY_CAPACITY)
+        else {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "calibration_runtime_window_invalid",
+                "error": "The completed calibration has no valid runtime scoring window.",
+            }));
+        };
+        (model_id, binding, runtime_window_size)
     };
 
+    let prewarm_deadline = tokio::time::Instant::now()
+        + Duration::from_millis(BOOTSTRAP_HOLDOUT_PREWARM_TIMEOUT_MS);
+    loop {
+        let (identity_matches, sequence_faulted, ready, current_window_size) = {
+            let s = state.read().await;
+            let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+            let identity_matches = s.calibration_model_id.as_deref()
+                == Some(expected_model_id.as_str())
+                && s.explicit_calibration_fresh_at(observed_at_unix_ms)
+                && s.calibration_grid_binding.is_some_and(|binding| {
+                    binding.source_node_id == expected_binding.source_node_id
+                        && binding.grid == expected_binding.grid
+                });
+            let sequence_faulted = s
+                .calibration_sequence_fault_node_ids
+                .contains(&expected_binding.source_node_id);
+            let current_window_size = s
+                .node_states
+                .get(&expected_binding.source_node_id)
+                .map_or(0, |node| node.field_model_history.len());
+            (
+                identity_matches,
+                sequence_faulted,
+                s.field_model_holdout_ready(
+                    expected_binding,
+                    holdout_window_size,
+                    std::time::Instant::now(),
+                ),
+                current_window_size,
+            )
+        };
+        if sequence_faulted {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "calibration_sequence_discontinuity",
+                "error": "The calibration CSI sequence faulted while preparing held out validation. The model was not stored.",
+            }));
+        }
+        if !identity_matches {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "calibration_model_changed",
+                "error": "Calibration changed while preparing held out validation. The model was not stored.",
+            }));
+        }
+        if ready {
+            break;
+        }
+        if tokio::time::Instant::now() >= prewarm_deadline {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "bootstrap_holdout_prewarm_timeout",
+                "error": "A complete fresh CSI scoring window was not available before the held out validation timeout. The model was not stored.",
+                "required_window_size": holdout_window_size,
+                "current_window_size": current_window_size,
+            }));
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
     let mut samples = Vec::with_capacity(BOOTSTRAP_VALIDATION_SAMPLES);
-    let mut last_tick = None;
+    let mut last_sequence = None;
     let mut next_sample_at = tokio::time::Instant::now();
     for _ in 0..BOOTSTRAP_VALIDATION_SAMPLES {
         tokio::time::sleep_until(next_sample_at).await;
@@ -7000,20 +7706,40 @@ async fn calibration_promote_bootstrap(
                 let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
                 if s.calibration_model_id.as_deref() != Some(expected_model_id.as_str())
                     || !s.explicit_calibration_fresh_at(observed_at_unix_ms)
+                    || !s.calibration_grid_binding.is_some_and(|binding| {
+                        binding.source_node_id == expected_binding.source_node_id
+                            && binding.grid == expected_binding.grid
+                    })
+                    || s.calibration_sequence_fault_node_ids
+                        .contains(&expected_binding.source_node_id)
                 {
                     None
                 } else {
-                    s.latest_update.as_ref().and_then(|update| {
-                        (Some(update.tick) != last_tick).then_some((
-                            update.tick,
-                            s.person_count() == 0,
-                            update.vital_signs.is_none(),
-                        ))
-                    })
+                    s.node_states
+                        .get(&expected_binding.source_node_id)
+                        .and_then(|node| {
+                            let sequence = node.field_model_latest_sequence?;
+                            let fresh = node.field_model_latest_seen.is_some_and(|seen| {
+                                std::time::Instant::now().saturating_duration_since(seen)
+                                    < ESP32_OFFLINE_TIMEOUT
+                            }) && Some(sequence) != last_sequence;
+                            let held_out = s.field_model_holdout_ready(
+                                expected_binding,
+                                holdout_window_size,
+                                std::time::Instant::now(),
+                            );
+                            (fresh && held_out).then_some((
+                                sequence,
+                                s.person_count() == 0,
+                                s.latest_update
+                                    .as_ref()
+                                    .is_none_or(|update| update.vital_signs.is_none()),
+                            ))
+                        })
                 }
             };
-            if let Some((tick, calibrated_empty, vital_signs_absent)) = observed {
-                last_tick = Some(tick);
+            if let Some((sequence, calibrated_empty, vital_signs_absent)) = observed {
+                last_sequence = Some(sequence);
                 sample = BootstrapValidationSample {
                     fresh_tick: true,
                     calibrated_empty,
@@ -7042,6 +7768,12 @@ async fn calibration_promote_bootstrap(
     let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
     if s.calibration_model_id.as_deref() != Some(expected_model_id.as_str())
         || !s.explicit_calibration_fresh_at(observed_at_unix_ms)
+        || !s.calibration_grid_binding.is_some_and(|binding| {
+            binding.source_node_id == expected_binding.source_node_id
+                && binding.grid == expected_binding.grid
+        })
+        || s.calibration_sequence_fault_node_ids
+            .contains(&expected_binding.source_node_id)
     {
         return Json(serde_json::json!({
             "success": false,
@@ -7077,6 +7809,7 @@ async fn calibration_promote_bootstrap(
         &path,
         &installation_id,
         &source_node_ids,
+        expected_binding.grid.as_bootstrap_grid(),
         &expected_model_id,
         created_at_unix_ms,
         field_model,
@@ -7097,6 +7830,7 @@ async fn calibration_promote_bootstrap(
         "success": true,
         "message": "Validated startup baseline stored locally.",
         "validation": validation,
+        "holdout_window_size": holdout_window_size,
         "bootstrap_baseline": stored,
         "calibrated_evidence_authorized": false,
         "numeric_vitals_authorized": false,
@@ -7118,7 +7852,7 @@ async fn calibration_refine_bootstrap(
         }));
     }
 
-    let (expected_model_id, expected_digest, source_node_id) = {
+    let (expected_model_id, expected_digest, source_node_id, expected_grid) = {
         let s = state.read().await;
         let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
         let Some(metadata) = s
@@ -7153,6 +7887,7 @@ async fn calibration_refine_bootstrap(
             metadata.source_model_id.clone(),
             metadata.content_sha256.clone(),
             *source_node_id,
+            CsiGridKey::from_bootstrap_grid(metadata.source_grid),
         )
     };
 
@@ -7175,13 +7910,19 @@ async fn calibration_refine_bootstrap(
                         metadata.source_model_id == expected_model_id
                             && metadata.content_sha256 == expected_digest
                             && metadata.source_node_ids.as_slice() == [source_node_id]
+                            && CsiGridKey::from_bootstrap_grid(metadata.source_grid)
+                                == expected_grid
+                    })
+                    && s.calibration_grid_binding.is_some_and(|binding| {
+                        binding.source_node_id == source_node_id
+                            && binding.grid == expected_grid
                     });
                 if !identity_matches {
                     None
                 } else {
                     s.node_states.get(&source_node_id).and_then(|node| {
-                        let sequence = node.latest_csi_sequence?;
-                        let fresh = node.last_frame_time.is_some_and(|seen| {
+                        let sequence = node.field_model_latest_sequence?;
+                        let fresh = node.field_model_latest_seen.is_some_and(|seen| {
                             std::time::Instant::now().saturating_duration_since(seen)
                                 < ESP32_OFFLINE_TIMEOUT
                         }) && Some(sequence) != last_sequence;
@@ -7190,7 +7931,7 @@ async fn calibration_refine_bootstrap(
                         }
                         let model = s.field_model.as_ref()?;
                         let recent_frames: Vec<Vec<f64>> =
-                            node.frame_history.iter().cloned().collect();
+                            node.field_model_history.iter().cloned().collect();
                         let residual = model.empty_room_match(&recent_frames)?.residual_energy;
                         let vital_signs_absent = s
                             .latest_update
@@ -7241,6 +7982,10 @@ async fn calibration_refine_bootstrap(
             metadata.source_model_id == expected_model_id
                 && metadata.content_sha256 == expected_digest
                 && metadata.source_node_ids.as_slice() == [source_node_id]
+                && CsiGridKey::from_bootstrap_grid(metadata.source_grid) == expected_grid
+        })
+        && s.calibration_grid_binding.is_some_and(|binding| {
+            binding.source_node_id == source_node_id && binding.grid == expected_grid
         });
     if !identity_matches {
         return Json(serde_json::json!({
@@ -7298,6 +8043,7 @@ async fn calibration_refine_bootstrap(
         &path,
         &installation_id,
         &[source_node_id],
+        expected_grid.as_bootstrap_grid(),
         &expected_model_id,
         created_at_unix_ms,
         &candidate,
@@ -7350,6 +8096,7 @@ async fn calibration_cancel(State(state): State<SharedState>) -> Json<serde_json
     s.field_model = None;
     s.calibration_model_id = None;
     s.calibration_source_node_ids.clear();
+    s.clear_field_model_binding();
     s.clear_calibration_sequence_state();
     if let Some(installation_id) = s.installation_id.clone() {
         let path = bootstrap_baseline::path_in(&s.data_dir);
@@ -7358,7 +8105,21 @@ async fn calibration_cancel(State(state): State<SharedState>) -> Json<serde_json
             &installation_id,
             chrono::Utc::now().timestamp_millis() as u64,
         ) {
+            let [source_node_id] = metadata.source_node_ids.as_slice() else {
+                return Json(serde_json::json!({
+                    "success": false,
+                    "error_code": "bootstrap_source_invalid",
+                    "error": "The stored bootstrap source identity is invalid.",
+                }));
+            };
+            let binding = CalibrationGridBinding {
+                source_node_id: *source_node_id,
+                grid: CsiGridKey::from_bootstrap_grid(metadata.source_grid),
+                evidence: None,
+            };
             s.field_model = Some(model);
+            s.calibration_source_node_ids.insert(*source_node_id);
+            s.calibration_grid_binding = Some(binding);
             s.bootstrap_baseline = Some(metadata);
             s.bootstrap_baseline_active = true;
         }
@@ -7375,6 +8136,7 @@ async fn calibration_reset(State(state): State<SharedState>) -> Json<serde_json:
     s.field_model = None;
     s.calibration_model_id = None;
     s.calibration_source_node_ids.clear();
+    s.clear_field_model_binding();
     s.clear_calibration_sequence_state();
     s.bootstrap_baseline_active = false;
     let path = bootstrap_baseline::path_in(&s.data_dir);
@@ -7793,13 +8555,8 @@ async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Va
                 && s.bootstrap_baseline.as_ref().is_some_and(|metadata| {
                     metadata.source_node_ids.as_slice() == [id]
                 })
-                && s.field_model.as_ref().is_some_and(|field_model| {
-                    field_bridge::bootstrap_empty_prior_applies(
-                        field_model,
-                        &ns.frame_history,
-                        observed_at_unix_ms.saturating_mul(1_000),
-                    )
-                });
+                && s.bootstrap_background_match(observed_at_unix_ms)
+                    .is_some_and(|result| result.matches_empty);
             serde_json::json!({
                 "node_id": id,
                 "status": status,
@@ -8427,7 +9184,25 @@ async fn udp_receiver_task(
 
                     let mut s = state.write().await;
                     s.source = "esp32".to_string();
-                    s.last_esp32_frame = Some(std::time::Instant::now());
+                    let observed_at = std::time::Instant::now();
+                    s.last_esp32_frame = Some(observed_at);
+                    let grid_key = CsiGridKey::from_frame(&frame);
+                    s.node_states
+                        .entry(frame.node_id)
+                        .or_insert_with(NodeState::new)
+                        .observe_raw_grid(grid_key, observed_at);
+
+                    // The field model owns a separate, frozen grid path. Feed
+                    // it before the global inference grid gate so a stable
+                    // 64-bin stream can remain comparable even when the
+                    // independent live feature path prefers a wider grid.
+                    s.maybe_feed_calibration_frame(
+                        frame.node_id,
+                        grid_key,
+                        frame.sequence,
+                        &frame.amplitudes,
+                        observed_at,
+                    );
 
                     // ── ADR-110 / issue #1005: per-node subcarrier-grid gate ──
                     // ESP32-C6 nodes interleave HE-SU 256-bin frames (~84%)
@@ -8686,14 +9461,6 @@ async fn udp_receiver_task(
                             .unwrap_or(0);
                         sref.engine_bridge.observe_cycle(&sref.node_states, now_ms);
                     }
-
-                    // Feed only this grid-admitted raw CSI observation. The
-                    // session boundary deduplicates its wrapping sequence.
-                    s.maybe_feed_calibration_frame(
-                        node_id,
-                        frame.sequence,
-                        &frame.amplitudes,
-                    );
 
                     // Build nodes array with all active nodes. ADR-141 output
                     // gating (review finding 1c): when the governed engine
@@ -9499,6 +10266,14 @@ fn coalesce_ui_path(initial: std::path::PathBuf) -> std::path::PathBuf {
     initial
 }
 
+fn validate_startup_calibration_request(calibrate: bool) -> Result<(), &'static str> {
+    if calibrate {
+        Err("--calibrate cannot safely select a source and CSI grid at process start. Start the server normally, wait at least 10 seconds for live grid evidence, then POST /api/v1/calibration/start with one explicit source_node_id.")
+    } else {
+        Ok(())
+    }
+}
+
 #[tokio::main]
 async fn main() {
     // Initialize tracing; with the `otel` feature and
@@ -9509,6 +10284,11 @@ async fn main() {
 
     let mut args = Args::parse();
     args.ui_path = coalesce_ui_path(args.ui_path);
+
+    if let Err(error) = validate_startup_calibration_request(args.calibrate) {
+        eprintln!("Error: {error}");
+        std::process::exit(2);
+    }
 
     // Handle --benchmark mode: run vital sign benchmark and exit
     if args.benchmark {
@@ -10455,17 +11235,25 @@ async fn main() {
             "Default Room",
             engine_bridge_multistatic_cfg,
         ),
-        field_model: if args.calibrate {
-            info!("Field model calibration enabled — room should be empty during startup");
-            FieldModel::new(field_bridge::single_link_config()).ok()
-        } else {
-            bootstrap_field_model
-        },
+        field_model: bootstrap_field_model,
         installation_id: args.installation_id.clone(),
-        bootstrap_baseline: bootstrap_metadata,
+        bootstrap_baseline: bootstrap_metadata.clone(),
         bootstrap_baseline_active,
-        calibration_model_id: args.calibrate.then(opaque_calibration_model_id),
-        calibration_source_node_ids: std::collections::BTreeSet::new(),
+        calibration_model_id: None,
+        calibration_source_node_ids: bootstrap_metadata
+            .as_ref()
+            .map(|metadata| metadata.source_node_ids.iter().copied().collect())
+            .unwrap_or_default(),
+        calibration_grid_binding: bootstrap_metadata.as_ref().and_then(|metadata| {
+            let [source_node_id] = metadata.source_node_ids.as_slice() else {
+                return None;
+            };
+            Some(CalibrationGridBinding {
+                source_node_id: *source_node_id,
+                grid: CsiGridKey::from_bootstrap_grid(metadata.source_grid),
+                evidence: None,
+            })
+        }),
         calibration_last_sequences: HashMap::new(),
         calibration_reordered_packets: HashMap::new(),
         calibration_max_reorder_depth: HashMap::new(),

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -6264,6 +6264,13 @@ struct CalibrationStartQuery {
     source_node_id: Option<u8>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct BootstrapRefineQuery {
+    #[serde(default)]
+    confirmed_empty: bool,
+    source_node_id: Option<u8>,
+}
+
 async fn calibration_start(
     State(state): State<SharedState>,
     Query(query): Query<CalibrationStartQuery>,
@@ -6401,6 +6408,7 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
             "significant_eigenvalue_p95": modes.baseline_runtime_eigenvalue_count,
             "residual_energy_threshold": modes.empty_room_residual_energy_threshold,
             "residual_reference_window_count": modes.empty_room_residual_energy_reference.len(),
+            "residual_refinement_count": modes.empty_room_residual_refinement_count,
             "raw_calibration_frames_persisted": false,
         }))
     });
@@ -6605,6 +6613,227 @@ async fn calibration_promote_bootstrap(
         "success": true,
         "message": "Validated startup baseline stored locally.",
         "validation": validation,
+        "bootstrap_baseline": stored,
+        "calibrated_evidence_authorized": false,
+        "numeric_vitals_authorized": false,
+    }))
+}
+
+/// Measure one separate operator-confirmed empty holdout and make a bounded,
+/// single-use adjustment to a restored bootstrap residual boundary. Only
+/// scalar residual energies enter the persisted image; raw CSI never does.
+async fn calibration_refine_bootstrap(
+    State(state): State<SharedState>,
+    Query(query): Query<BootstrapRefineQuery>,
+) -> Json<serde_json::Value> {
+    if !query.confirmed_empty {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "empty_confirmation_required",
+            "error": "Explicit empty-room confirmation is required for bootstrap refinement.",
+        }));
+    }
+
+    let (expected_model_id, expected_digest, source_node_id) = {
+        let s = state.read().await;
+        let Some(metadata) = s.bootstrap_baseline.as_ref().filter(|_| s.bootstrap_baseline_active)
+        else {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "bootstrap_not_active",
+                "error": "A restored startup baseline must be active before refinement.",
+            }));
+        };
+        let [source_node_id] = metadata.source_node_ids.as_slice() else {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "bootstrap_source_invalid",
+                "error": "Bootstrap refinement requires exactly one bound source node.",
+            }));
+        };
+        if query
+            .source_node_id
+            .is_some_and(|requested| requested != *source_node_id)
+        {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "bootstrap_source_mismatch",
+                "error": "The requested source does not match the stored bootstrap source.",
+            }));
+        }
+        (
+            metadata.source_model_id.clone(),
+            metadata.content_sha256.clone(),
+            *source_node_id,
+        )
+    };
+
+    let mut residuals = Vec::with_capacity(BOOTSTRAP_VALIDATION_SAMPLES);
+    let mut stale_sample_count = 0usize;
+    let mut vital_sign_sample_count = 0usize;
+    let mut last_sequence = None;
+    let mut next_sample_at = tokio::time::Instant::now();
+    for _ in 0..BOOTSTRAP_VALIDATION_SAMPLES {
+        tokio::time::sleep_until(next_sample_at).await;
+        let interval_deadline = tokio::time::Instant::now()
+            + Duration::from_millis(BOOTSTRAP_VALIDATION_SAMPLE_TIMEOUT_MS);
+        let mut observed = None;
+        while tokio::time::Instant::now() < interval_deadline {
+            observed = {
+                let s = state.read().await;
+                let identity_matches = s.bootstrap_baseline_active
+                    && s.bootstrap_baseline.as_ref().is_some_and(|metadata| {
+                        metadata.source_model_id == expected_model_id
+                            && metadata.content_sha256 == expected_digest
+                            && metadata.source_node_ids.as_slice() == [source_node_id]
+                    });
+                if !identity_matches {
+                    None
+                } else {
+                    s.node_states.get(&source_node_id).and_then(|node| {
+                        let sequence = node.latest_csi_sequence?;
+                        let fresh = node.last_frame_time.is_some_and(|seen| {
+                            std::time::Instant::now().saturating_duration_since(seen)
+                                < ESP32_OFFLINE_TIMEOUT
+                        }) && Some(sequence) != last_sequence;
+                        if !fresh {
+                            return None;
+                        }
+                        let model = s.field_model.as_ref()?;
+                        let recent_frames: Vec<Vec<f64>> =
+                            node.frame_history.iter().cloned().collect();
+                        let residual = model.empty_room_match(&recent_frames)?.residual_energy;
+                        let vital_signs_absent = s
+                            .latest_update
+                            .as_ref()
+                            .is_some_and(|update| update.vital_signs.is_none());
+                        Some((sequence, residual, vital_signs_absent))
+                    })
+                }
+            };
+            if observed.is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        if let Some((sequence, residual, vital_signs_absent)) = observed {
+            last_sequence = Some(sequence);
+            residuals.push(residual);
+            if !vital_signs_absent {
+                vital_sign_sample_count += 1;
+            }
+        } else {
+            stale_sample_count += 1;
+        }
+        next_sample_at = tokio::time::Instant::now()
+            + Duration::from_millis(BOOTSTRAP_VALIDATION_MIN_SPACING_MS);
+    }
+
+    if residuals.len() != BOOTSTRAP_VALIDATION_SAMPLES
+        || stale_sample_count != 0
+        || vital_sign_sample_count != 0
+    {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "bootstrap_refinement_validation_failed",
+            "error": "The fresh empty-room refinement gate did not pass. The stored baseline was not changed.",
+            "validation": {
+                "sample_count": residuals.len(),
+                "stale_sample_count": stale_sample_count,
+                "vital_sign_sample_count": vital_sign_sample_count,
+            },
+        }));
+    }
+
+    let mut s = state.write().await;
+    let identity_matches = s.bootstrap_baseline_active
+        && s.bootstrap_baseline.as_ref().is_some_and(|metadata| {
+            metadata.source_model_id == expected_model_id
+                && metadata.content_sha256 == expected_digest
+                && metadata.source_node_ids.as_slice() == [source_node_id]
+        });
+    if !identity_matches {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "bootstrap_changed",
+            "error": "The bootstrap identity changed during refinement. The stored baseline was not changed.",
+        }));
+    }
+    let candidate_snapshot = match s
+        .field_model
+        .as_ref()
+        .ok_or(wifi_densepose_signal::ruvsense::field_model::FieldModelError::NotCalibrated)
+        .and_then(|model| model.export_snapshot())
+    {
+        Ok(snapshot) => snapshot,
+        Err(_) => {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "bootstrap_refinement_rejected",
+                "error": "The bootstrap model rejected this bounded refinement.",
+            }));
+        }
+    };
+    let now_us = chrono::Utc::now().timestamp_micros() as u64;
+    let mut candidate = match FieldModel::from_snapshot(candidate_snapshot, now_us) {
+        Ok(model) => model,
+        Err(_) => {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "bootstrap_refinement_rejected",
+                "error": "The bootstrap model rejected this bounded refinement.",
+            }));
+        }
+    };
+    let refinement = match candidate.refine_empty_room_residual_boundary(&residuals) {
+        Ok(refinement) => refinement,
+        Err(_) => {
+            return Json(serde_json::json!({
+                "success": false,
+                "error_code": "bootstrap_refinement_rejected",
+                "error": "The bootstrap model rejected this bounded refinement.",
+            }));
+        }
+    };
+    let Some(installation_id) = s.installation_id.clone() else {
+        return Json(serde_json::json!({
+            "success": false,
+            "error_code": "installation_id_required",
+            "error": "A stable installation identity is required to store a local startup baseline.",
+        }));
+    };
+    let path = bootstrap_baseline::path_in(&s.data_dir);
+    let created_at_unix_ms = chrono::Utc::now().timestamp_millis() as u64;
+    let stored = match bootstrap_baseline::store(
+        &path,
+        &installation_id,
+        &[source_node_id],
+        &expected_model_id,
+        created_at_unix_ms,
+        &candidate,
+    ) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return error_response::internal_error_json("bootstrap baseline refinement store", error)
+        }
+    };
+    s.field_model = Some(candidate);
+    s.bootstrap_baseline = Some(stored.clone());
+    Json(serde_json::json!({
+        "success": true,
+        "message": "The local empty-room startup baseline was refined.",
+        "validation": {
+            "sample_count": residuals.len(),
+            "stale_sample_count": stale_sample_count,
+            "vital_sign_sample_count": vital_sign_sample_count,
+        },
+        "refinement": {
+            "threshold_before": refinement.threshold_before,
+            "threshold_after": refinement.threshold_after,
+            "held_out_p95": refinement.held_out_p95,
+            "held_out_sample_count": refinement.held_out_sample_count,
+            "reference_window_count": refinement.reference_window_count,
+        },
         "bootstrap_baseline": stored,
         "calibrated_evidence_authorized": false,
         "numeric_vitals_authorized": false,
@@ -10053,6 +10282,10 @@ async fn main() {
         .route(
             "/api/v1/calibration/bootstrap/promote",
             post(calibration_promote_bootstrap),
+        )
+        .route(
+            "/api/v1/calibration/bootstrap/refine",
+            post(calibration_refine_bootstrap),
         )
         .route("/api/v1/calibration/cancel", post(calibration_cancel))
         .route("/api/v1/calibration/status", get(calibration_status))

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -6520,10 +6520,12 @@ mod bootstrap_vital_publication_tests {
         );
         inner.calibration_model_id = Some("cal-model-test".to_string());
         inner.calibration_source_node_ids.insert(5);
+        inner.calibration_last_sequences.insert(5, 41);
         inner.calibration_sequence_fault_node_ids.insert(5);
         let state = Arc::new(RwLock::new(inner));
 
         let Json(status) = calibration_status(State(state.clone())).await;
+        assert_eq!(status["last_sequence_by_node"]["5"], 41);
         assert_eq!(status["sequence_fault_node_ids"], serde_json::json!([5]));
 
         let Json(stopped) = calibration_stop(State(state)).await;
@@ -6823,6 +6825,7 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
         "min_duration_s": min_duration_s,
         "model_id": s.calibration_model_id,
         "source_node_ids": s.calibration_source_node_ids,
+        "last_sequence_by_node": s.calibration_last_sequences,
         "sequence_fault_node_ids": s.calibration_sequence_fault_node_ids,
         "runtime_reference": runtime_reference,
         "binding_mode": if bootstrap_active { "bootstrap_only" } else if active { "runtime" } else { "none" },

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1635,8 +1635,13 @@ struct AppStateInner {
     /// Last admitted raw CSI sequence per contributing node. Edge-vitals
     /// packets do not carry a new CSI observation and cannot advance this map.
     calibration_last_sequences: HashMap<u8, u32>,
-    /// Nodes whose sequence moved backward during the current session. Without
-    /// a wire boot epoch, the session must stay failed closed after regression.
+    /// Late packets inside the bounded UDP reorder window are ignored rather
+    /// than counted. These receipts make the transport behavior auditable.
+    calibration_reordered_packets: HashMap<u8, u64>,
+    calibration_max_reorder_depth: HashMap<u8, u32>,
+    /// Nodes whose sequence moved backward beyond the bounded UDP reorder
+    /// window during the current session. Without a wire boot epoch, the
+    /// session must stay failed closed after a material discontinuity.
     calibration_sequence_fault_node_ids: std::collections::BTreeSet<u8>,
     // ── ADR-044 §5.2: adaptive rolling-p95 normalization ─────────────────────
     /// Rolling P95 of `FeatureInfo.variance` over the last ~30 s (600 frames @ 20 Hz).
@@ -1745,8 +1750,15 @@ enum CalibrationSequenceOrder {
     First,
     Forward,
     Duplicate,
-    Regression,
+    Reordered(u32),
+    Discontinuity,
 }
+
+/// Live Node 5 evidence observed a same-source receive batch ordered as high
+/// water mark, then minus three, minus two, minus one. Four covers that
+/// measured UDP reorder with one frame of margin. At the firmware's 50 Hz
+/// ceiling it spans at most 80 ms; larger backward jumps stay failed closed.
+const CALIBRATION_SEQUENCE_REORDER_WINDOW: u32 = 4;
 
 fn calibration_sequence_order(previous: Option<u32>, sequence: u32) -> CalibrationSequenceOrder {
     let Some(previous) = previous else {
@@ -1758,7 +1770,12 @@ fn calibration_sequence_order(previous: Option<u32>, sequence: u32) -> Calibrati
     } else if delta < (1_u32 << 31) {
         CalibrationSequenceOrder::Forward
     } else {
-        CalibrationSequenceOrder::Regression
+        let reorder_depth = previous.wrapping_sub(sequence);
+        if reorder_depth <= CALIBRATION_SEQUENCE_REORDER_WINDOW {
+            CalibrationSequenceOrder::Reordered(reorder_depth)
+        } else {
+            CalibrationSequenceOrder::Discontinuity
+        }
     }
 }
 
@@ -1780,13 +1797,31 @@ impl AppStateInner {
         let previous_sequence = self.calibration_last_sequences.get(&node_id).copied();
         match calibration_sequence_order(previous_sequence, sequence) {
             CalibrationSequenceOrder::Duplicate => return false,
-            CalibrationSequenceOrder::Regression => {
+            CalibrationSequenceOrder::Reordered(depth) => {
+                *self
+                    .calibration_reordered_packets
+                    .entry(node_id)
+                    .or_default() += 1;
+                self.calibration_max_reorder_depth
+                    .entry(node_id)
+                    .and_modify(|observed| *observed = (*observed).max(depth))
+                    .or_insert(depth);
+                debug!(
+                    node_id,
+                    previous_sequence,
+                    sequence,
+                    depth,
+                    "Ignored bounded late CSI packet during calibration"
+                );
+                return false;
+            }
+            CalibrationSequenceOrder::Discontinuity => {
                 self.calibration_sequence_fault_node_ids.insert(node_id);
                 warn!(
                     node_id,
                     previous_sequence,
                     sequence,
-                    "Calibration source sequence regressed; restart the empty-room capture"
+                    "Calibration source sequence discontinuity exceeded reorder window; restart the empty-room capture"
                 );
                 return false;
             }
@@ -1805,6 +1840,8 @@ impl AppStateInner {
 
     fn clear_calibration_sequence_state(&mut self) {
         self.calibration_last_sequences.clear();
+        self.calibration_reordered_packets.clear();
+        self.calibration_max_reorder_depth.clear();
         self.calibration_sequence_fault_node_ids.clear();
     }
 
@@ -2051,6 +2088,8 @@ impl AppStateInner {
             calibration_model_id: None,
             calibration_source_node_ids: std::collections::BTreeSet::new(),
             calibration_last_sequences: HashMap::new(),
+            calibration_reordered_packets: HashMap::new(),
+            calibration_max_reorder_depth: HashMap::new(),
             calibration_sequence_fault_node_ids: std::collections::BTreeSet::new(),
             p95_variance: RollingP95::new(600, 60),
             p95_motion_band_power: RollingP95::new(600, 60),
@@ -6432,7 +6471,7 @@ mod bootstrap_vital_publication_tests {
     }
 
     #[test]
-    fn calibration_sequence_regression_latches_session_failure() {
+    fn calibration_bounded_reorder_is_dropped_without_feeding_model() {
         let mut state = AppStateInner::minimal();
         state.field_model = Some(
             FieldModel::new(field_bridge::single_link_config()).expect("field model"),
@@ -6440,11 +6479,14 @@ mod bootstrap_vital_publication_tests {
         state.calibration_source_node_ids.insert(5);
         let frame = vec![0.25; 56];
 
-        assert!(state.maybe_feed_calibration_frame(5, 10, &frame));
-        assert!(state.maybe_feed_calibration_frame(5, 11, &frame));
-        assert!(!state.maybe_feed_calibration_frame(5, 10, &frame));
-        assert!(!state.maybe_feed_calibration_frame(5, 12, &frame));
-        assert!(state.calibration_sequence_fault_node_ids.contains(&5));
+        assert!(state.maybe_feed_calibration_frame(5, 4_119_566, &frame));
+        assert!(!state.maybe_feed_calibration_frame(5, 4_119_563, &frame));
+        assert!(!state.maybe_feed_calibration_frame(5, 4_119_564, &frame));
+        assert!(!state.maybe_feed_calibration_frame(5, 4_119_565, &frame));
+        assert!(state.maybe_feed_calibration_frame(5, 4_119_567, &frame));
+        assert!(state.calibration_sequence_fault_node_ids.is_empty());
+        assert_eq!(state.calibration_reordered_packets.get(&5), Some(&3));
+        assert_eq!(state.calibration_max_reorder_depth.get(&5), Some(&3));
         assert_eq!(
             state
                 .field_model
@@ -6453,10 +6495,35 @@ mod bootstrap_vital_publication_tests {
                 .calibration_frame_count(),
             2
         );
+    }
+
+    #[test]
+    fn calibration_sequence_discontinuity_latches_session_failure() {
+        let mut state = AppStateInner::minimal();
+        state.field_model = Some(
+            FieldModel::new(field_bridge::single_link_config()).expect("field model"),
+        );
+        state.calibration_source_node_ids.insert(5);
+        let frame = vec![0.25; 56];
+
+        assert!(state.maybe_feed_calibration_frame(5, 100, &frame));
+        assert!(!state.maybe_feed_calibration_frame(5, 95, &frame));
+        assert!(!state.maybe_feed_calibration_frame(5, 101, &frame));
+        assert!(state.calibration_sequence_fault_node_ids.contains(&5));
+        assert_eq!(
+            state
+                .field_model
+                .as_ref()
+                .expect("field model")
+                .calibration_frame_count(),
+            1
+        );
 
         state.clear_calibration_sequence_state();
         assert!(state.calibration_sequence_fault_node_ids.is_empty());
         assert!(state.calibration_last_sequences.is_empty());
+        assert!(state.calibration_reordered_packets.is_empty());
+        assert!(state.calibration_max_reorder_depth.is_empty());
     }
 
     #[test]
@@ -6485,7 +6552,7 @@ mod bootstrap_vital_publication_tests {
     }
 
     #[test]
-    fn calibration_sequence_order_rejects_backward_and_half_range() {
+    fn calibration_sequence_order_drops_bounded_late_and_rejects_discontinuity() {
         assert_eq!(
             calibration_sequence_order(None, 7),
             CalibrationSequenceOrder::First
@@ -6500,11 +6567,19 @@ mod bootstrap_vital_publication_tests {
         );
         assert_eq!(
             calibration_sequence_order(Some(8), 7),
-            CalibrationSequenceOrder::Regression
+            CalibrationSequenceOrder::Reordered(1)
+        );
+        assert_eq!(
+            calibration_sequence_order(Some(8), 4),
+            CalibrationSequenceOrder::Reordered(4)
+        );
+        assert_eq!(
+            calibration_sequence_order(Some(8), 3),
+            CalibrationSequenceOrder::Discontinuity
         );
         assert_eq!(
             calibration_sequence_order(Some(0), 1_u32 << 31),
-            CalibrationSequenceOrder::Regression
+            CalibrationSequenceOrder::Discontinuity
         );
         assert_eq!(
             calibration_sequence_order(Some(u32::MAX), 0),
@@ -6521,11 +6596,16 @@ mod bootstrap_vital_publication_tests {
         inner.calibration_model_id = Some("cal-model-test".to_string());
         inner.calibration_source_node_ids.insert(5);
         inner.calibration_last_sequences.insert(5, 41);
+        inner.calibration_reordered_packets.insert(5, 3);
+        inner.calibration_max_reorder_depth.insert(5, 3);
         inner.calibration_sequence_fault_node_ids.insert(5);
         let state = Arc::new(RwLock::new(inner));
 
         let Json(status) = calibration_status(State(state.clone())).await;
         assert_eq!(status["last_sequence_by_node"]["5"], 41);
+        assert_eq!(status["reorder_window_sequences"], 4);
+        assert_eq!(status["reordered_packets_by_node"]["5"], 3);
+        assert_eq!(status["max_reorder_depth_by_node"]["5"], 3);
         assert_eq!(status["sequence_fault_node_ids"], serde_json::json!([5]));
 
         let Json(stopped) = calibration_stop(State(state)).await;
@@ -6536,6 +6616,8 @@ mod bootstrap_vital_publication_tests {
         );
         assert_eq!(stopped["model_id"], "cal-model-test");
         assert_eq!(stopped["source_node_ids"], serde_json::json!([5]));
+        assert_eq!(stopped["reordered_packets_by_node"]["5"], 3);
+        assert_eq!(stopped["max_reorder_depth_by_node"]["5"], 3);
     }
 
     fn strong_candidates() -> VitalSigns {
@@ -6712,13 +6794,17 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
     let mut s = state.write().await;
     let model_id = s.calibration_model_id.clone();
     let source_node_ids: Vec<u8> = s.calibration_source_node_ids.iter().copied().collect();
+    let reordered_packets_by_node = s.calibration_reordered_packets.clone();
+    let max_reorder_depth_by_node = s.calibration_max_reorder_depth.clone();
     if !s.calibration_sequence_fault_node_ids.is_empty() {
         return Json(serde_json::json!({
             "success": false,
             "error_code": "calibration_sequence_discontinuity",
-            "error": "Raw CSI sequence moved backward during capture. Cancel and restart the empty-room calibration.",
+            "error": "Raw CSI sequence moved backward beyond the bounded UDP reorder window. Cancel and restart the empty-room calibration.",
             "model_id": model_id,
             "source_node_ids": source_node_ids,
+            "reordered_packets_by_node": reordered_packets_by_node,
+            "max_reorder_depth_by_node": max_reorder_depth_by_node,
             "sequence_fault_node_ids": s.calibration_sequence_fault_node_ids,
         }));
     }
@@ -6769,6 +6855,8 @@ async fn calibration_stop(State(state): State<SharedState>) -> Json<serde_json::
                     "elapsed_s": elapsed_s,
                     "model_id": model_id,
                     "source_node_ids": source_node_ids,
+                    "reordered_packets_by_node": reordered_packets_by_node,
+                    "max_reorder_depth_by_node": max_reorder_depth_by_node,
                 }))
             }
             // ADR-080 #2: finalize error chain stays server-side only.
@@ -6826,6 +6914,10 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
         "model_id": s.calibration_model_id,
         "source_node_ids": s.calibration_source_node_ids,
         "last_sequence_by_node": s.calibration_last_sequences,
+        "sequence_policy": "forward_only_with_bounded_udp_reorder_drop_v1",
+        "reorder_window_sequences": CALIBRATION_SEQUENCE_REORDER_WINDOW,
+        "reordered_packets_by_node": s.calibration_reordered_packets,
+        "max_reorder_depth_by_node": s.calibration_max_reorder_depth,
         "sequence_fault_node_ids": s.calibration_sequence_fault_node_ids,
         "runtime_reference": runtime_reference,
         "binding_mode": if bootstrap_active { "bootstrap_only" } else if active { "runtime" } else { "none" },
@@ -10375,6 +10467,8 @@ async fn main() {
         calibration_model_id: args.calibrate.then(opaque_calibration_model_id),
         calibration_source_node_ids: std::collections::BTreeSet::new(),
         calibration_last_sequences: HashMap::new(),
+        calibration_reordered_packets: HashMap::new(),
+        calibration_max_reorder_depth: HashMap::new(),
         calibration_sequence_fault_node_ids: std::collections::BTreeSet::new(),
         // ADR-044 §5.2: rolling-P95 over ~30 s at 20 Hz; warm-up after 60 samples.
         p95_variance: RollingP95::new(600, 60),

--- a/v2/crates/wifi-densepose-sensing-server/src/types.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/types.rs
@@ -544,6 +544,10 @@ impl AppStateInner {
     pub fn person_count(&self) -> usize {
         use crate::csi::score_to_person_count;
         use crate::field_bridge;
+        let observed_at_us = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_micros() as u64)
+            .unwrap_or(0);
         match self.field_model.as_ref() {
             Some(fm) => {
                 let history = if !self.frame_history.is_empty() {
@@ -559,6 +563,7 @@ impl AppStateInner {
                 field_bridge::occupancy_or_fallback(
                     fm,
                     history,
+                    observed_at_us,
                     self.smoothed_person_score,
                     self.prev_person_count,
                 )

--- a/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
@@ -346,6 +346,31 @@ impl VitalSignDetector {
         self.frame_count = 0;
     }
 
+    /// Retune temporal windows to an observed CSI clock. Changes smaller than
+    /// twenty percent are ignored to avoid resetting on normal arrival jitter.
+    /// A real clock change clears history so samples from different clocks are
+    /// never interpreted in one spectrum.
+    pub fn reconfigure_sample_rate(&mut self, sample_rate: f64) -> bool {
+        if !sample_rate.is_finite() || sample_rate < 1.0 {
+            return false;
+        }
+        let relative_change = (sample_rate - self.sample_rate).abs() / self.sample_rate.max(1.0);
+        if relative_change < 0.20 {
+            return false;
+        }
+        self.sample_rate = sample_rate;
+        self.breathing_capacity =
+            ((sample_rate * self.breathing_window_secs) as usize).max(1);
+        self.heartbeat_capacity =
+            ((sample_rate * self.heartbeat_window_secs) as usize).max(1);
+        self.reset();
+        true
+    }
+
+    pub fn sample_rate_hz(&self) -> f64 {
+        self.sample_rate
+    }
+
     /// Current buffer fill levels for diagnostics.
     /// Returns (breathing_len, breathing_capacity, heartbeat_len, heartbeat_capacity).
     pub fn buffer_status(&self) -> (usize, usize, usize, usize) {
@@ -840,6 +865,22 @@ mod tests {
         let (br_len, _, hb_len, _) = detector.buffer_status();
         assert_eq!(br_len, 0);
         assert_eq!(hb_len, 0);
+    }
+
+    #[test]
+    fn measured_clock_reconfigures_once_and_clears_mixed_history() {
+        let mut detector = VitalSignDetector::new(20.0);
+        let amp = vec![10.0; 56];
+        let phase = vec![0.0; 56];
+        for _ in 0..32 {
+            detector.process_frame(&amp, &phase);
+        }
+        assert!(!detector.reconfigure_sample_rate(18.0));
+        assert_eq!(detector.sample_rate_hz(), 20.0);
+        assert!(detector.reconfigure_sample_rate(12.0));
+        assert_eq!(detector.sample_rate_hz(), 12.0);
+        assert_eq!(detector.buffer_status(), (0, 360, 0, 180));
+        assert!(!detector.reconfigure_sample_rate(f64::NAN));
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
+++ b/v2/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
@@ -57,6 +57,10 @@ pub const MIN_CALIBRATION_FRAMES: usize =
     RUNTIME_OCCUPANCY_WINDOW * MIN_BACKGROUND_REFERENCE_WINDOWS;
 const CALIBRATION_BACKGROUND_WINDOWS_MAX: usize = 512;
 const EMPTY_ROOM_RESIDUAL_MARGIN: f64 = 1.5;
+const EMPTY_ROOM_HELD_OUT_MARGIN: f64 = 1.10;
+const EMPTY_ROOM_REFINEMENT_MAX_LIFT: f64 = 1.25;
+const EMPTY_ROOM_REFINEMENT_MIN_SAMPLES: usize = 10;
+const EMPTY_ROOM_REFINEMENT_MAX_SAMPLES: usize = 64;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -362,6 +366,11 @@ pub struct FieldNormalMode {
     /// an empty room model into positive person evidence.
     #[serde(default)]
     pub empty_room_residual_energy_reference: Vec<f64>,
+    /// Number of operator-confirmed held-out empty refinements. Version one
+    /// permits one bounded refinement so repeated calls cannot ratchet the
+    /// background boundary upward until a weak occupant is suppressed.
+    #[serde(default)]
+    pub empty_room_residual_refinement_count: u8,
 }
 
 /// A bounded comparison between one runtime window and the learned empty room
@@ -374,6 +383,16 @@ pub struct EmptyRoomMatch {
     pub residual_energy: f64,
     pub residual_energy_threshold: f64,
     pub window_size: usize,
+    pub reference_window_count: usize,
+}
+
+/// Receipt for one bounded, operator-confirmed empty-room refinement.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EmptyRoomRefinement {
+    pub threshold_before: f64,
+    pub threshold_after: f64,
+    pub held_out_p95: f64,
+    pub held_out_sample_count: usize,
     pub reference_window_count: usize,
 }
 
@@ -692,6 +711,73 @@ impl FieldModel {
             .and_then(|modes| modes.empty_room_residual_energy_threshold)
     }
 
+    /// Refine a completed single-link empty-room boundary with scalar residuals
+    /// measured during a separate operator-confirmed empty holdout.
+    ///
+    /// This never ingests or persists raw CSI. The lift is capped at 25 percent
+    /// and may happen only once per snapshot, preventing repeated calls from
+    /// silently erasing weak occupied evidence.
+    pub fn refine_empty_room_residual_boundary(
+        &mut self,
+        held_out_residuals: &[f64],
+    ) -> Result<EmptyRoomRefinement, FieldModelError> {
+        if self.config.n_links != 1 || self.status != CalibrationStatus::Fresh {
+            return Err(FieldModelError::NotCalibrated);
+        }
+        if !(EMPTY_ROOM_REFINEMENT_MIN_SAMPLES..=EMPTY_ROOM_REFINEMENT_MAX_SAMPLES)
+            .contains(&held_out_residuals.len())
+            || held_out_residuals
+                .iter()
+                .any(|value| !value.is_finite() || *value < 0.0)
+        {
+            return Err(FieldModelError::InvalidConfig(
+                "held-out empty residuals are missing, excessive, or non-finite".into(),
+            ));
+        }
+        let modes = self.modes.as_mut().ok_or(FieldModelError::NotCalibrated)?;
+        if modes.empty_room_residual_refinement_count != 0 {
+            return Err(FieldModelError::InvalidConfig(
+                "the empty-room boundary already has its one permitted held-out refinement"
+                    .into(),
+            ));
+        }
+        if modes.empty_room_residual_energy_reference.len() + held_out_residuals.len()
+            > CALIBRATION_BACKGROUND_WINDOWS_MAX
+        {
+            return Err(FieldModelError::InvalidConfig(
+                "the empty-room residual reference limit would be exceeded".into(),
+            ));
+        }
+        let threshold_before = modes
+            .empty_room_residual_energy_threshold
+            .ok_or(FieldModelError::NotCalibrated)?
+            .max(EMPTY_ROOM_RESIDUAL_ENERGY_MAX);
+        let held_out_p95 = percentile_95(held_out_residuals.to_vec())
+            .ok_or(FieldModelError::NotCalibrated)?;
+        let proposed = held_out_p95 * EMPTY_ROOM_HELD_OUT_MARGIN;
+        let threshold_after = threshold_before
+            .max(proposed.min(threshold_before * EMPTY_ROOM_REFINEMENT_MAX_LIFT));
+
+        modes
+            .empty_room_residual_energy_reference
+            .extend_from_slice(held_out_residuals);
+        modes
+            .empty_room_residual_energy_reference
+            .sort_by(|left, right| {
+                left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal)
+            });
+        modes.empty_room_residual_energy_threshold = Some(threshold_after);
+        modes.empty_room_residual_refinement_count = 1;
+
+        Ok(EmptyRoomRefinement {
+            threshold_before,
+            threshold_after,
+            held_out_p95,
+            held_out_sample_count: held_out_residuals.len(),
+            reference_window_count: modes.empty_room_residual_energy_reference.len(),
+        })
+    }
+
     /// Export aggregate model state suitable for local restart persistence.
     /// Raw calibration observations and Welford accumulators are not exported.
     pub fn export_snapshot(&self) -> Result<FieldModelSnapshotV1, FieldModelError> {
@@ -762,6 +848,7 @@ impl FieldModel {
                 .is_none_or(|threshold| threshold.is_finite() && threshold >= 0.0)
             && modes.empty_room_residual_energy_reference.len()
                 <= CALIBRATION_BACKGROUND_WINDOWS_MAX
+            && modes.empty_room_residual_refinement_count <= 1
             && modes
                 .empty_room_residual_energy_reference
                 .iter()
@@ -1118,6 +1205,7 @@ impl FieldModel {
             baseline_runtime_window_size: None,
             empty_room_residual_energy_threshold: None,
             empty_room_residual_energy_reference: Vec::new(),
+            empty_room_residual_refinement_count: 0,
         };
 
         // The full calibration covariance and a fifty frame runtime covariance
@@ -2064,6 +2152,44 @@ mod tests {
         assert!(background
             .score
             .is_some_and(|score| (0.5..=1.0).contains(&score)));
+    }
+
+    #[test]
+    fn held_out_empty_refinement_is_bounded_and_single_use() {
+        let config = FieldModelConfig {
+            n_links: 1,
+            n_subcarriers: 8,
+            n_modes: 2,
+            min_calibration_frames: 100,
+            min_calibration_duration_s: 0.0,
+            baseline_expiry_s: 86_400.0,
+        };
+        let mut model = FieldModel::new(config).unwrap();
+        for frame_index in 0..1_000 {
+            let phase = frame_index as f64 * 0.071;
+            let frame = (0..8)
+                .map(|index| 20.0 + index as f64 * 0.1 + (phase + index as f64).sin())
+                .collect();
+            model.feed_calibration(&[frame]).unwrap();
+        }
+        model.finalize_calibration(1_000_000, 0).unwrap();
+
+        let before = model.empty_room_residual_energy_threshold().unwrap();
+        let residuals = vec![before * 1.4; 12];
+        let receipt = model
+            .refine_empty_room_residual_boundary(&residuals)
+            .unwrap();
+        assert_eq!(receipt.threshold_before, before);
+        assert!(receipt.threshold_after > before);
+        assert!(receipt.threshold_after <= before * EMPTY_ROOM_REFINEMENT_MAX_LIFT);
+        assert_eq!(receipt.held_out_sample_count, 12);
+        assert_eq!(
+            model.modes().unwrap().empty_room_residual_refinement_count,
+            1
+        );
+        assert!(model
+            .refine_empty_room_residual_boundary(&residuals)
+            .is_err());
     }
 
     #[cfg(feature = "eigenvalue")]

--- a/v2/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
+++ b/v2/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
@@ -380,6 +380,12 @@ pub struct FieldNormalMode {
 pub struct EmptyRoomMatch {
     pub matches_empty: bool,
     pub score: Option<f64>,
+    /// Robust residual distance from the quiet reference median.
+    pub normalized_residual_z: Option<f64>,
+    /// Reference coverage relative to the normal calibration target.
+    pub maturity: f64,
+    /// Whether the reference set is large and valid enough to suppress change.
+    pub reliable: bool,
     pub residual_energy: f64,
     pub residual_energy_threshold: f64,
     pub window_size: usize,
@@ -642,6 +648,27 @@ fn percentile_95(mut values: Vec<f64>) -> Option<f64> {
         .div_ceil(100)
         .saturating_sub(1);
     values.get(index).copied()
+}
+
+fn robust_residual_z(reference: &[f64], residual: f64) -> Option<f64> {
+    if !residual.is_finite() || reference.is_empty() {
+        return None;
+    }
+    let mut sorted: Vec<f64> = reference
+        .iter()
+        .copied()
+        .filter(|value| value.is_finite() && *value >= 0.0)
+        .collect();
+    if sorted.len() != reference.len() {
+        return None;
+    }
+    sorted.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+    let median = sorted[sorted.len() / 2];
+    let mut deviations: Vec<f64> = sorted.iter().map(|value| (value - median).abs()).collect();
+    deviations.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+    let mad = deviations[deviations.len() / 2];
+    let robust_scale = (1.4826 * mad).max((median.abs() * 0.01).max(f64::EPSILON));
+    Some((residual - median) / robust_scale)
 }
 
 #[cfg(feature = "eigenvalue")]
@@ -1315,12 +1342,20 @@ impl FieldModel {
         let residual_energy_threshold = modes
             .empty_room_residual_energy_threshold?
             .max(EMPTY_ROOM_RESIDUAL_ENERGY_MAX);
-        let matches_empty = residual_energy <= residual_energy_threshold;
         let reference_window_count = modes.empty_room_residual_energy_reference.len();
-        let score = if !matches_empty {
-            Some(0.0)
-        } else if reference_window_count == 0 {
+        let maturity = (reference_window_count as f64
+            / MIN_BACKGROUND_REFERENCE_WINDOWS as f64)
+            .clamp(0.0, 1.0);
+        let reliable = reference_window_count >= 10
+            && modes
+                .empty_room_residual_energy_reference
+                .iter()
+                .all(|value| value.is_finite() && *value >= 0.0);
+        let matches_empty = reliable && residual_energy <= residual_energy_threshold;
+        let score = if !reliable {
             None
+        } else if !matches_empty {
+            Some(0.0)
         } else {
             let at_or_below = modes
                 .empty_room_residual_energy_reference
@@ -1331,6 +1366,12 @@ impl FieldModel {
         Some(EmptyRoomMatch {
             matches_empty,
             score,
+            normalized_residual_z: robust_residual_z(
+                &modes.empty_room_residual_energy_reference,
+                residual_energy,
+            ),
+            maturity,
+            reliable,
             residual_energy,
             residual_energy_threshold,
             window_size,
@@ -2149,6 +2190,9 @@ mod tests {
             .expect("background match");
         assert!(background.matches_empty);
         assert_eq!(background.reference_window_count, 12);
+        assert!(background.reliable);
+        assert_eq!(background.maturity, 0.6);
+        assert!(background.normalized_residual_z.is_some());
         assert!(background
             .score
             .is_some_and(|score| (0.5..=1.0).contains(&score)));
@@ -2237,6 +2281,51 @@ mod tests {
         let background = model.empty_room_match(&shifted).expect("shifted match");
         assert!(!background.matches_empty);
         assert_eq!(background.score, Some(0.0));
+        assert!(background.reliable);
+        assert!(background.normalized_residual_z.is_some());
+    }
+
+    #[cfg(feature = "eigenvalue")]
+    #[test]
+    fn sparse_background_reference_cannot_suppress_runtime_change() {
+        let config = FieldModelConfig {
+            n_links: 1,
+            n_subcarriers: 56,
+            n_modes: 3,
+            min_calibration_frames: 500,
+            min_calibration_duration_s: 0.0,
+            baseline_expiry_s: 86_400.0,
+        };
+        let mut model = FieldModel::new(config).unwrap();
+        let mut calibration = Vec::new();
+        for frame_index in 0..600 {
+            let time = frame_index as f64 * 0.071;
+            let frame: Vec<f64> = (0..56)
+                .map(|subcarrier| {
+                    let carrier = subcarrier as f64;
+                    18.0 + carrier * 0.08
+                        + (time + carrier * 0.13).sin() * 0.8
+                        + (time * 0.37 + carrier * 0.031).cos() * 0.35
+                })
+                .collect();
+            model.feed_calibration(&[frame.clone()]).unwrap();
+            calibration.push(frame);
+        }
+        model.finalize_calibration(1_000_000, 0).unwrap();
+        model
+            .modes
+            .as_mut()
+            .unwrap()
+            .empty_room_residual_energy_reference
+            .truncate(9);
+
+        let result = model
+            .empty_room_match(&calibration[550..600])
+            .expect("background comparison");
+        assert!(!result.reliable);
+        assert!(!result.matches_empty);
+        assert_eq!(result.score, None);
+        assert_eq!(result.maturity, 0.45);
     }
 
     #[test]


### PR DESCRIPTION
## Outcome

This hardens raw CSI calibration, empty room bootstrap restore, field model lifetime, and vital timing without persisting raw CSI.

## Changes

* Select and bind one explicit, rate qualified source node and stable CSI grid
* Count unique CSI sequences and tolerate only bounded measured UDP reordering
* Expose admission, reorder, discontinuity, source, and grid receipts
* Learn held out empty residuals and fail closed on stale or mismatched bootstrap images
* Expire live field models safely and prevent mixed grid history
* Sanitize ESP32 CSI frame prefixes and document the firmware contract
* Add ADRs 355 through 357 and focused tests

## Validation

* MEASURED: full Rust workspace passed with no failures using `cargo test --workspace --no-default-features`
* MEASURED: RuView auth all feature suite passed
* MEASURED: CIR and calibration deterministic witness proofs passed
* MEASURED: browser UI suite passed, 29 tests
* MEASURED: contributor harness passed, 93 tests; security passed, 24 tests; manifest, brain, flywheel, audit, and package dry run passed
* MEASURED: ESP32 host suite passed: ADR 110, CSI sanitation, vitals, mmWave, and thermal tests
* MEASURED: secret scan and ADR claim checks passed

## Physical installation evidence

A Node 5 only empty home capture collected 3259 unique frames over 616.85 seconds at about 5.28 Hz on the 64 bin grid. The held out gate observed 12 of 12 empty samples, zero stale samples, and zero numeric vital samples. After a clean managed server restart, 12 of 12 fresh samples remained absent with no numeric vitals. This proves only the tested installation and empty condition. It does not establish occupied recall or general human detection accuracy.

## Release boundary

No private baseline, raw CSI, credential, or client supplied validation score is included. Firmware source changes are included, but this PR does not invent a standalone firmware version tag. The repository main CI owns the GitHub release after merge.