### PR TITLE
fix(training): export the real contrastive lossHistory/duration, not a no-op baseline pass

### DIFF
--- a/docs/huggingface/MODEL_CARD.md
+++ b/docs/huggingface/MODEL_CARD.md
@@ -81,6 +81,42 @@ v1, with its flat loss, was barely better than random on this same test.
 params, trained with InfoNCE (temperature 0.1, in-batch + temporal-far negatives), AdamW, 60 epochs.
 Temporal positives within 2 s; negatives >30 s apart. Time-disjoint 80/20 split.
 
+**EWC (catastrophic-forgetting protection):** measured forgetting rate on the 4 protected
+tasks is **32.97%** — real and non-trivial, disclosed here rather than only in the raw
+`training-metrics.json`. Fisher information is computed and applied (protection strength
+2000), but this is not "solved forgetting" — a user fine-tuning per-room LoRA adapters
+should expect some drift on earlier tasks, not none.
+
+## 🔧 v2.0.1 — fixed the published training-metrics.json itself (2026-09-09)
+
+Separately from the v1→v2 accuracy retraction above, an unrelated bug was found and fixed
+in the **export code** (`scripts/train-ruvllm.js`) that produces `config.json` and
+`training-metrics.json` for this file set (`model.safetensors`, `model-q2/q4/q8.bin`,
+`presence-head.json`, `node-1/2.json`) — separate from the `csi-embed-v2*` files, which
+come from a different script.
+
+The exported `lossHistory` and `contrastive.durationMs` were being read from a disconnected
+baseline pass (`ContrastiveTrainer.train()`, which computes loss but never updates the
+encoder) instead of from the loop that actually performs gradient updates on the encoder
+weights. Concretely: `lossHistory` published a flat, non-decreasing curve around `0.1352`
+for all 20 epochs, and `durationMs` reported ~12.4s — both measuring the wrong computation.
+
+**This did not affect `finalLoss`/`improvement`/the 82.3% held-out temporal-triplet
+accuracy above** — those were already computed from the real training loop and are
+unchanged by this fix. It only affected the exported diagnostic curve and duration, which
+anyone auditing convergence from the published JSON would have been misled by. Re-run
+against the same real capture (`data/recordings/overnight-1775217646.csi.jsonl`) with the
+fix applied: `lossHistory` now shows a genuine decreasing curve (0.1037 -> 0.0654 across 20
+epochs) and `durationMs` reports the real ~40s gradient-loop time. `config.json`'s
+`training.steps` field (`12212300` — epochs × triplets, arithmetically consistent but read
+like optimizer-step count) is now reported as separate `epochs`/`tripletUpdatesPerEpoch`
+fields instead.
+
+Repro: `node scripts/train-ruvllm.js --data data/recordings/overnight-1775217646.csi.jsonl
+--output <dir> --epochs 20` in [github.com/ruvnet/RuView](https://github.com/ruvnet/RuView)
+(the `aether-arena/staging/train_csi_embed.py` path cited above is for the separate
+`csi-embed-v2*` files and was not touched by this fix).
+
 ### v2 files & proof
 | File | Size | Use |
 |------|------|-----|

--- a/scripts/train-ruvllm.js
+++ b/scripts/train-ruvllm.js
@@ -1166,11 +1166,21 @@ async function main() {
   // We iterate over triplets, compute gradients via computeGradient(), and apply
   // them to update the encoder's w2 layer (the embedding projection layer).
   console.log('  Applying gradient updates to encoder weights...');
+  // Same bug class as lossHistory: contrastiveResult.durationMs times the
+  // no-op contrastiveTrainer.train() baseline pass above, not this loop --
+  // the actual gradient-update work. Time it here instead.
+  const contrastiveLoopStart = Date.now();
 
   const contrastiveLr = CONFIG.learningRate;
   const contrastiveEpochs = CONFIG.epochs;
   let initialContrastiveLoss = 0;
   let finalContrastiveLoss = 0;
+  // Real per-epoch loss from the loop that actually updates encoder.w2 below —
+  // NOT contrastiveResult.history, which comes from contrastiveTrainer.train()
+  // above and never touches the encoder (see its own comment). Exporting that
+  // instead of this produced a flat, meaningless lossHistory in the published
+  // model's training-metrics.json.
+  const realContrastiveLossHistory = [];
 
   // Compute initial loss
   for (const triplet of triplets) {
@@ -1230,7 +1240,9 @@ async function main() {
       if (CONFIG.verbose) console.log(`    Epoch ${epoch + 1}/${contrastiveEpochs}: loss=${epochLoss.toFixed(6)}`);
     }
     finalContrastiveLoss = epochLoss;
+    realContrastiveLossHistory.push({ epoch: epoch + 1, loss: epochLoss });
   }
+  const realContrastiveDurationMs = Date.now() - contrastiveLoopStart;
 
   // Re-encode all features with updated encoder
   console.log('  Re-encoding features with updated encoder...');
@@ -1494,10 +1506,15 @@ async function main() {
   const exportModel = {
     metadata: {
       name: 'wifi-densepose-csi-embedding',
-      version: '1.0.0',
+      version: '2.0.1',
       architecture: 'csi-encoder-8-64-128',
       training: {
-        steps: contrastiveResult.history.length * contrastiveTrainer.getTripletCount(),
+        // Real epoch count and real per-epoch triplet-update count, reported
+        // separately rather than pre-multiplied into one "steps" figure --
+        // that reads as optimizer steps, but every triplet with loss>0 gets
+        // an immediate direct weight update here, not a batched gradient step.
+        epochs: realContrastiveLossHistory.length,
+        tripletUpdatesPerEpoch: triplets.length,
         loss: contrastiveResult.finalLoss,
         learningRate: CONFIG.learningRate,
       },
@@ -1609,8 +1626,14 @@ async function main() {
       initialLoss: contrastiveResult.initialLoss,
       finalLoss: contrastiveResult.finalLoss,
       improvement: contrastiveResult.improvement,
-      durationMs: contrastiveResult.durationMs,
-      lossHistory: contrastiveResult.history,
+      // Real wall-clock of the actual gradient loop -- contrastiveResult.durationMs
+      // timed the no-op baseline pass instead, same bug as lossHistory above.
+      durationMs: realContrastiveDurationMs,
+      // The real per-epoch loss from the loop that actually updates the
+      // encoder (see realContrastiveLossHistory above) -- contrastiveResult.history
+      // comes from a separate, non-weight-updating baseline pass and was flat/
+      // meaningless here.
+      lossHistory: realContrastiveLossHistory,
     },
     taskHeads: taskTrainingData.length > 0 ? {
       samples: labeledCount,


### PR DESCRIPTION
## What is wrong

`scripts/train-ruvllm.js` runs two separate computations during contrastive pretraining:

1. `ContrastiveTrainer.train()` — a baseline pass that computes loss but never updates the encoder (per its own comment in the calling code).
2. A hand-written loop that actually applies gradient updates to `encoder.w2`.

The exported `training-metrics.json` took `lossHistory` and `contrastive.durationMs` from the **first (no-op)** pass instead of the second (real) one. Result: the published loss curve was flat/meaningless (~0.1352 for all 20 epochs, no real convergence signal) and the duration was reported as ~12.4s when the real gradient loop actually takes tens of seconds.

This is live today in the published `ruvnet/wifi-densepose-pretrained` model on HuggingFace — I downloaded `training-metrics.json`/`config.json` directly from the Hub and confirmed the flat curve there.

## What this does NOT affect

`finalLoss`/`improvement` and the model's headline held-out temporal-triplet accuracy (82.3%) were already computed from the real loop and are unchanged. Only the diagnostic curve/duration anyone auditing convergence from the published JSON would see was wrong.

## The fix

- Track real per-epoch loss inside the actual gradient loop (`realContrastiveLossHistory`) and export that instead of `contrastiveResult.history`.
- Time the real loop directly (`realContrastiveDurationMs`) instead of using `contrastiveResult.durationMs`.
- `config.json`'s `training.steps` field (`epochs * triplets` — arithmetically consistent but reads like an optimizer-step count, e.g. `12212300`) is now reported as separate `epochs`/`tripletUpdatesPerEpoch` fields.
- Bumped the exported `version` field `1.0.0` -> `2.0.1` to match the "v2" naming already used elsewhere for this file set.

## Verification

Re-ran against the real capture (`data/recordings/overnight-1775217646.csi.jsonl`, the same data the live model was trained on):

- `lossHistory` now shows a genuine decreasing curve: `0.1037 -> 0.0654` across 20 epochs.
- Final loss (`0.065434`) matches the already-published value exactly, confirming the real training loop was never the problem — only its exported diagnostics were.
- `durationMs` now reports the real ~40s gradient-loop time.

## Docs

`docs/huggingface/MODEL_CARD.md` updated with a disclosure section, plus:
- A previously-undisclosed real EWC forgetting-rate figure (32.97%, present in `training-metrics.json` but not surfaced in the human-readable card).
- A corrected repro-script pointer (the previously-cited `aether-arena/staging/train_csi_embed.py` path doesn't exist in this repo; that path is for a separate `csi-embed-v2*` file set produced by a different script, not touched by this fix).

## Follow-up (not in this PR)

The corrected model files (`config.json`, `training-metrics.json`, `model.safetensors`, `presence-head.json`, quantized/LoRA files) need re-uploading to the live HuggingFace repo separately, since that's an external publish outside this PR's scope.