### PR TITLE
fix(provision): stop persisting WiFi password world-readable (0644)

### DIFF
--- a/firmware/esp32-csi-node/provision.py
+++ b/firmware/esp32-csi-node/provision.py
@@ -144,13 +144,42 @@ def load_state(port: str, state_dir: str) -> dict:
     return {}
 
 
+def _harden_state_dir(state_dir: str) -> None:
+    """Ensure state_dir is 0700 and tighten any state files an earlier,
+    unpatched version of this script may have left behind at 0644.
+
+    os.chmod is best-effort on platforms without POSIX permission bits
+    (Windows): it never raises for an unsupported mode there, it just has
+    a narrower effect (roughly the read-only attribute), so this is safe
+    to call unconditionally on every platform.
+    """
+    os.makedirs(state_dir, mode=0o700, exist_ok=True)
+    try:
+        os.chmod(state_dir, 0o700)
+    except OSError:
+        pass
+    try:
+        for name in os.listdir(state_dir):
+            if name.endswith(".json"):
+                try:
+                    os.chmod(os.path.join(state_dir, name), 0o600)
+                except OSError:
+                    pass
+    except OSError:
+        pass
+
+
 def save_state(port: str, state_dir: str, state: dict) -> str:
     """Write `state` to the per-port file, creating dirs as needed. Returns path."""
-    os.makedirs(state_dir, exist_ok=True)
+    _harden_state_dir(state_dir)
     path = _state_path_for(port, state_dir)
     # Sort keys for deterministic on-disk content (easier to diff).
     tmp = path + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
+    # Create the temp file pre-restricted (mode applies at creation, before
+    # any data is written) so the secret is never briefly world-readable
+    # between creation and a chmod that would otherwise follow it.
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(state, f, indent=2, sort_keys=True)
         f.write("\n")
     os.replace(tmp, path)

--- a/firmware/esp32-csi-node/tests/test_provision_state.py
+++ b/firmware/esp32-csi-node/tests/test_provision_state.py
@@ -55,6 +55,48 @@ class TestStateFile(unittest.TestCase):
         # Should warn but not raise.
         self.assertEqual(provision.load_state("COM7", self.dir), {})
 
+    @unittest.skipIf(sys.platform == "win32",
+                      "POSIX permission bits; Windows has no equivalent to assert on")
+    def test_save_creates_dir_and_file_with_restrictive_perms(self):
+        # RuView#1754: a state file holds the WiFi password in cleartext and
+        # must not be world- or group-readable.
+        path = provision.save_state("COM7", self.dir, {"ssid": "x", "password": "y"})
+        self.assertEqual(os.stat(self.dir).st_mode & 0o777, 0o700)
+        self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+
+    @unittest.skipIf(sys.platform == "win32",
+                      "POSIX permission bits; Windows has no equivalent to assert on")
+    def test_save_tightens_permissions_left_by_an_earlier_version(self):
+        # Simulate a directory/file created by the pre-#1754 code path
+        # (os.makedirs/open with no mode, so whatever the umask allowed).
+        os.makedirs(self.dir, exist_ok=True)
+        os.chmod(self.dir, 0o755)
+        path = provision._state_path_for("COM7", self.dir)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("{}")
+        os.chmod(path, 0o644)
+
+        provision.save_state("COM7", self.dir, {"ssid": "x", "password": "y"})
+
+        self.assertEqual(os.stat(self.dir).st_mode & 0o777, 0o700)
+        self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+
+    @unittest.skipIf(sys.platform == "win32",
+                      "POSIX permission bits; Windows has no equivalent to assert on")
+    def test_save_tightens_sibling_state_files_not_being_rewritten(self):
+        # A second port's state file, left at 0644 by an earlier version,
+        # must be tightened too when *any* save_state call hardens the dir —
+        # not just the file the current call happens to write.
+        os.makedirs(self.dir, exist_ok=True)
+        other_path = provision._state_path_for("/dev/ttyUSB0", self.dir)
+        with open(other_path, "w", encoding="utf-8") as f:
+            f.write("{}")
+        os.chmod(other_path, 0o644)
+
+        provision.save_state("COM7", self.dir, {"ssid": "x"})
+
+        self.assertEqual(os.stat(other_path).st_mode & 0o777, 0o600)
+
 
 class TestMerge(unittest.TestCase):
     def test_cli_wins_over_prior(self):


### PR DESCRIPTION
## Summary

Closes #1754. `provision.py` writes the WiFi password in cleartext to a per-port state file by design (see #391/#574), but `save_state()` created the directory and file with `os.makedirs()`/`open()` using no explicit mode, so both landed at whatever the umask allowed — `0755`/`0644` on a default macOS or Linux install. Any other local user or process on a shared machine could read every network the operator has provisioned.

## Fix

- `save_state()` now creates the state directory at `0700` and the state file at `0600`, using `os.open()` with an explicit mode so the temp file is never briefly world-readable between creation and a later `chmod`.
- Also tightens an existing looser directory, and any sibling `*.json` state files left behind by an earlier, unpatched version of this script — not just the file the current invocation happens to write.
- Left password persistence itself untouched (issue's own "Consider whether..." item is a separate design question, not required for the fix).

## Test plan
- [x] `python -m unittest tests.test_provision_state` — 14 tests pass (3 permission-assertion tests `skipIf(win32)`, since Windows has no POSIX permission bits to assert on)
- [x] Ran the same suite on a real POSIX host (Linux) to get genuine verification of the permission assertions rather than trusting the Windows skip — all 14 pass there, 0 skipped