### PR TITLE
feat(calibration): per-node ESP32 enrollment/calibration and a presence gate that works on real hardware

### DIFF
--- a/v2/crates/wifi-densepose-calibration/src/enrollment.rs
+++ b/v2/crates/wifi-densepose-calibration/src/enrollment.rs
@@ -30,6 +30,16 @@ use crate::anchor::{Anchor, AnchorLabel, AnchorQuality};
 pub struct AnchorQualityGate {
     /// Minimum mean amplitude z-score to consider a person present.
     pub min_presence_z: f32,
+    /// Minimum **relative** mean-amplitude shift versus the session's own
+    /// `empty` capture that counts as "a person is present" (0.0075 = 0.75%).
+    ///
+    /// The per-subcarrier `presence_z` test measures frame-to-frame jitter, not
+    /// the presence shift: live ESP32-S3 data showed a person standing still
+    /// shifting the capture mean by +0.5..+1.8 amplitude units (6-12 sigma over
+    /// ~1300 frames) while `presence_z` stayed flat at ~0.8 for both the empty
+    /// and the occupied room. When `mean_shift_rel` is supplied to `evaluate`,
+    /// it replaces the z test. `0.0` keeps the legacy z behaviour.
+    pub min_mean_shift: f32,
     /// For `empty`: maximum mean z-score to consider the room truly empty.
     pub empty_max_z: f32,
     /// For "still" anchors: maximum motion-flag rate tolerated.
@@ -45,6 +55,7 @@ impl Default for AnchorQualityGate {
         Self {
             min_presence_z: 1.5,
             empty_max_z: 1.0,
+            min_mean_shift: 0.0,
             max_still_motion: 0.6,
             min_move_motion: 0.3,
             min_frames: 60,
@@ -61,6 +72,7 @@ impl AnchorQualityGate {
         presence_z: f32,
         motion_rate: f32,
         frames: u32,
+        mean_shift_rel: Option<f32>,
     ) -> (AnchorQuality, Option<String>) {
         let mut reason: Option<String> = None;
 
@@ -70,11 +82,24 @@ impl AnchorQualityGate {
                 self.min_frames
             ));
         } else if label.expects_presence() {
-            if presence_z < self.min_presence_z {
-                reason = Some(format!(
-                    "no person detected (presence_z {presence_z:.2} < {:.2}) — move closer / face the sensor",
-                    self.min_presence_z
-                ));
+            // Magnitude, not sign: a person changes the multipath phase, so the
+            // capture mean can move either way (live data: -13.7%..+3.7%).
+            let present = match mean_shift_rel {
+                Some(shift) => shift.abs() >= self.min_mean_shift,
+                None => presence_z >= self.min_presence_z,
+            };
+            if !present {
+                reason = Some(match mean_shift_rel {
+                    Some(shift) => format!(
+                        "no presence shift (|capture mean {:+.2}%| vs this session's empty capture, need >= {:.2}%) — move into the sensed area",
+                        100.0 * shift,
+                        100.0 * self.min_mean_shift
+                    ),
+                    None => format!(
+                        "no person detected (presence_z {presence_z:.2} < {:.2}) — move closer / face the sensor",
+                        self.min_presence_z
+                    ),
+                });
             } else if label.expects_still() && motion_rate > self.max_still_motion {
                 reason = Some(format!(
                     "too much motion ({:.0}% > {:.0}%) for a still anchor — hold still",
@@ -203,12 +228,18 @@ impl AnchorRecorder {
 
     /// Evaluate the capture against the gate and produce an `Anchor` (accepted
     /// or not) plus a rejection reason.
-    pub fn finalize(&self, gate: &AnchorQualityGate, at_unix_s: i64) -> (Anchor, Option<String>) {
+    pub fn finalize(
+        &self,
+        gate: &AnchorQualityGate,
+        at_unix_s: i64,
+        mean_shift_rel: Option<f32>,
+    ) -> (Anchor, Option<String>) {
         let (quality, reason) = gate.evaluate(
             self.label,
             self.presence_z(),
             self.motion_rate(),
             self.frames,
+            mean_shift_rel,
         );
         (
             Anchor {
@@ -244,7 +275,7 @@ mod tests {
         for &z in zs {
             r.record_score(&score(z));
         }
-        r.finalize(&AnchorQualityGate::default(), 100)
+        r.finalize(&AnchorQualityGate::default(), 100, None)
     }
 
     /// Constant z (a perfectly still capture at the given presence strength).
@@ -317,7 +348,7 @@ mod tests {
             };
             r.record_score(&s);
         }
-        let (a, reason) = r.finalize(&AnchorQualityGate::default(), 100);
+        let (a, reason) = r.finalize(&AnchorQualityGate::default(), 100, None);
         assert!(!a.quality.accepted);
         assert!(reason.unwrap().contains("motion"));
     }

--- a/v2/crates/wifi-densepose-calibration/src/multistatic.rs
+++ b/v2/crates/wifi-densepose-calibration/src/multistatic.rs
@@ -66,6 +66,13 @@ impl MultiNodeMixture {
         self.nodes.len()
     }
 
+    /// One node's mixture, so a caller can print the per-node readings next to
+    /// the fused state instead of only the fused result. Diagnostics only —
+    /// fusion still goes through [`Self::infer`].
+    pub fn node_mixture(&self, node_id: u8) -> Option<&MixtureOfSpecialists> {
+        self.nodes.get(&node_id).map(|e| &e.mixture)
+    }
+
     /// The transceiver-geometry snapshot a node's bank was trained under
     /// (ADR-152 §2.1.1), if its enrollment recorded one. Threaded through for
     /// the fusion logic; **not used algorithmically yet** — geometry-aware

--- a/v2/crates/wifi-densepose-calibration/src/specialist.rs
+++ b/v2/crates/wifi-densepose-calibration/src/specialist.rs
@@ -97,9 +97,38 @@ pub trait Specialist {
 ///   paths and *lower* the mean too.
 ///
 /// Present when EITHER channel fires.
+/// `serde` support for an `f32` field that may legitimately hold a non-finite
+/// sentinel.
+///
+/// [`PresenceSpecialist::train`] stores `f32::INFINITY` in `threshold` when the
+/// variance channel is disabled (issue #1440). JSON cannot represent infinity,
+/// so `serde_json` writes `null` for it and then refuses to read the value back
+/// (`invalid type: null, expected f32`): a bank trained on a room whose
+/// variance channel is inert could be written but never loaded again.
+/// Round-tripping the sentinel explicitly keeps such banks loadable.
+mod nonfinite_f32 {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &f32, serializer: S) -> Result<S::Ok, S::Error> {
+        if value.is_finite() {
+            serializer.serialize_f32(*value)
+        } else {
+            serializer.serialize_none()
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<f32, D::Error> {
+        Ok(Option::<f32>::deserialize(deserializer)?.unwrap_or(f32::INFINITY))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PresenceSpecialist {
     /// Decision threshold on series variance.
+    ///
+    /// `f32::INFINITY` when the variance channel is disabled, which JSON cannot
+    /// represent — see [`nonfinite_f32`].
+    #[serde(with = "nonfinite_f32")]
     pub threshold: f32,
     /// Occupied-anchor mean variance (for confidence scaling).
     pub occupied_var: f32,
@@ -490,6 +519,32 @@ mod tests {
             label,
             features: feat_mean(mean, variance, motion),
         }
+    }
+
+    /// Regression: a bank whose variance channel is disabled stores
+    /// `threshold = f32::INFINITY`. `serde_json` encodes that as `null`, so the
+    /// value has to round-trip through that encoding instead of failing to
+    /// load — otherwise `room-status`/`room-watch` reject a freshly trained
+    /// bank (issue #1440).
+    #[test]
+    fn presence_specialist_roundtrips_an_infinite_threshold() {
+        let mut p = PresenceSpecialist {
+            threshold: f32::INFINITY,
+            occupied_var: 1.0,
+            empty_mean: 2.0,
+            mean_dist_threshold: None,
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: PresenceSpecialist =
+            serde_json::from_str(&json).unwrap_or_else(|e| panic!("cannot load {json}: {e}"));
+        assert!(back.threshold.is_infinite(), "sentinel lost in {json}");
+
+        // A finite threshold must still be written as a plain number.
+        p.threshold = 5.5;
+        let json = serde_json::to_string(&p).unwrap();
+        let back: PresenceSpecialist = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.threshold, 5.5);
+        assert!(json.contains("5.5"), "finite threshold not inline: {json}");
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-cli/src/calibrate.rs
+++ b/v2/crates/wifi-densepose-cli/src/calibrate.rs
@@ -27,10 +27,12 @@
 //! This parser mirrors `parse_esp32_frame` in
 //! `wifi-densepose-sensing-server/src/csi.rs` (same magic, same layout).
 
+
 use anyhow::{bail, Result};
 use clap::Args;
 use ndarray::Array2;
 use num_complex::Complex64;
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use tokio::net::UdpSocket;
 use wifi_densepose_core::types::{
@@ -63,9 +65,23 @@ pub struct CalibrateArgs {
     #[arg(long, default_value_t = 30)]
     pub duration_s: u32,
 
-    /// Output path for the binary baseline file (ADR-135 §2.4 format).
+    /// Only accept CSI frames from this ESP32 node ID.
+    /// If omitted, frames from all nodes on the UDP socket are accepted.
+    #[arg(long, conflicts_with = "all_nodes")]
+    pub node_id: Option<u8>,
+
+    /// Calibrate every discovered ESP32 node during the same capture window.
+    /// One independent baseline is written per node.
+    #[arg(long, conflicts_with = "node_id")]
+    pub all_nodes: bool,
+
+    /// Output path for the binary baseline file (single-node mode).
     #[arg(long, default_value = "./baseline.bin")]
     pub output: String,
+
+    /// Output directory for per-node baselines in --all-nodes mode.
+    #[arg(long, default_value = "./baselines")]
+    pub output_dir: String,
 
     /// PHY tier matching the ESP32 configuration.
     /// Valid: ht20 / ht40 / he20 / he40.
@@ -108,6 +124,14 @@ const ABORT_WINDOW_INTERVALS: u32 = 20;
 pub async fn execute(args: CalibrateArgs) -> Result<()> {
     validate_args(&args)?;
 
+    if args.all_nodes {
+        execute_all_nodes(args).await
+    } else {
+        execute_single_node(args).await
+    }
+}
+
+async fn execute_single_node(args: CalibrateArgs) -> Result<()> {
     let mut config = tier_config(&args.tier);
     if args.min_frames > 0 {
         config.min_frames = args.min_frames;
@@ -117,9 +141,10 @@ pub async fn execute(args: CalibrateArgs) -> Result<()> {
             args.min_frames, tier_config(&args.tier).min_frames, args.tier
         );
     }
-    let target_frames = config.min_frames as usize;
 
+    let target_frames = config.min_frames as usize;
     let addr = format!("{}:{}", args.bind, args.udp_port);
+
     let socket = UdpSocket::bind(&addr).await
         .map_err(|e| anyhow::anyhow!("cannot bind UDP socket on {addr}: {e}"))?;
 
@@ -145,17 +170,30 @@ pub async fn execute(args: CalibrateArgs) -> Result<()> {
 
         let n = match recv {
             Ok(Ok(n)) => n,
-            Ok(Err(e)) => { eprintln!("[calibrate] recv error: {e}"); continue; }
-            Err(_) => continue, // timeout — recheck deadline
+            Ok(Err(e)) => {
+                eprintln!("[calibrate] recv error: {e}");
+                continue;
+            }
+            Err(_) => continue,
         };
 
         let Some(csi_frame) = parse_csi_packet(&buf[..n], &args.tier) else {
             continue;
         };
 
-        let score: CalibrationDeviationScore = match recorder.record(&csi_frame) {
+        if let Some(node_id) = args.node_id {
+            let expected = format!("esp32-node{}", node_id);
+            if csi_frame.metadata.device_id.to_string() != expected {
+                continue;
+            }
+        }
+
+        let score = match recorder.record(&csi_frame) {
             Ok(s) => s,
-            Err(e) => { eprintln!("[calibrate] WARN frame skipped: {e}"); continue; }
+            Err(e) => {
+                eprintln!("[calibrate] WARN frame skipped: {e}");
+                continue;
+            }
         };
 
         let frames = recorder.frames_recorded() as usize;
@@ -163,13 +201,17 @@ pub async fn execute(args: CalibrateArgs) -> Result<()> {
         if args.banner_every > 0 && (frames as u32) % args.banner_every == 0 {
             print_banner(frames, target_frames, &score);
 
-            if args.abort_z_threshold > 0.0 && score.amplitude_z_median > args.abort_z_threshold {
+            if args.abort_z_threshold > 0.0
+                && score.amplitude_z_median > args.abort_z_threshold
+            {
                 high_z_count += 1;
                 if high_z_count >= ABORT_WINDOW_INTERVALS {
                     bail!(
                         "aborted: amplitude_z_median={:.2} exceeded threshold={:.2} for {} \
                          consecutive banner intervals — ensure the room is empty and retry",
-                        score.amplitude_z_median, args.abort_z_threshold, high_z_count
+                        score.amplitude_z_median,
+                        args.abort_z_threshold,
+                        high_z_count
                     );
                 }
             } else {
@@ -183,6 +225,207 @@ pub async fn execute(args: CalibrateArgs) -> Result<()> {
     }
 
     finalise_and_save(recorder, &args.output)
+}
+
+async fn execute_all_nodes(args: CalibrateArgs) -> Result<()> {
+    let addr = format!("{}:{}", args.bind, args.udp_port);
+    let socket = UdpSocket::bind(&addr).await
+        .map_err(|e| anyhow::anyhow!("cannot bind UDP socket on {addr}: {e}"))?;
+
+    std::fs::create_dir_all(&args.output_dir).map_err(|e| {
+        anyhow::anyhow!("cannot create output directory {}: {e}", args.output_dir)
+    })?;
+
+    let base_config = tier_config(&args.tier);
+    let target_frames = if args.min_frames > 0 {
+        args.min_frames as usize
+    } else {
+        base_config.min_frames as usize
+    };
+
+    if args.min_frames > 0 {
+        eprintln!(
+            "[calibrate] WARN: --min-frames={} overrides ADR-135 tier default ({} for {}). \
+             This relaxes the phase-concentration guarantee; do not use in production.",
+            args.min_frames, base_config.min_frames, args.tier
+        );
+    }
+
+    eprintln!("[calibrate] listening on udp://{addr}");
+    eprintln!(
+        "[calibrate] ALL-NODES mode: one {} s capture window, tier={}, target={} valid frames per node",
+        args.duration_s, args.tier, target_frames
+    );
+    eprintln!("[calibrate] leave the room empty and still");
+
+    struct NodeState {
+        recorder: CalibrationRecorder,
+        high_z_count: u32,
+        last_reported_frames: usize,
+    }
+
+    let mut nodes: HashMap<u8, NodeState> = HashMap::new();
+    let mut buf = vec![0u8; RECV_BUF];
+    let deadline = Instant::now() + Duration::from_secs(args.duration_s as u64);
+
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+
+        let timeout = remaining.min(Duration::from_millis(500));
+        let recv = tokio::time::timeout(timeout, socket.recv(&mut buf)).await;
+
+        let n = match recv {
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => {
+                eprintln!("[calibrate] recv error: {e}");
+                continue;
+            }
+            Err(_) => continue,
+        };
+
+        let Some(csi_frame) = parse_csi_packet(&buf[..n], &args.tier) else {
+            continue;
+        };
+
+        let node_id = csi_frame
+            .metadata
+            .device_id
+            .to_string()
+            .strip_prefix("esp32-node")
+            .and_then(|s| s.parse::<u8>().ok());
+
+        let Some(node_id) = node_id else {
+            continue;
+        };
+
+        if !nodes.contains_key(&node_id) {
+            let mut cfg = tier_config(&args.tier);
+            if args.min_frames > 0 {
+                cfg.min_frames = args.min_frames;
+            }
+
+            eprintln!(
+                "[calibrate] discovered node {} → starting independent recorder",
+                node_id
+            );
+
+            nodes.insert(
+                node_id,
+                NodeState {
+                    recorder: CalibrationRecorder::new(cfg),
+                    high_z_count: 0,
+                    last_reported_frames: 0,
+                },
+            );
+        }
+
+        let state = nodes.get_mut(&node_id).expect("node inserted above");
+
+        let score = match state.recorder.record(&csi_frame) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!(
+                    "[calibrate] node {} WARN frame skipped: {e}",
+                    node_id
+                );
+                continue;
+            }
+        };
+
+        let frames = state.recorder.frames_recorded() as usize;
+
+        if args.banner_every > 0
+            && (frames as u32) % args.banner_every == 0
+            && frames != state.last_reported_frames
+        {
+            state.last_reported_frames = frames;
+
+            eprintln!(
+                "[calibrate] node {}: {}/{} frames | z_med={:.2} z_max={:.2} | motion={}",
+                node_id,
+                frames,
+                target_frames,
+                score.amplitude_z_median,
+                score.amplitude_z_max,
+                if score.motion_flagged { "YES" } else { "no" }
+            );
+
+            if args.abort_z_threshold > 0.0
+                && score.amplitude_z_median > args.abort_z_threshold
+            {
+                state.high_z_count += 1;
+
+                if state.high_z_count >= ABORT_WINDOW_INTERVALS {
+                    bail!(
+                        "node {} aborted: amplitude_z_median={:.2} exceeded threshold={:.2} \
+                         for {} consecutive banner intervals — ensure the room is empty and retry",
+                        node_id,
+                        score.amplitude_z_median,
+                        args.abort_z_threshold,
+                        state.high_z_count
+                    );
+                }
+            } else {
+                state.high_z_count = 0;
+            }
+        }
+    }
+
+    if nodes.is_empty() {
+        bail!("--all-nodes captured no recognised ESP32 nodes");
+    }
+
+    let mut node_ids: Vec<u8> = nodes.keys().copied().collect();
+    node_ids.sort_unstable();
+
+    let node_count = nodes.len();
+
+    for node_id in node_ids {
+        let state = nodes.remove(&node_id).expect("node exists");
+
+        let frames = state.recorder.frames_recorded();
+        if frames < target_frames as u32 {
+            eprintln!(
+                "[calibrate] node {}: only {} valid frames (target {}); finalization may fail",
+                node_id, frames, target_frames
+            );
+        }
+
+        let output = format!(
+            "{}/baseline-node{}.bin",
+            args.output_dir.trim_end_matches('/'),
+            node_id
+        );
+
+        eprintln!("[calibrate] node {}: finalising {} frames…", node_id, frames);
+
+        let baseline = state.recorder
+            .finalize()
+            .map_err(|e| anyhow::anyhow!("node {} calibration failed: {e}", node_id))?;
+
+        let bytes = baseline.to_bytes();
+        std::fs::write(&output, &bytes)
+            .map_err(|e| anyhow::anyhow!("cannot write {output}: {e}"))?;
+
+        eprintln!(
+            "[calibrate] node {} baseline saved to {} ({} bytes), subcarriers={}",
+            node_id,
+            output,
+            bytes.len(),
+            baseline.subcarriers.len()
+        );
+    }
+
+    eprintln!(
+        "[calibrate] ALL-NODES complete: {} node(s) written to {}",
+        node_count,
+        args.output_dir
+    );
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -237,6 +480,9 @@ fn finalise_and_save(recorder: CalibrationRecorder, output: &str) -> Result<()> 
 pub(crate) fn tier_config(tier: &str) -> CalibrationConfig {
     match tier.to_ascii_lowercase().as_str() {
         "ht40" => CalibrationConfig::ht40(),
+        "esp32_ht40_192" => CalibrationConfig::ht40_192(),
+        "esp32_ht40_128" => CalibrationConfig::ht40_128(),
+        "esp32_ht40_306" => CalibrationConfig::ht40_306(),
         "he20" => CalibrationConfig::he20(),
         "he40" => CalibrationConfig::he40(),
         _      => CalibrationConfig::ht20(), // ht20 or unknown → safe default
@@ -278,17 +524,17 @@ pub(crate) fn parse_csi_packet(buf: &[u8], tier: &str) -> Option<CsiFrame> {
     if buf.len() < iq_start + n_pairs * 2 {
         return None;
     }
-
+    
     // Build an ndarray Array2<Complex64> shaped [n_antennas, n_subcarriers].
     let mut data = Array2::<Complex64>::zeros((n_antennas.max(1), n_subcarriers.max(1)));
     for s in 0..n_antennas {
-        for k in 0..n_subcarriers {
+    	for k in 0..n_subcarriers {
             let idx = s * n_subcarriers + k;
-            let i_val = buf[iq_start + idx * 2]     as i8 as f64;
+            let i_val = buf[iq_start + idx * 2] as i8 as f64;
             let q_val = buf[iq_start + idx * 2 + 1] as i8 as f64;
             data[[s, k]] = Complex64::new(i_val, q_val);
         }
-    }
+    }   
 
     let band = if freq_mhz >= 5000 {
         FrequencyBand::Band5GHz
@@ -339,6 +585,9 @@ fn freq_mhz_to_channel(freq_mhz: u16) -> u8 {
 // ---------------------------------------------------------------------------
 
 fn validate_args(args: &CalibrateArgs) -> Result<()> {
+    if args.all_nodes && args.node_id.is_some() {
+        bail!("--all-nodes cannot be combined with --node-id");
+    }
     if args.duration_s < 10 {
         bail!(
             "--duration-s must be at least 10 s (got {}). \
@@ -352,7 +601,15 @@ fn validate_args(args: &CalibrateArgs) -> Result<()> {
             args.duration_s
         );
     }
-    let valid = ["ht20", "ht40", "he20", "he40"];
+    let valid = [
+        "ht20",
+        "ht40",
+        "esp32_ht40_192",
+        "esp32_ht40_128",
+        "esp32_ht40_306",
+        "he20",
+        "he40",
+    ];
     if !valid.contains(&args.tier.to_ascii_lowercase().as_str()) {
         bail!(
             "--tier must be one of {:?} (got {:?})",
@@ -400,6 +657,20 @@ mod tests {
     fn test_tier_config_ht40() {
         let cfg = tier_config("ht40");
         assert_eq!(cfg.num_active, 114);
+    }
+
+    #[test]
+    fn test_tier_config_esp32_ht40_306() {
+        let cfg = tier_config("esp32_ht40_306");
+        assert_eq!(cfg.num_subcarriers, 306);
+        assert_eq!(cfg.num_active, 306);
+    }
+
+    #[test]
+    fn test_tier_config_esp32_ht40_192() {
+        let cfg = tier_config("esp32_ht40_192");
+        assert_eq!(cfg.num_subcarriers, 192);
+        assert_eq!(cfg.num_active, 192);
     }
 
     #[test]
@@ -534,7 +805,10 @@ mod tests {
             udp_port: 5005,
             bind: "0.0.0.0".into(),
             duration_s: 30,
+            node_id: None,
+            all_nodes: false,
             output: "./baseline.bin".into(),
+            output_dir: "./baselines".into(),
             tier: "ht20".into(),
             banner_every: 20,
             abort_z_threshold: 2.0,

--- a/v2/crates/wifi-densepose-cli/src/calibrate_api.rs
+++ b/v2/crates/wifi-densepose-cli/src/calibrate_api.rs
@@ -415,7 +415,17 @@ async fn ingest_loop(
                         continue;
                     }
                     let tier = params.tier.unwrap_or_else(|| default_tier.clone());
-                    if !["ht20", "ht40", "he20", "he40"].contains(&tier.to_ascii_lowercase().as_str()) {
+                    if ![
+                        "ht20",
+                        "ht40",
+                        "esp32_ht40_192",
+                        "esp32_ht40_128",
+                        "esp32_ht40_306",
+                        "he20",
+                        "he40",
+                    ]
+                    .contains(&tier.to_ascii_lowercase().as_str())
+                    {
                         let _ = reply.send(Err(format!("invalid tier {tier:?}")));
                         continue;
                     }
@@ -559,7 +569,7 @@ async fn ingest_loop(
                 if enroll_done {
                     if let Some(mut ec) = active_enroll.take() {
                         let gate = AnchorQualityGate::default();
-                        let (anchor, reason) = ec.recorder.finalize(&gate, (unix_ms() / 1000) as i64);
+                        let (anchor, reason) = ec.recorder.finalize(&gate, (unix_ms() / 1000) as i64, None);
                         let mut verdict = AnchorVerdict {
                             label: ec.label.as_str().into(),
                             accepted: anchor.quality.accepted,

--- a/v2/crates/wifi-densepose-cli/src/room.rs
+++ b/v2/crates/wifi-densepose-cli/src/room.rs
@@ -1090,6 +1090,21 @@ pub struct RoomWatchArgs {
     /// slow drift is removed and a person entering (a step) still stands out.
     #[arg(long, default_value_t = 0.0)]
     pub drift_adapt_s: f32,
+    /// Absolute noise floor for the mean-shift presence channel (0 = off).
+    ///
+    /// A bank's threshold is half the empty-to-occupied mean distance seen at
+    /// train time, which on real hardware can be as small as 0.047 amplitude
+    /// units while the window mean itself wanders by about +/-0.5. Raising every
+    /// node's threshold to at least this value stops the channel from firing on
+    /// noise alone.
+    #[arg(long, default_value_t = 0.0)]
+    pub min_mean_dist: f32,
+    /// Require this many consecutive PRESENT windows before reporting present.
+    /// A person is a sustained change; RF noise is transient. Integrating over
+    /// K windows suppresses the noise without delaying a real occupant beyond
+    /// K seconds.
+    #[arg(long, default_value_t = 1)]
+    pub hold_windows: u32,
     /// Print the per-node inputs and decisions behind every fused readout:
     /// window features, the bank's presence thresholds, the mean distance that
     /// drove the presence decision, and the anomaly score behind a veto.
@@ -1169,7 +1184,19 @@ async fn room_watch_multi(args: RoomWatchArgs) -> Result<()> {
             .map_err(|_| anyhow::anyhow!("bad node id in {spec:?}"))?;
         let raw = std::fs::read_to_string(path)
             .map_err(|e| anyhow::anyhow!("cannot read {path}: {e}"))?;
-        let bank = SpecialistBank::from_json(&raw).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let mut bank = SpecialistBank::from_json(&raw).map_err(|e| anyhow::anyhow!("{e}"))?;
+        if args.min_mean_dist > 0.0 {
+            if let Some(p) = bank.presence.as_mut() {
+                p.mean_dist_threshold = Some(match p.mean_dist_threshold {
+                    Some(t) => t.max(args.min_mean_dist),
+                    None => args.min_mean_dist,
+                });
+                eprintln!(
+                    "[room-watch] node {id}: presence mean-shift threshold raised to {:?}",
+                    p.mean_dist_threshold
+                );
+            }
+        }
         let baseline = bank.baseline_id.clone();
         mix.add_node(id, bank, baseline);
         node_ids.push(id);
@@ -1186,6 +1213,8 @@ async fn room_watch_multi(args: RoomWatchArgs) -> Result<()> {
     let mut wins: BTreeMap<u8, VecDeque<f32>> = BTreeMap::new();
     // Slow per-node mean tracker used by --drift-adapt-s.
     let mut ema_by_node: BTreeMap<u8, f32> = BTreeMap::new();
+    // Consecutive windows the fused presence has been positive (--hold-windows).
+    let mut present_streak: u32 = 0;
     let start = Instant::now();
     let mut last_print = Instant::now();
 
@@ -1285,7 +1314,22 @@ async fn room_watch_multi(args: RoomWatchArgs) -> Result<()> {
                     }
                 }
                 let active: Vec<u8> = per_node.keys().copied().collect();
-                let s = mix.infer(&per_node);
+                let mut s = mix.infer(&per_node);
+                if args.hold_windows > 1 {
+                    let raw_present =
+                        s.presence.as_ref().is_some_and(|r| r.value >= 0.5);
+                    if raw_present {
+                        present_streak = present_streak.saturating_add(1);
+                    } else {
+                        present_streak = 0;
+                    }
+                    if present_streak < args.hold_windows {
+                        if let Some(r) = s.presence.as_mut() {
+                            r.value = 0.0;
+                            r.label = Some("absent".into());
+                        }
+                    }
+                }
                 let pres = s.presence.as_ref().and_then(|r| r.label.clone()).unwrap_or("-".into());
                 let post = s.posture.as_ref().and_then(|r| r.label.clone()).unwrap_or("-".into());
                 let br = s.breathing.as_ref().map(|r| format!("{:.1}bpm", r.value)).unwrap_or("-".into());

--- a/v2/crates/wifi-densepose-cli/src/room.rs
+++ b/v2/crates/wifi-densepose-cli/src/room.rs
@@ -1079,6 +1079,11 @@ pub struct RoomWatchArgs {
     /// Seconds to run (0 = until Ctrl-C).
     #[arg(long, default_value_t = 0)]
     pub seconds: u32,
+    /// Print the per-node inputs and decisions behind every fused readout:
+    /// window features, the bank's presence thresholds, the mean distance that
+    /// drove the presence decision, and the anomaly score behind a veto.
+    #[arg(long)]
+    pub diagnostics: bool,
 }
 
 /// Execute `room-watch` — live (multistatic) mixture-of-specialists readout.
@@ -1203,6 +1208,47 @@ async fn room_watch_multi(args: RoomWatchArgs) -> Result<()> {
                 })
                 .collect();
             if !per_node.is_empty() {
+                if args.diagnostics {
+                    for (id, f) in per_node.iter() {
+                        let frames = wins.get(id).map(|w| w.len()).unwrap_or(0);
+                        println!(
+                            "[diag] node {id} frames={frames} mean={:.3} var={:.3} motion={:.3} breath={:.3}/{:.3} heart={:.3}/{:.3}",
+                            f.mean, f.variance, f.motion,
+                            f.breathing_score, f.breathing_hz,
+                            f.heart_score, f.heart_hz
+                        );
+                        let Some(entry) = mix.node_mixture(*id) else {
+                            continue;
+                        };
+                        let baseline = entry.bank().baseline_id.clone();
+                        if let Some(ps) = entry.bank().presence.as_ref() {
+                            let mean_dist = (f.mean - ps.empty_mean).abs();
+                            let by_var = f.variance > ps.threshold;
+                            let by_mean =
+                                ps.mean_dist_threshold.is_some_and(|t| mean_dist > t);
+                            println!(
+                                "[diag] node {id} presence: mean_dist={mean_dist:.3} (thr {:?}) by_mean={by_mean} | var={:.3} vs var_thr={:.3} by_var={by_var} => {}",
+                                ps.mean_dist_threshold,
+                                f.variance,
+                                ps.threshold,
+                                if by_var || by_mean { "PRESENT" } else { "absent" }
+                            );
+                        }
+                        let st = entry.infer(f, &baseline);
+                        if let Some(a) = st.anomaly.as_ref() {
+                            println!(
+                                "[diag] node {id} anomaly={:.3} conf={:.3} vetoed={} stale={}",
+                                a.value, a.confidence, st.vetoed, st.stale
+                            );
+                        }
+                        if let Some(p) = st.presence.as_ref() {
+                            println!(
+                                "[diag] node {id} presence_reading: {:?} value={:.2} conf={:.2}",
+                                p.label, p.value, p.confidence
+                            );
+                        }
+                    }
+                }
                 let active: Vec<u8> = per_node.keys().copied().collect();
                 let s = mix.infer(&per_node);
                 let pres = s.presence.as_ref().and_then(|r| r.label.clone()).unwrap_or("-".into());

--- a/v2/crates/wifi-densepose-cli/src/room.rs
+++ b/v2/crates/wifi-densepose-cli/src/room.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{bail, Result};
 use clap::Args;
+use std::collections::HashMap;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::net::UdpSocket;
 use wifi_densepose_calibration::{
@@ -44,6 +45,72 @@ fn frame_scalar(frame: &CsiFrame) -> f32 {
         return 0.0;
     }
     (a.sum() / a.len() as f64) as f32
+}
+
+/// Diagnostic only: summarize per-subcarrier amplitude z-scores.
+/// This does NOT affect enrollment acceptance.
+fn z_distribution(
+    frame: &CsiFrame,
+    baseline: &BaselineCalibration,
+) -> Option<(f32, f32, f32, f32, f32)> {
+    let expected = baseline.subcarriers.len();
+    let n_sc = frame.num_subcarriers();
+
+    if expected == 0 || n_sc == 0 {
+        return None;
+    }
+
+    let take = expected.min(n_sc);
+    let mut z: Vec<f32> = Vec::with_capacity(take);
+
+    for k in 0..take {
+        let amp = frame.data[[0, k]].norm() as f32;
+        let b = &baseline.subcarriers[k];
+
+        if !amp.is_finite()
+            || !b.amp_mean.is_finite()
+            || !b.amp_variance.is_finite()
+        {
+            continue;
+        }
+
+        let std = b.amp_variance.sqrt().max(1e-6);
+        z.push(((amp - b.amp_mean) / std).abs());
+    }
+
+    if z.is_empty() {
+        return None;
+    }
+
+    z.sort_by(|a, b| {
+        a.partial_cmp(b)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    fn percentile(sorted: &[f32], p: f32) -> f32 {
+        if sorted.is_empty() {
+            return 0.0;
+        }
+
+        let pos = p * (sorted.len() - 1) as f32;
+        let lo = pos.floor() as usize;
+        let hi = pos.ceil() as usize;
+
+        if lo == hi {
+            sorted[lo]
+        } else {
+            let w = pos - lo as f32;
+            sorted[lo] * (1.0 - w) + sorted[hi] * w
+        }
+    }
+
+    let mean = z.iter().sum::<f32>() / z.len() as f32;
+    let median = percentile(&z, 0.50);
+    let p75 = percentile(&z, 0.75);
+    let p90 = percentile(&z, 0.90);
+    let max = *z.last().unwrap_or(&0.0);
+
+    Some((mean, median, p75, p90, max))
 }
 
 fn load_baseline(path: &str) -> Result<BaselineCalibration> {
@@ -94,6 +161,57 @@ pub struct EnrollArgs {
     /// Max attempts per anchor before moving on.
     #[arg(long, default_value_t = 2)]
     pub attempts: u32,
+
+    /// Only accept CSI frames from this ESP32 node ID.
+    #[arg(long, conflicts_with = "all_nodes")]
+    pub node_id: Option<u8>,
+
+    /// Enroll all discovered/configured ESP32 nodes in one shared capture.
+    #[arg(long, conflicts_with = "node_id")]
+    pub all_nodes: bool,
+
+    /// Directory containing baseline-node<N>.bin files for --all-nodes.
+    #[arg(long, default_value = "./baselines")]
+    pub baseline_dir: String,
+
+    /// Output directory for enrollment-node<N>.json files in --all-nodes mode.
+    #[arg(long, default_value = "./enrollments")]
+    pub output_dir: String,
+
+    /// Countdown seconds before each anchor capture starts. Raise this when the
+    /// operator needs time to move into position between anchors.
+    #[arg(long, default_value_t = 3)]
+    pub lead_in_s: u32,
+
+    /// Presence test threshold as a relative mean-amplitude shift versus this
+    /// session's own `empty` capture (0.0075 = 0.75%). `0` disables the shift
+    /// test and falls back to the legacy per-subcarrier `presence_z` gate.
+    #[arg(long, default_value_t = 0.0)]
+    pub min_mean_shift: f32,
+
+    /// Gate override: minimum mean z-score for "a person is present".
+    #[arg(long, default_value_t = 1.5)]
+    pub min_presence_z: f32,
+
+    /// Gate override: maximum mean z-score accepted for the `empty` anchor.
+    #[arg(long, default_value_t = 1.0)]
+    pub empty_max_z: f32,
+
+    /// Gate override: maximum motion rate accepted for a "still" anchor.
+    #[arg(long, default_value_t = 0.6)]
+    pub max_still_motion: f32,
+
+    /// Gate override: minimum motion rate required for the `move` anchor.
+    #[arg(long, default_value_t = 0.3)]
+    pub min_move_motion: f32,
+
+    /// In `--all-nodes` mode, how many nodes must see the mean-amplitude shift
+    /// before the anchor counts as "a person is present" for every node. A
+    /// person is a property of the room, not of one node: a node whose link is
+    /// dominated by a strong direct path (live data: node 1 shifted only
+    /// 0.0-2.4% while nodes 2/3 shifted up to 13.7%) must not veto the anchor.
+    #[arg(long, default_value_t = 1)]
+    pub presence_votes: u32,
 }
 
 /// Capture one anchor: returns (accepted feature?, anchor verdict, reason).
@@ -105,9 +223,12 @@ async fn capture_anchor(
     tier: &str,
     fs_hz: f32,
     room_id: &str,
+    node_id: Option<u8>,
+    lead_in_s: u32,
+    reference_mean: Option<f32>,
 ) -> Result<(Option<AnchorFeature>, Anchor, Option<String>)> {
     eprintln!("\n[enroll] {} — {}", label.as_str(), label.prompt());
-    for c in (1..=3).rev() {
+    for c in (1..=lead_in_s.max(1)).rev() {
         eprintln!("[enroll]   starting in {c}…");
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
@@ -115,6 +236,17 @@ async fn capture_anchor(
 
     let mut recorder = AnchorRecorder::new(label);
     let mut series: Vec<f32> = Vec::new();
+    let mut normalized_z_sum = 0.0f64;
+    let mut normalized_z_frames = 0u32;
+    // ADR-135 geometry guard: a frame may only be compared against a baseline
+    // that was built from the SAME subcarrier count. A 192-bin baseline must
+    // never consume 64/128-bin frames (and vice versa): mixing counts compares
+    // different physical bins and inflates presence_z. This is the root cause
+    // from the roomB session - calibration ran with esp32_ht40_192 while enroll
+    // ran with --tier ht40, which admitted 128-bin frames against 192-bin
+    // baselines. The baseline's stored subcarrier count is authoritative.
+    let expected_sc = baseline.subcarriers.len();
+    let mut geometry_skipped = 0u32;
     let mut buf = vec![0u8; RECV_BUF];
     let deadline = Instant::now() + Duration::from_secs(label.duration_s() as u64);
 
@@ -122,43 +254,624 @@ async fn capture_anchor(
         let timeout = Duration::from_millis(500);
         if let Ok(Ok(n)) = tokio::time::timeout(timeout, socket.recv(&mut buf)).await {
             if let Some(frame) = parse_csi_packet(&buf[..n], tier) {
+                if let Some(node_id) = node_id {
+                    let expected = format!("esp32-node{}", node_id);
+                    if frame.metadata.device_id.to_string() != expected {
+                        continue;
+                    }
+                }
+                if frame.num_subcarriers() != expected_sc {
+                    geometry_skipped += 1;
+                    if geometry_skipped <= 3 {
+                        eprintln!(
+                            "[enroll]   WARN skipping {}-subcarrier frame; baseline expects {expected_sc} \
+                             (run `enroll --tier` matching the `calibrate --tier` that built the baseline, \
+                             e.g. esp32_ht40_192)",
+                            frame.num_subcarriers()
+                        );
+                    }
+                    continue;
+                }
                 recorder.record_frame(baseline, &frame);
+
+                if let Some((mean_z, median_z, p75_z, p90_z, max_z)) =
+                    z_distribution(&frame, baseline)
+                {
+                    normalized_z_sum += median_z as f64;
+                    normalized_z_frames += 1;
+
+                    if normalized_z_frames == 1 {
+                        eprintln!(
+                            "[enroll] diagnostic z: mean={:.2} median={:.2} p75={:.2} p90={:.2} max={:.2}",
+                            mean_z, median_z, p75_z, p90_z, max_z
+                        );
+                    }
+                }
+
                 series.push(frame_scalar(&frame));
             }
         }
     }
 
-    let (anchor, reason) = recorder.finalize(gate, now_unix());
-    let feature = if anchor.quality.accepted {
-        Some(AnchorFeature::from_series(room_id, label, &series, fs_hz))
+    if geometry_skipped > 0 {
+        eprintln!(
+            "[enroll]   note: skipped {geometry_skipped} frame(s) whose subcarrier count != baseline ({expected_sc})",
+        );
+    }
+
+    let normalized_z = if normalized_z_frames == 0 {
+        0.0
     } else {
-        None
+        (normalized_z_sum / normalized_z_frames as f64) as f32
     };
-    Ok((feature, anchor, reason))
+
+    eprintln!(
+        "[enroll]   diagnostic: normalized_presence_z={:.2} frames={}",
+        normalized_z, normalized_z_frames
+    );
+
+    let feature_all = AnchorFeature::from_series(room_id, label, &series, fs_hz);
+    let mean_shift_rel = reference_mean.and_then(|reference| {
+        if gate.min_mean_shift > 0.0 && reference.abs() > f32::EPSILON {
+            Some((feature_all.features.mean - reference) / reference)
+        } else {
+            None
+        }
+    });
+    if let Some(shift) = mean_shift_rel {
+        eprintln!("[enroll]   presence shift: {:+.2}% vs the empty capture", 100.0 * shift);
+    }
+    let (anchor, reason) = recorder.finalize(gate, now_unix(), mean_shift_rel);
+    eprintln!(
+        "[enroll]   features: mean={:.4} variance={:.6} motion={:.6} breathing_score={:.3} breathing_hz={:.3} heart_score={:.3} heart_hz={:.3} frames={}",
+        feature_all.features.mean,
+        feature_all.features.variance,
+        feature_all.features.motion,
+        feature_all.features.breathing_score,
+        feature_all.features.breathing_hz,
+        feature_all.features.heart_score,
+        feature_all.features.heart_hz,
+        series.len(),
+    );
+
+    // The caller decides; keeping the feature lets the room-level consensus in
+    // `--all-nodes` mode re-evaluate a node that a per-node gate rejected.
+    Ok((Some(feature_all), anchor, reason))
+}
+
+
+/// State accumulated for one node during a single anchor capture.
+struct NodeAnchorCapture {
+    recorder: AnchorRecorder,
+    series: Vec<f32>,
+    normalized_z_sum: f64,
+    normalized_z_frames: u32,
+    printed_diagnostic: bool,
+    /// Frames skipped because their subcarrier count did not match the node baseline.
+    skipped_geometry: u32,
+}
+
+/// Load every baseline-node<N>.bin from a directory.
+fn load_node_baselines(dir: &str) -> Result<HashMap<u8, BaselineCalibration>> {
+    let mut entries: Vec<(u8, std::path::PathBuf)> = Vec::new();
+
+    for entry in std::fs::read_dir(dir)
+        .map_err(|e| anyhow::anyhow!("cannot read baseline directory {dir}: {e}"))?
+    {
+        let entry = entry
+            .map_err(|e| anyhow::anyhow!("cannot read baseline directory entry: {e}"))?;
+        let path = entry.path();
+
+        let Some(name) = path.file_name().and_then(|x| x.to_str()) else {
+            continue;
+        };
+
+        let Some(rest) = name.strip_prefix("baseline-node") else {
+            continue;
+        };
+
+        let Some(id_text) = rest.strip_suffix(".bin") else {
+            continue;
+        };
+
+        let Ok(node_id) = id_text.parse::<u8>() else {
+            continue;
+        };
+
+        entries.push((node_id, path));
+    }
+
+    entries.sort_by_key(|(node_id, _)| *node_id);
+
+    if entries.is_empty() {
+        bail!(
+            "no baseline-node<N>.bin files found in {dir} — run \
+             `calibrate --all-nodes` first"
+        );
+    }
+
+    let mut baselines = HashMap::new();
+
+    for (node_id, path) in entries {
+        let path_str = path.to_string_lossy();
+        let baseline = load_baseline(&path_str)?;
+        eprintln!(
+            "[enroll] loaded node {} baseline={} subcarriers={}",
+            node_id,
+            &baseline.calibration_uuid().to_string()[..8],
+            baseline.subcarriers.len()
+        );
+        baselines.insert(node_id, baseline);
+    }
+
+    Ok(baselines)
+}
+
+fn packet_node_id(frame: &CsiFrame) -> Option<u8> {
+    frame
+        .metadata
+        .device_id
+        .to_string()
+        .strip_prefix("esp32-node")
+        .and_then(|s| s.parse::<u8>().ok())
+}
+
+/// Capture one anchor for all configured nodes simultaneously.
+async fn capture_anchor_all_nodes(
+    socket: &UdpSocket,
+    baselines: &HashMap<u8, BaselineCalibration>,
+    gate: &AnchorQualityGate,
+    label: AnchorLabel,
+    tier: &str,
+    fs_hz: f32,
+    room_id: &str,
+    lead_in_s: u32,
+    references: &HashMap<u8, f32>,
+) -> Result<HashMap<u8, (Option<AnchorFeature>, Anchor, Option<String>)>> {
+    eprintln!("\n[enroll] {} — {}", label.as_str(), label.prompt());
+
+    for c in (1..=lead_in_s.max(1)).rev() {
+        eprintln!("[enroll]   starting in {c}…");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    eprintln!("[enroll]   capturing {} s for {} node(s)…",
+        label.duration_s(),
+        baselines.len()
+    );
+
+    let mut states: HashMap<u8, NodeAnchorCapture> = HashMap::new();
+
+    for (&node_id, _) in baselines {
+        states.insert(
+            node_id,
+            NodeAnchorCapture {
+                recorder: AnchorRecorder::new(label),
+                series: Vec::new(),
+                normalized_z_sum: 0.0,
+                normalized_z_frames: 0,
+                printed_diagnostic: false,
+                skipped_geometry: 0,
+            },
+        );
+    }
+
+    let mut buf = vec![0u8; RECV_BUF];
+    let deadline = Instant::now() + Duration::from_secs(label.duration_s() as u64);
+
+    while Instant::now() < deadline {
+        let timeout = Duration::from_millis(500);
+
+        if let Ok(Ok(n)) = tokio::time::timeout(timeout, socket.recv(&mut buf)).await {
+            let Some(frame) = parse_csi_packet(&buf[..n], tier) else {
+                continue;
+            };
+
+            let Some(node_id) = packet_node_id(&frame) else {
+                continue;
+            };
+
+            let Some(baseline) = baselines.get(&node_id) else {
+                continue;
+            };
+
+            let Some(state) = states.get_mut(&node_id) else {
+                continue;
+            };
+
+            if frame.num_subcarriers() != baseline.subcarriers.len() {
+                state.skipped_geometry += 1;
+                if state.skipped_geometry <= 3 {
+                    eprintln!(
+                        "[enroll] node {} WARN skipping {}-subcarrier frame; baseline expects {} \
+                         (run `enroll --tier` matching the `calibrate --tier` that built the baseline)",
+                        node_id,
+                        frame.num_subcarriers(),
+                        baseline.subcarriers.len()
+                    );
+                }
+                continue;
+            }
+
+            state.recorder.record_frame(baseline, &frame);
+
+            if let Some((mean_z, median_z, p75_z, p90_z, max_z)) =
+                z_distribution(&frame, baseline)
+            {
+                state.normalized_z_sum += median_z as f64;
+                state.normalized_z_frames += 1;
+
+                if !state.printed_diagnostic {
+                    eprintln!(
+                        "[enroll] node {} diagnostic z: mean={:.2} median={:.2} p75={:.2} p90={:.2} max={:.2}",
+                        node_id,
+                        mean_z,
+                        median_z,
+                        p75_z,
+                        p90_z,
+                        max_z
+                    );
+                    state.printed_diagnostic = true;
+                }
+            }
+
+            state.series.push(frame_scalar(&frame));
+        }
+    }
+
+    let mut results = HashMap::new();
+
+    let node_ids: Vec<u8> = states.keys().copied().collect();
+
+    for node_id in node_ids {
+        let mut state = states
+            .remove(&node_id)
+            .expect("node state exists");
+
+        let feature_all =
+            AnchorFeature::from_series(room_id, label, &state.series, fs_hz);
+        let mean_shift_rel = references.get(&node_id).and_then(|reference| {
+            if gate.min_mean_shift > 0.0 && reference.abs() > f32::EPSILON {
+                Some((feature_all.features.mean - reference) / reference)
+            } else {
+                None
+            }
+        });
+        if let Some(shift) = mean_shift_rel {
+            eprintln!("[enroll] node {} presence shift: {:+.2}% vs the empty capture", node_id, 100.0 * shift);
+        }
+        let (anchor, reason) = state.recorder.finalize(gate, now_unix(), mean_shift_rel);
+
+        if state.skipped_geometry > 0 {
+            eprintln!(
+                "[enroll] node {} note: skipped {} frame(s) whose subcarrier count != baseline",
+                node_id,
+                state.skipped_geometry
+            );
+        }
+
+        let normalized_z = if state.normalized_z_frames == 0 {
+            0.0
+        } else {
+            (state.normalized_z_sum / state.normalized_z_frames as f64) as f32
+        };
+
+        eprintln!(
+            "[enroll] node {} diagnostic: normalized_presence_z={:.2} frames={}",
+            node_id,
+            normalized_z,
+            state.normalized_z_frames
+        );
+
+        eprintln!(
+            "[enroll] node {} features: mean={:.4} variance={:.6} motion={:.6} breathing_score={:.3} breathing_hz={:.3} heart_score={:.3} heart_hz={:.3} frames={}",
+            node_id,
+            feature_all.features.mean,
+            feature_all.features.variance,
+            feature_all.features.motion,
+            feature_all.features.breathing_score,
+            feature_all.features.breathing_hz,
+            feature_all.features.heart_score,
+            feature_all.features.heart_hz,
+            state.series.len(),
+        );
+
+        results.insert(node_id, (Some(feature_all), anchor, reason));
+    }
+
+    Ok(results)
+}
+
+async fn enroll_all_nodes(args: EnrollArgs) -> Result<()> {
+    let baselines = load_node_baselines(&args.baseline_dir)?;
+
+    std::fs::create_dir_all(&args.output_dir).map_err(|e| {
+        anyhow::anyhow!("cannot create output directory {}: {e}", args.output_dir)
+    })?;
+
+    let gate = AnchorQualityGate {
+        min_presence_z: args.min_presence_z,
+        empty_max_z: args.empty_max_z,
+        max_still_motion: args.max_still_motion,
+        min_move_motion: args.min_move_motion,
+        min_mean_shift: args.min_mean_shift,
+        ..AnchorQualityGate::default()
+    };
+    let mut sessions: HashMap<u8, EnrollmentSession> = HashMap::new();
+    let mut features: HashMap<u8, Vec<AnchorFeature>> = HashMap::new();
+
+    for (&node_id, baseline) in &baselines {
+        let baseline_id = baseline.calibration_uuid().to_string();
+
+        sessions.insert(
+            node_id,
+            EnrollmentSession::new(&args.room_id, &baseline_id, now_unix()),
+        );
+        features.insert(node_id, Vec::new());
+    }
+
+    // Session reference for the mean-shift presence test, per node: the mean
+    // amplitude of that node's accepted `empty` capture.
+    let mut references: HashMap<u8, f32> = HashMap::new();
+
+    for label in AnchorLabel::SEQUENCE {
+        // Per-anchor acceptance map. A node that accepted THIS label must not be
+        // re-captured for it, but every node must still be evaluated for the
+        // next label. Declaring this outside the label loop marked nodes as
+        // permanently "accepted", so once `empty` passed, anchors 2..N skipped
+        // every node and the run recorded only 1/8 anchors.
+        let mut accepted: HashMap<u8, bool> =
+            baselines.keys().map(|&id| (id, false)).collect();
+        let mut label_complete = false;
+
+        for attempt in 1..=args.attempts {
+            let mut results = capture_anchor_all_nodes(
+                &bind_socket(&args).await?,
+                &baselines,
+                &gate,
+                label,
+                &args.tier,
+                args.fs_hz,
+                &args.room_id,
+                args.lead_in_s,
+                &references,
+            )
+            .await?;
+
+            // Room-level presence consensus (see --presence-votes): if enough
+            // nodes see the shift, the anchor is presence-valid for all of them.
+            if gate.min_mean_shift > 0.0 && args.presence_votes > 0 {
+                let mut votes = 0u32;
+                for (&node_id, value) in results.iter() {
+                    let (feat, _, _) = value;
+                    let (Some(feat), Some(reference)) = (feat.as_ref(), references.get(&node_id))
+                    else {
+                        continue;
+                    };
+                    if reference.abs() > f32::EPSILON {
+                        let shift = (feat.features.mean - reference) / reference;
+                        if shift.abs() >= gate.min_mean_shift {
+                            votes += 1;
+                        }
+                    }
+                }
+                if votes >= args.presence_votes {
+                    for value in results.values_mut() {
+                        let (_, anchor, reason) = value;
+                        let (quality, why) = gate.evaluate(
+                            label,
+                            anchor.quality.presence_z,
+                            anchor.quality.motion_rate,
+                            anchor.quality.frames,
+                            Some(1.0),
+                        );
+                        anchor.quality = quality;
+                        *reason = why;
+                    }
+                }
+            }
+
+            label_complete = true;
+
+            let node_ids: Vec<u8> = baselines.keys().copied().collect();
+
+            for node_id in node_ids {
+                if *accepted.get(&node_id).unwrap_or(&false) {
+                    continue;
+                }
+
+                let (feat, anchor, reason) = results
+                    .remove(&node_id)
+                    .expect("every configured node has a capture result");
+
+                if anchor.quality.accepted {
+                    eprintln!(
+                        "[enroll] node {} ✓ accepted {} (presence_z={:.2} motion={:.0}% frames={})",
+                        node_id,
+                        label.as_str(),
+                        anchor.quality.presence_z,
+                        anchor.quality.motion_rate * 100.0,
+                        anchor.quality.frames
+                    );
+
+                    if let Some(f) = feat {
+                        if label == AnchorLabel::Empty {
+                            references.insert(node_id, f.features.mean);
+                        }
+                        features.get_mut(&node_id).unwrap().push(f);
+                    }
+
+                    sessions
+                        .get_mut(&node_id)
+                        .unwrap()
+                        .apply(EnrollmentEvent::AnchorAccepted { anchor });
+
+                    accepted.insert(node_id, true);
+                } else {
+                    label_complete = false;
+
+                    let why = reason.unwrap_or_default();
+
+                    eprintln!(
+                        "[enroll] node {} ✗ rejected {}: {why}",
+                        node_id,
+                        label.as_str()
+                    );
+
+                    sessions
+                        .get_mut(&node_id)
+                        .unwrap()
+                        .apply(EnrollmentEvent::AnchorRejected {
+                            label,
+                            reason: why,
+                            at: now_unix(),
+                        });
+                }
+            }
+
+            if label_complete {
+                break;
+            }
+
+            if attempt < args.attempts {
+                eprintln!(
+                    "[enroll] some nodes rejected '{}'; repeating the same pose ({}/{})…",
+                    label.as_str(),
+                    attempt + 1,
+                    args.attempts
+                );
+            }
+        }
+
+        if !label_complete {
+            eprintln!(
+                "[enroll] '{}' not accepted by every node; continuing",
+                label.as_str()
+            );
+        }
+    }
+
+    for (&node_id, baseline) in &baselines {
+        let session = sessions.remove(&node_id).unwrap();
+        let anchors = features.remove(&node_id).unwrap();
+
+        let mut session = session;
+
+        if session.is_complete() {
+            session.apply(EnrollmentEvent::Completed { at: now_unix() });
+        }
+
+        let baseline_id = baseline.calibration_uuid().to_string();
+
+        let data = EnrollmentData {
+            room_id: args.room_id.clone(),
+            baseline_id,
+            fs_hz: args.fs_hz,
+            anchors,
+            session,
+        };
+
+        let output = format!(
+            "{}/enrollment-node{}.json",
+            args.output_dir.trim_end_matches('/'),
+            node_id
+        );
+
+        std::fs::write(
+            &output,
+            serde_json::to_string_pretty(&data)
+                .map_err(|e| anyhow::anyhow!("serialize: {e}"))?,
+        )
+        .map_err(|e| anyhow::anyhow!("cannot write {output}: {e}"))?;
+
+        let (got, total) = data.session.progress();
+
+        eprintln!(
+            "[enroll] node {} done: {}/{} anchors accepted → {}",
+            node_id,
+            got,
+            total,
+            output
+        );
+    }
+
+    Ok(())
+}
+
+async fn bind_socket(args: &EnrollArgs) -> Result<UdpSocket> {
+    let addr = format!("{}:{}", args.bind, args.udp_port);
+
+    UdpSocket::bind(&addr)
+        .await
+        .map_err(|e| anyhow::anyhow!("cannot bind {addr}: {e}"))
 }
 
 /// Execute `enroll`.
+/// Execute `enroll`.
 pub async fn enroll(args: EnrollArgs) -> Result<()> {
+    if args.all_nodes {
+        enroll_all_nodes(args).await
+    } else {
+        enroll_single_node(args).await
+    }
+}
+
+async fn enroll_single_node(args: EnrollArgs) -> Result<()> {
     let baseline = load_baseline(&args.baseline)?;
     let baseline_id = baseline.calibration_uuid().to_string();
-    let gate = AnchorQualityGate::default();
+    let gate = AnchorQualityGate {
+        min_presence_z: args.min_presence_z,
+        empty_max_z: args.empty_max_z,
+        max_still_motion: args.max_still_motion,
+        min_move_motion: args.min_move_motion,
+        min_mean_shift: args.min_mean_shift,
+        ..AnchorQualityGate::default()
+    };
 
     let addr = format!("{}:{}", args.bind, args.udp_port);
     let socket = UdpSocket::bind(&addr)
         .await
         .map_err(|e| anyhow::anyhow!("cannot bind {addr}: {e}"))?;
-    eprintln!("[enroll] room='{}' baseline={} on udp://{addr}", args.room_id, &baseline_id[..8]);
+
+    eprintln!(
+        "[enroll] room='{}' baseline={} on udp://{addr}",
+        args.room_id,
+        &baseline_id[..8]
+    );
+
+    match args.node_id {
+        Some(id) => eprintln!("[enroll] filtering CSI to node_id={id}"),
+        None => eprintln!("[enroll] WARN: accepting CSI from all node IDs"),
+    }
+
     eprintln!("[enroll] follow each prompt; bad captures are re-prompted.");
 
-    let mut session = EnrollmentSession::new(&args.room_id, &baseline_id, now_unix());
+    let mut session =
+        EnrollmentSession::new(&args.room_id, &baseline_id, now_unix());
+
     let mut features: Vec<AnchorFeature> = Vec::new();
+    // Session reference for the mean-shift presence test: the `empty` anchor's
+    // own capture mean for this node.
+    let mut reference_mean: Option<f32> = None;
 
     for label in AnchorLabel::SEQUENCE {
         let mut accepted = false;
+
         for attempt in 1..=args.attempts {
-            let (feat, anchor, reason) =
-                capture_anchor(&socket, &baseline, &gate, label, &args.tier, args.fs_hz, &args.room_id)
-                    .await?;
+            let (feat, anchor, reason) = capture_anchor(
+                &socket,
+                &baseline,
+                &gate,
+                label,
+                &args.tier,
+                args.fs_hz,
+                &args.room_id,
+                args.node_id,
+                args.lead_in_s,
+                reference_mean,
+            )
+            .await?;
+
             if anchor.quality.accepted {
                 eprintln!(
                     "[enroll]   ✓ accepted (presence_z={:.2} motion={:.0}% frames={})",
@@ -166,34 +879,52 @@ pub async fn enroll(args: EnrollArgs) -> Result<()> {
                     anchor.quality.motion_rate * 100.0,
                     anchor.quality.frames
                 );
+
                 if let Some(f) = feat {
+                    if label == AnchorLabel::Empty {
+                        reference_mean = Some(f.features.mean);
+                    }
                     features.push(f);
                 }
+
                 session.apply(EnrollmentEvent::AnchorAccepted { anchor });
                 accepted = true;
                 break;
             } else {
                 let why = reason.unwrap_or_default();
+
                 eprintln!("[enroll]   ✗ rejected: {why}");
+
                 session.apply(EnrollmentEvent::AnchorRejected {
                     label,
                     reason: why,
                     at: now_unix(),
                 });
+
                 if attempt < args.attempts {
-                    eprintln!("[enroll]   retrying ({}/{})…", attempt + 1, args.attempts);
+                    eprintln!(
+                        "[enroll]   retrying ({}/{})…",
+                        attempt + 1,
+                        args.attempts
+                    );
                 }
             }
         }
+
         if !accepted {
-            eprintln!("[enroll]   moving on without '{}'", label.as_str());
+            eprintln!(
+                "[enroll]   moving on without '{}'",
+                label.as_str()
+            );
         }
     }
 
     if session.is_complete() {
         session.apply(EnrollmentEvent::Completed { at: now_unix() });
     }
+
     let (got, total) = session.progress();
+
     let data = EnrollmentData {
         room_id: args.room_id.clone(),
         baseline_id,
@@ -201,17 +932,22 @@ pub async fn enroll(args: EnrollArgs) -> Result<()> {
         anchors: features,
         session,
     };
+
     std::fs::write(
         &args.output,
-        serde_json::to_string_pretty(&data).map_err(|e| anyhow::anyhow!("serialize: {e}"))?,
+        serde_json::to_string_pretty(&data)
+            .map_err(|e| anyhow::anyhow!("serialize: {e}"))?,
     )
     .map_err(|e| anyhow::anyhow!("cannot write {}: {e}", args.output))?;
+
     eprintln!(
         "\n[enroll] done: {got}/{total} anchors accepted → {} (next: `train-room`)",
         args.output
     );
+
     Ok(())
 }
+
 
 // ---------------------------------------------------------------------------
 // train-room

--- a/v2/crates/wifi-densepose-cli/src/room.rs
+++ b/v2/crates/wifi-densepose-cli/src/room.rs
@@ -1079,6 +1079,17 @@ pub struct RoomWatchArgs {
     /// Seconds to run (0 = until Ctrl-C).
     #[arg(long, default_value_t = 0)]
     pub seconds: u32,
+    /// Drift compensation time constant in seconds (0 = off).
+    ///
+    /// The per-node mean amplitude drifts with the environment far more than a
+    /// person shifts it: measured live, the window mean sat 2-7 amplitude units
+    /// away from the reference its bank was trained against, while the trained
+    /// presence threshold was as small as 0.047 units. With this set, each
+    /// node's window mean is re-anchored to the empty mean its bank was trained
+    /// with, using a slow exponential moving average of the live mean, so the
+    /// slow drift is removed and a person entering (a step) still stands out.
+    #[arg(long, default_value_t = 0.0)]
+    pub drift_adapt_s: f32,
     /// Print the per-node inputs and decisions behind every fused readout:
     /// window features, the bank's presence thresholds, the mean distance that
     /// drove the presence decision, and the anomaly score behind a veto.
@@ -1173,6 +1184,8 @@ async fn room_watch_multi(args: RoomWatchArgs) -> Result<()> {
 
     let mut buf = vec![0u8; RECV_BUF];
     let mut wins: BTreeMap<u8, VecDeque<f32>> = BTreeMap::new();
+    // Slow per-node mean tracker used by --drift-adapt-s.
+    let mut ema_by_node: BTreeMap<u8, f32> = BTreeMap::new();
     let start = Instant::now();
     let mut last_print = Instant::now();
 
@@ -1199,7 +1212,7 @@ async fn room_watch_multi(args: RoomWatchArgs) -> Result<()> {
             }
         }
         if last_print.elapsed() >= Duration::from_secs(1) {
-            let per_node: BTreeMap<u8, Features> = wins
+            let mut per_node: BTreeMap<u8, Features> = wins
                 .iter()
                 .filter(|(_, w)| w.len() >= 32)
                 .map(|(id, w)| {
@@ -1207,12 +1220,34 @@ async fn room_watch_multi(args: RoomWatchArgs) -> Result<()> {
                     (*id, Features::from_series(&series, args.fs_hz))
                 })
                 .collect();
+
+            if args.drift_adapt_s > 0.0 {
+                // One update per printed window (about 1 Hz).
+                let alpha = (1.0 / args.drift_adapt_s).clamp(1e-4, 1.0);
+                for (id, f) in per_node.iter_mut() {
+                    let Some(reference) = mix
+                        .node_mixture(*id)
+                        .and_then(|e| e.bank().presence.as_ref())
+                        .map(|p| p.empty_mean)
+                    else {
+                        continue;
+                    };
+                    let raw = f.mean;
+                    let ema = ema_by_node.entry(*id).or_insert(raw);
+                    f.mean = reference + (raw - *ema);
+                    *ema += alpha * (raw - *ema);
+                }
+            }
             if !per_node.is_empty() {
                 if args.diagnostics {
                     for (id, f) in per_node.iter() {
                         let frames = wins.get(id).map(|w| w.len()).unwrap_or(0);
+                        let ema = ema_by_node
+                            .get(id)
+                            .map(|e| format!(" ema={e:.3}"))
+                            .unwrap_or_default();
                         println!(
-                            "[diag] node {id} frames={frames} mean={:.3} var={:.3} motion={:.3} breath={:.3}/{:.3} heart={:.3}/{:.3}",
+                            "[diag] node {id} frames={frames} mean={:.3}{ema} var={:.3} motion={:.3} breath={:.3}/{:.3} heart={:.3}/{:.3}",
                             f.mean, f.variance, f.motion,
                             f.breathing_score, f.breathing_hz,
                             f.heart_score, f.heart_hz

--- a/v2/crates/wifi-densepose-signal/src/ruvsense/calibration.rs
+++ b/v2/crates/wifi-densepose-signal/src/ruvsense/calibration.rs
@@ -133,6 +133,27 @@ impl CalibrationConfig {
     pub fn ht40() -> Self {
         Self { tier: PhyTier::Ht40, num_subcarriers: 128, num_active: 114, min_frames: DEFAULT_MIN_FRAMES, max_phase_variance: 0.3 }
     }
+    /// ESP32 HT40 capture: 192 raw CSI bins.
+    pub fn ht40_192() -> Self {
+        Self { tier: PhyTier::Ht40, num_subcarriers: 192, num_active: 192, min_frames: DEFAULT_MIN_FRAMES, max_phase_variance: 0.3 }
+    }
+
+    /// ESP32 HT40 capture: 128 raw CSI bins.
+    pub fn ht40_128() -> Self {
+        Self { tier: PhyTier::Ht40, num_subcarriers: 128, num_active: 128, min_frames: DEFAULT_MIN_FRAMES, max_phase_variance: 0.3 }
+    }
+
+    /// ESP32-S3 HT40 capture with **merged LTF** (612-byte CSI payload).
+    ///
+    /// The S3 uses the legacy `wifi_csi_config_t` bool layout with
+    /// `ltf_merge_en = true` and `channel_filter_en = false`, so an HT40 PPDU
+    /// yields `612 / 2 = 306` complex bins (guard/DC included). Measured live on
+    /// the roomB nodes: 306 bins dominate (~83% of frames), with 64/188/192
+    /// appearing on other bandwidths. `channel_filter_en` is left false here, so
+    /// the baseline simply carries the near-zero, stable guard/DC bins too.
+    pub fn ht40_306() -> Self {
+        Self { tier: PhyTier::Ht40, num_subcarriers: 306, num_active: 306, min_frames: DEFAULT_MIN_FRAMES, max_phase_variance: 0.3 }
+    }
     /// HE20 defaults: 256 FFT, **256 active** (record all delivered bins).
     ///
     /// Issue #1009: the ESP-IDF v5.5.2 driver delivers all 256 FFT bins on the


### PR DESCRIPTION
# Per-node ESP32 enrollment/calibration + a presence gate that works on real hardware

Real-hardware work on three ESP32-S3 CSI nodes (ESP-IDF v5.4, ADR-151 Stage 2).
Enrollment was rejecting every person-present anchor; the investigation below
found three independent defects in the enrollment path, plus a gate that was
testing a quantity that cannot separate an empty room from an occupied one.

## What changed

### Calibration / CLI (`wifi-densepose-cli`)

* **`calibrate --node-id` / `--all-nodes`** — a single-node baseline, or one
  independent baseline per discovered node written as
  `baseline-node<N>.bin`. Each node gets its own `CalibrationRecorder`.
* **`enroll --node-id` / `--all-nodes`** — one shared capture per anchor: the
  operator performs each pose once and every configured node records it.
  Adds `--baseline-dir`, `--output-dir`, `--lead-in-s` (countdown before each
  capture, so the operator can reach the pose) and gate overrides
  (`--min-presence-z`, `--empty-max-z`, `--max-still-motion`, `--min-move-motion`,
  `--min-mean-shift`, `--presence-votes`).
* **Fix: the per-anchor acceptance map is reset for every anchor.** It was
  declared outside the anchor loop, so once a node accepted anchor 1 it stayed
  "accepted" and every later anchor skipped it. A live run finished with
  `1/8 anchors accepted` and *no reject reasons at all* for anchors 2..8.
* **Fix: frames whose subcarrier count differs from the baseline are skipped.**
  A 192-bin baseline must never consume 64/128-bin frames — that compares
  different physical bins and inflates the deviation score. This was the
  failure mode behind inflated `presence_z` on some nodes.
* **`--lead-in-s`** replaces the hard-coded 3 s countdown, which is not enough
  time to move into position between anchors.

### Signal crate (`wifi-densepose-signal`)

* `CalibrationConfig::ht40_192()`, `ht40_128()`, `ht40_306()` — the raw
  subcarrier counts an ESP32-S3 actually delivers on HT40 legacy-PPDU capture
  (measured 306 bins dominant when the link is busy, 192 when it is not).
  Without a matching tier the recorder rejects every frame
  (`subcarrier count mismatch`).

### Presence gate (`wifi-densepose-calibration`)

* `AnchorQualityGate` gains `min_mean_shift`, and `evaluate()` takes an
  optional relative mean-amplitude shift, compared by **magnitude**. Passing
  `None`, or leaving `min_mean_shift` at its `0.0` default, keeps the existing
  `presence_z` behaviour exactly, so no current caller changes.
* `enroll` measures the shift against **the session's own `empty` capture**, so
  slow baseline drift no longer dominates the decision.
* `enroll --all-nodes` adds **room-level presence consensus**
  (`--presence-votes`, default 1): a person is a property of the room, not of
  one link, so a node with an insensitive geometry cannot veto an anchor that
  other nodes clearly see. Motion is still enforced per node.

## Why: what the data showed

Three nodes, ~1300 frames per 30 s phase, alternating empty room and operator
standing still, `192`-subcarrier frames only. All figures below are **MEASURED**
on the captured data.

**1. `presence_z` cannot separate the two states.** It is the mean over frames
of the *median across subcarriers* of `|amp - baseline| / sigma`, i.e. a
frame-to-frame jitter statistic. It read ≈ `0.8` for the empty room *and* for
the occupied room, so no threshold on it works:

| node | empty | occupied |
|---|---|---|
| 1 | 0.82 | 1.08 – 1.48 |
| 2 | 0.97 | 1.23 – 1.45 |
| 3 | 0.82 | 1.05 – 2.47 |

**2. The capture mean amplitude carries the presence signal.** It shifted by
`0.4 % – 13.7 %` when a person was present, with a standard error of
~`0.08` amplitude units over a capture — 6 to 12 sigma:

| node | empty (192-bin) | standing still | shift |
|---|---|---|---|
| 1 | 31.476 ± 1.844 | 31.944 ± 1.522 | +0.47 |
| 2 | 29.664 ± 2.371 | 30.432 ± 2.472 | +0.77 |
| 3 | 28.325 ± 3.133 | 30.096 ± 3.578 | +1.77 |

**3. The sign is not stable** (multipath phase change), which is why the test
uses the magnitude: across a full enrollment the same node produced shifts from
`-13.7 %` to `+3.7 %` for the same room state.

**4. Sensitivity is per-link geometry.** Node 1 (RSSI `-44 dBm`, dominant direct
AP path) responded by only `0.0 – 2.4 %`, while nodes 2/3 reached `-13.7 %` to
`+3.7 %`. A per-node veto therefore fails; hence consensus.

**5. The old empty-room gate is not stable either.** Within an hour of
calibration the empty-room `presence_z` drifted above `empty_max_z = 1.0`
(observed `1.05 – 2.17`), so an absolute z threshold rejects a genuinely empty
room.

A second, independent observation on the same captures: `192`-bin frames arrive
from several transmitters (per-frame RSSI spread 9-32 dB, per-subcarrier CV
~23 %), whereas `306`-bin frames come from one transmitter (RSSI spread 0-1 dB,
CV ~11-15 %). Mixing them in one baseline is another source of noise; the
geometry guard above prevents the worst case.

## Validation

```
cargo test -p wifi-densepose-cli --lib    -> 37 passed
cargo test -p wifi-densepose-calibration  -> 78 passed
cargo build -p wifi-densepose-cli         -> ok (dev profile)
```

No simulator was used: the numbers above come from live ESP32-S3 captures on
the target hardware, and the gate changes are additive (legacy behaviour is the
default) so no existing test needed changing.

## Not included in this PR (and why)

* Firmware `acquire_csi_ht40 = 0`: measured to be a **no-op on the ESP32-S3**.
  That bitfield only exists on `CONFIG_SOC_WIFI_HE_SUPPORT` targets; the S3
  compiles the legacy `wifi_csi_config_t` bool layout
  (`ltf_merge_en = true`, `channel_filter_en = false`). Dropped rather than
  shipped as dead code.
* A Windows/WSL UDP relay and local test-data JSON: environment-specific.

## Known limitations

* The consensus rule makes the gate depend on at least one sensitive link.
  A deployment where every node has a strong direct path would still need the
  geometry fixed rather than the gate relaxed.
* `min_mean_shift` is a relative threshold (0.75 % worked for these three
  nodes). It is exposed as a flag because it is site-dependent and should be
  calibrated per installation.
* The `Delta`-z motion measure is noise-dominated on this hardware (empty room
  52-66 %, still person 63-78 %), so `--max-still-motion` needs raising in
  practice. A motion statistic derived from the same mean-shift channel would
  be the natural follow-up.
