### PR TITLE
chore: ignore host-test binaries by shape, not by a list that goes stale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,16 @@ firmware/esp32-csi-node/sdkconfig.defaults.bak
 firmware/esp32-hello-world/sdkconfig.old
 
 # Host-built firmware test binaries (compiled from test/*.c, not source)
-firmware/esp32-csi-node/test/test_adr110
-firmware/esp32-csi-node/test/test_vitals
-firmware/esp32-csi-node/test/fuzz_serialize
-firmware/esp32-csi-node/test/fuzz_edge
-firmware/esp32-csi-node/test/fuzz_nvs
+# Compiled host-test and fuzz binaries. The Makefile writes them beside their
+# sources, so they land in a tracked directory. Ignore them by SHAPE rather
+# than by name: every source here carries an extension and no binary does.
+#
+# This replaced a hand-maintained list of five targets, which had gone stale --
+# test_csi_sanitize, test_mmwave_detect and test_thermal were all built by
+# `make host_tests`, ignored by nothing, and got committed by accident.
+firmware/esp32-csi-node/test/test_*
+firmware/esp32-csi-node/test/fuzz_*
+!firmware/esp32-csi-node/test/*.*
 firmware/esp32-csi-node/test/*.exe
 firmware/esp32-csi-node/test/*.obj
 


### PR DESCRIPTION
`make host_tests` writes its binaries beside their sources, inside a tracked directory. `.gitignore` named five of them individually, and that list had fallen behind the Makefile: `test_csi_sanitize`, `test_mmwave_detect` and `test_thermal` are built by the **default target**, ignored by nothing.

That is not hypothetical — all three were committed by accident on two contribution branches and had to be removed again.

Enumerating targets cannot hold: every new host test needs someone to remember this file. So ignore by shape instead. In that directory every source carries an extension and no binary does:

```
firmware/esp32-csi-node/test/test_*
firmware/esp32-csi-node/test/fuzz_*
!firmware/esp32-csi-node/test/*.*
```

## Verified, not reasoned about

- Built every host test, then `git status --porcelain` reports **only `.gitignore`** — no untracked binaries left behind.
- `git check-ignore` confirms all ten binaries are ignored, including `test_edge_grid_he` and `test_edge_grid_pre_he`, which are **not on main yet** — the rule covers tests that do not exist.
- The `.c` sources, `Makefile`, `README.md` and `corpus/*.bin` seeds all remain tracked. This was the risk worth checking: a careless `test_*` would have swallowed `test_adr110_encoding.c` and silently dropped real source.

No behaviour change; one file, one commit.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01BHNNWbmKvxXrVaEDwXEBNo