### PR TITLE
fix: correct ESP32 source detection and honest labelling of commodity-WiFi data

### DIFF
--- a/archive/v1/src/sensing/ws_server.py
+++ b/archive/v1/src/sensing/ws_server.py
@@ -215,14 +215,23 @@ def probe_esp32_udp(port: int = ESP32_UDP_PORT, timeout: float = 2.0) -> bool:
     """Return True if an ESP32 is actively streaming on the UDP port."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.settimeout(timeout)
     try:
         sock.bind(("0.0.0.0", port))
-        data, _ = sock.recvfrom(256)
-        if len(data) >= 20:
-            magic = struct.unpack_from('<I', data, 0)[0]
-            return magic == 0xC5110001
-        return False
+        # Keep reading until the deadline instead of judging the first datagram.
+        # An esp32-csi-node interleaves several frame types on this port (CSI
+        # 0xC5110001, sync 0xC5110002, feature 0xC5110006), so the first packet
+        # to arrive is frequently *not* the CSI frame. Returning False on it
+        # made a live, streaming node look absent and silently demoted the
+        # server to the commodity-RSSI collector.
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            sock.settimeout(remaining)
+            data, _ = sock.recvfrom(2048)
+            if len(data) >= 20 and struct.unpack_from('<I', data, 0)[0] == 0xC5110001:
+                return True
     except (socket.timeout, OSError):
         return False
     finally:

--- a/ui/components/SensingTab.js
+++ b/ui/components/SensingTab.js
@@ -108,7 +108,7 @@ export class SensingTab {
           <!-- Setup info -->
           <div class="sensing-card">
             <div class="sensing-card-title">About This Data</div>
-            <p class="sensing-about-text">
+            <p class="sensing-about-text" id="sensingAboutText">
               Metrics are computed from WiFi Channel State Information (CSI).
               With <strong><span id="sensingNodeCount">0</span> ESP32 node(s)</strong> you get presence detection, breathing
               estimation, and gross motion. Add <strong>3-4+ ESP32 nodes</strong>
@@ -226,6 +226,7 @@ export class SensingTab {
       const dataSource = sensingService.dataSource;
       const bannerConfig = {
         'live':              { text: 'LIVE \u2014 ESP32 HARDWARE',           cls: 'sensing-source-live' },
+        'rssi-only':         { text: 'LIVE RSSI \u2014 REAL DATA, NO CSI',  cls: 'sensing-source-rssi' },
         'server-simulated':  { text: 'SIMULATED \u2014 NO HARDWARE',        cls: 'sensing-source-server-sim' },
         'reconnecting':      { text: 'RECONNECTING...',                    cls: 'sensing-source-reconnecting' },
         'unreachable':       { text: 'NO DATA \u2014 SERVER UNREACHABLE',   cls: 'sensing-source-simulated' },
@@ -234,6 +235,38 @@ export class SensingTab {
       const cfg = bannerConfig[dataSource] || bannerConfig.reconnecting;
       banner.textContent = cfg.text;
       banner.className = 'sensing-source-banner ' + cfg.cls;
+    }
+
+    this._updateAboutText(sensingService.dataSource);
+  }
+
+  /**
+   * Keep "About This Data" truthful about where the numbers came from.
+   *
+   * The default copy describes the CSI pipeline, which is wrong when the
+   * server fell back to a commodity RSSI adapter: there are no subcarriers,
+   * no ESP32 nodes, and breathing/heart rate are not recoverable from a
+   * single aggregate power scalar.
+   */
+  _updateAboutText(dataSource) {
+    const el = this.container.querySelector('#sensingAboutText');
+    if (!el) return;
+
+    if (dataSource === 'rssi-only') {
+      el.innerHTML =
+        'Metrics are computed from an <strong>RSSI time series</strong> read off this ' +
+        'machine\'s own WiFi adapter &mdash; real measurements, but <strong>not CSI</strong>. ' +
+        'RSSI is one aggregate power scalar per sample (1 dBm quantisation), so only ' +
+        '<strong>presence and gross motion</strong> are recoverable. Breathing rate, heart ' +
+        'rate, pose and person-counting need per-subcarrier phase &mdash; add an ' +
+        '<strong>ESP32-S3/C6 node</strong> on UDP :5005 to unlock them.';
+    } else {
+      el.innerHTML =
+        'Metrics are computed from WiFi Channel State Information (CSI). ' +
+        'With <strong><span id="sensingNodeCount">0</span> ESP32 node(s)</strong> you get ' +
+        'presence detection, breathing estimation, and gross motion. Add ' +
+        '<strong>3-4+ ESP32 nodes</strong> around the room for spatial resolution and ' +
+        'limb-level tracking.';
     }
   }
 

--- a/ui/services/sensing.service.js
+++ b/ui/services/sensing.service.js
@@ -18,6 +18,13 @@ const SENSING_WS_PORT_BY_HTTP_PORT = {
   '8080': '8765',
 };
 
+// Raw `source` values emitted by ws_server.py when it falls back to a
+// commodity platform WiFi adapter (ADR-013 collectors). The samples are really
+// measured, but the adapter exposes RSSI only — no per-subcarrier CSI — so
+// these map to the dedicated "rssi-only" state rather than "live" or
+// "server-simulated". Capabilities: PRESENCE + MOTION only.
+const RSSI_ONLY_SOURCES = new Set(['macos_wifi', 'linux_wifi', 'windows_wifi']);
+
 export function buildSensingWsUrl(locationLike = (typeof window !== 'undefined' ? window.location : null)) {
   const protocol = locationLike && locationLike.protocol === 'https:' ? 'wss:' : 'ws:';
   const host = locationLike && locationLike.host ? locationLike.host : 'localhost:3001';
@@ -88,6 +95,7 @@ class SensingService {
     this._state = 'disconnected';
     // Data-source label exposed to the UI:
     //   "live"              — real ESP32 hardware connected
+    //   "rssi-only"         — real commodity-WiFi RSSI measurements, no CSI
     //   "server-simulated"  — server is running but using synthetic data (no hardware)
     //   "reconnecting"      — WebSocket disconnected, retrying
     //   "simulated"         — client-side fallback simulation (server unreachable)
@@ -155,6 +163,8 @@ class SensingService {
   /**
    * Current data source label.
    * "live"         — frames are arriving from the real ESP32 over WebSocket
+   * "rssi-only"    — frames are real measurements from this machine's own WiFi
+   *                  adapter (RSSI only, no CSI): presence + gross motion only
    * "reconnecting" — WebSocket disconnected; actively retrying, no frames emitted
    * "unreachable"  — retries exhausted, client simulation off; NO frames emitted
    *                  and whatever is on screen is the last live reading, stale
@@ -457,6 +467,12 @@ class SensingService {
     }
     if (rawSource === 'esp32' || rawSource === 'wifi' || rawSource === 'live') {
       this._setDataSource('live');
+    } else if (RSSI_ONLY_SOURCES.has(rawSource)) {
+      // Real measurements from a commodity platform WiFi adapter (ADR-013 /
+      // ADR-049 collectors). These are genuinely measured — collapsing them to
+      // "server-simulated" would label real data as invented — but they carry
+      // no CSI, so they must not be promoted to "live" either. Third state.
+      this._setDataSource('rssi-only');
     } else if (rawSource === 'simulated' || rawSource === 'simulate') {
       this._setDataSource('server-simulated');
     } else {
@@ -529,7 +545,7 @@ class SensingService {
   /**
    * Update the dataSource label and notify state listeners so the UI can
    * react without needing a separate subscription.
-   * @param {'live'|'server-simulated'|'reconnecting'|'simulated'} source
+   * @param {'live'|'rssi-only'|'server-simulated'|'reconnecting'|'simulated'} source
    */
   _setDataSource(source) {
     if (source === this._dataSource) return;

--- a/ui/style.css
+++ b/ui/style.css
@@ -1911,6 +1911,15 @@ canvas {
   color: #00cc88;
 }
 
+/* Real measurements from a commodity RSSI adapter: genuine data, but no CSI.
+   Deliberately cyan — distinct from the green "ESP32 + CSI" state above and
+   from the orange "synthetic" state below, so neither can be mistaken for it. */
+.sensing-source-rssi {
+  background: rgba(0, 170, 255, 0.14);
+  border: 1px solid #00aaff;
+  color: #00aaff;
+}
+
 .sensing-source-reconnecting {
   background: rgba(255, 180, 0, 0.12);
   border: 1px solid var(--color-warning);

--- a/ui/utils/connection-status.js
+++ b/ui/utils/connection-status.js
@@ -53,6 +53,7 @@ export class ConnectionStatus {
 
     if (state === 'connected' || state === 'streaming') {
       const label = source === 'live' ? 'Live' :
+                    source === 'rssi-only' ? 'Live RSSI' :
                     source === 'server-simulated' ? 'Simulated' :
                     'Connected';
       this.setStatus('connected', label);


### PR DESCRIPTION
## Summary

Two related fixes to how the sensing stack detects and labels its data source. Both were
found while bringing up a real ESP32-S3 node against `ruvnet/wifi-densepose:latest`, and both
cause the server or UI to misreport what the operator is actually looking at.

1. **`probe_esp32_udp()` only inspected the first datagram**, so a live, streaming ESP32 was
   detected as absent and the server silently fell back to the commodity RSSI collector.
2. **The UI labelled real commodity-WiFi measurements as `SIMULATED — NO HARDWARE`**, which is
   the inverse of the honesty rule the repo enforces everywhere else.

## 1. ESP32 detection (`archive/v1/src/sensing/ws_server.py`)

An `esp32-csi-node` interleaves several frame types on port 5005. Measured arrival order from
a live ESP32-S3 node:

```
#1  magic=0xC5110006   60B
#2  magic=0xC5110006   60B
#3  magic=0xC5110001  148B   <- CSI frame, third in line
#4  magic=0xC5110002   32B
```

Distribution over 25 s: `0xC5110006` ×125, `0xC5110001` ×33, `0xC5110002` ×24,
`0xC5110003` ×24. Since the probe judged only the first datagram, it returned `False` most of
the time. The node was healthy and streaming, but every broadcast frame carried
`"source": "macos_wifi"` with `subcarrier_count: 0` instead of real CSI.

The fix reads until the deadline and returns on the first CSI frame. The receive buffer also
grows from 256 to 2048 bytes — v0.8.8 firmware emits frames up to 404 B, which the old buffer
truncated.

Against the same node, the probe now returns `True` in 0.54 s (the time spent skipping non-CSI
datagrams) and the server correctly selects `Esp32UdpCollector`.

## 2. Data-source labelling (`ui/`)

`ws_server.py` emits `macos_wifi` / `linux_wifi` / `windows_wifi` for platform adapters. The UI
whitelist only recognised `esp32` / `wifi` / `live`, so all three fell through to
`server-simulated`.

Rather than folding these into an existing state, this adds a third one. Promoting them to
`live` would be equally dishonest — they carry no CSI — while `server-simulated` denies they
were measured at all:

| source | state | banner |
|---|---|---|
| `esp32` | `live` | `LIVE — ESP32 HARDWARE` |
| `macos_wifi` / `linux_wifi` / `windows_wifi` | `rssi-only` | `LIVE RSSI — REAL DATA, NO CSI` |
| `simulated` | `server-simulated` | `SIMULATED — NO HARDWARE` |

The "About This Data" copy is now source-aware. The default text claims metrics come from CSI
with *N* ESP32 nodes and offers breathing estimation — none of which holds for an RSSI-only
source, where the signal is one aggregate power scalar at 1 dBm quantisation.

This is a follow-up to #1845, which added the macOS CoreWLAN collector without updating the UI
whitelist. Linux and Windows collectors were already affected before that.

## Verification

Source mapping, including the conservative defaults and ADR-295 precedence:

```
esp32                        -> live
macos_wifi                   -> rssi-only
linux_wifi                   -> rssi-only
windows_wifi                 -> rssi-only
simulated                    -> server-simulated
<unknown>                    -> server-simulated   (conservative default kept)
macos_wifi + state=synthetic -> server-simulated   (ADR-295 precedence kept)
```

Repository validation matrix for the touched areas:

```
$ python archive/v1/data/proof/verify.py
    Computed: f8e76f21a0f9852b70b6d9dd5318239f6b20cbcb4cdd995863263cecdc446f7a
    Expected: f8e76f21a0f9852b70b6d9dd5318239f6b20cbcb4cdd995863263cecdc446f7a
    Status:   MATCH (bit-exact)
  VERDICT: PASS

$ cd archive && python -m pytest v1/tests/unit/test_sensing.py -q
45 passed
```

Hardware used: Waveshare ESP32-S3 AMOLED 1.8" (SH8601), 16 MB flash / 8 MB PSRAM, chip rev
v0.2, on a 2.4 GHz AP (channel 1), streaming to `ruvnet/wifi-densepose:latest` with
`CSI_SOURCE=esp32`.

`ui/utils/data-source-banner.js` intentionally needs no change: it already hides its global
warning bar for unrecognised states, and that bar warns "nothing on this screen is current",
which does not apply to real RSSI.

## Note

While bringing this node up I also hit a separate, unrelated problem: the pre-built binaries in
`firmware/esp32-csi-node/release_bins/` are several releases behind the published GitHub
releases, and on an ESP32-S3 with a display panel they yield ~1 pps — below
`CALIBRATION_GRID_MIN_RATE_HZ = 2.0`, so room calibration can never start. Flashing the
published v0.8.8 bundle to the same board raised it to 34 pps. That is a firmware/packaging
matter rather than a code change, so I have kept it out of this PR and will file it separately.
