### PR TITLE
fix(ci): size the firmware budget to each variant's own app partition

### DIFF
--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -52,16 +52,16 @@ jobs:
             target: esp32s3
             sdkconfig: sdkconfig.defaults
             partition_table_name: partitions_display.csv
-            size_warn_kb: 1100
-            size_limit_kb: 1152
+            size_warn_kb: 1474
+            size_limit_kb: 1638
             artifact_app: esp32-csi-node.bin
             artifact_pt: partition-table.bin
           - variant: 4mb
             target: esp32s3
             sdkconfig: sdkconfig.defaults.4mb
             partition_table_name: partitions_4mb.csv
-            size_warn_kb: 1100
-            size_limit_kb: 1152
+            size_warn_kb: 1335
+            size_limit_kb: 1484
             artifact_app: esp32-csi-node-4mb.bin
             artifact_pt: partition-table-4mb.bin
           # ADR-110: ESP32-C6 research target (Wi-Fi 6 / 802.15.4 / TWT / LP-core)
@@ -69,8 +69,8 @@ jobs:
             target: esp32c6
             sdkconfig: sdkconfig.defaults
             partition_table_name: partitions_4mb.csv
-            size_warn_kb: 1100
-            size_limit_kb: 1152
+            size_warn_kb: 1335
+            size_limit_kb: 1484
             artifact_app: esp32-csi-node-c6.bin
             artifact_pt: partition-table-c6.bin
 


### PR DESCRIPTION
`firmware-ci.yml` applies `size_limit_kb: 1152` to all three build variants, whose `ota_0` slots are very different sizes:

| variant | partition table | ota_0 slot | old limit | new limit |
|---|---|---|---|---|
| esp32s3 / 8mb | partitions_display.csv | 2.00 MB (2048 KB) | 1152 | 1638 |
| esp32s3 / 4mb | partitions_4mb.csv | 1.81 MB (1856 KB) | 1152 | 1484 |
| esp32c6 / c6-4mb | partitions_4mb.csv | 1.81 MB (1856 KB) | 1152 | 1484 |

New limits are ~80% of each slot, with `size_warn_kb` at ~90% of the limit, so real headroom is preserved rather than removed.

The current gate is not a hardware limit. `main` builds the 8MB variant at 1,171,248 bytes: **99.3% of the 1152 KB gate, but only 56% of the 2 MB partition it actually flashes into.** Any feature addition trips a ceiling roughly half the size of the available space, which is what happened on #1827.

No other workflow logic is changed.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01PVWMiHQifoYXL7uL3bphrZ
