### PR TITLE
feat(firmware): add the 16MB flash profile the C6 fleet runs on

### DIFF
--- a/firmware/esp32-csi-node/partitions_16mb.csv
+++ b/firmware/esp32-csi-node/partitions_16mb.csv
@@ -1,0 +1,25 @@
+# ESP32-C6 CSI Node - 16MB flash partition table
+# For boards with 16MB flash (e.g. ESP32-C6 DevKitC-1 N16).
+#
+# Two 4MB OTA slots. The app is ~1.04MB, so the slots are far larger than
+# needed for the binary alone -- the size is chosen so an OTA never has to
+# care how much the image has grown, and it leaves room for a coredump
+# partition and an 8MB FAT volume for on-node storage.
+#
+# The 4MB and display layouts do not fit this: their slots are 1.875MB and
+# 2MB, sized for 4MB and 8MB parts respectively.
+#
+# Usage: set in sdkconfig, or use the matching defaults file:
+#   CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_16mb.csv"
+#   idf.py -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.esp32c6;sdkconfig.defaults.16mb" build
+#
+# Verify before flashing an already-deployed node: a smaller table written
+# over a 16MB node relocates NVS and destroys its provisioning.
+# Name, Type, SubType, Offset, Size, Flags
+nvs,data,nvs,0x9000,24K,
+otadata,data,ota,0xf000,8K,
+phy_init,data,phy,0x11000,4K,
+ota_0,app,ota_0,0x20000,4M,
+ota_1,app,ota_1,0x420000,4M,
+coredump,data,coredump,0x820000,64K,
+storage,data,fat,0x830000,8000K,

--- a/firmware/esp32-csi-node/sdkconfig.defaults.16mb
+++ b/firmware/esp32-csi-node/sdkconfig.defaults.16mb
@@ -1,0 +1,23 @@
+# ESP32-C6 CSI Node - 16MB Flash SDK Configuration
+# For boards with 16MB flash (e.g. ESP32-C6 DevKitC-1 N16).
+#
+# Layered on top of sdkconfig.defaults.esp32c6, which keeps a 4MB layout
+# because 4MB C6 devkits are the common case and must not be silently
+# repartitioned by inheriting this.
+#
+# Build:
+#   idf.py -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.esp32c6;sdkconfig.defaults.16mb" build
+#
+# Confirm before flashing a deployed node: /ota/status must report
+# max_size 4194304. Writing a smaller table over a 16MB node relocates NVS
+# and destroys its provisioning.
+
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="16MB"
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_16mb.csv"
+
+# Firmware rollback: an OTA'd image boots PENDING_VERIFY and must confirm
+# itself, or the bootloader reverts on the next boot. See ota_rollback_* in
+# ota_update.c for when confirmation happens and why.
+CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y


### PR DESCRIPTION
## Summary
Adds `partitions_16mb.csv` and `sdkconfig.defaults.16mb` for 16MB ESP32-C6 boards (DevKitC-1 N16). The tree currently has 4MB and display (8MB) layouts only — their OTA slots are 1.875MB and 2MB — so building for a 16MB part meant hand-editing `sdkconfig` on a workstation.

Two 4MB OTA slots, a 64K `coredump` partition, and an 8000K FAT `storage` volume. `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y` so an OTA'd image that cannot confirm itself is reverted.

## Why it belongs in the repo
Writing a smaller partition table over a deployed 16MB node relocates NVS and destroys its provisioning. A layout that the hardware depends on should not live only in an untracked local `sdkconfig` — this repo has lost a partition table that way before.

## Layered, not inherited
`sdkconfig.defaults.esp32c6` deliberately keeps its 4MB layout, so the common 4MB devkit is never silently repartitioned. The 16MB profile is opt-in:

```
idf.py -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.esp32c6;sdkconfig.defaults.16mb" build
```

## Scope
Data files only — no C changes, no behaviour change for any existing target. Coredump-to-flash enablement is deliberately not included here; it belongs with the on-node logging work that consumes these partitions.

## Test plan
- [x] Layout verified against a deployed 16MB C6 node (`/ota/status` reports `max_size 4194304`)
- [x] No credentials, SSIDs, or site-specific addresses in either file
- [ ] CI build (no target in CI currently builds the 16MB profile — it is opt-in)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01PVWMiHQifoYXL7uL3bphrZ