### PR TITLE
fix(ui): make the live CSI view reach LIVE against the bundled sensing server

### DIFF
--- a/ui/observatory/js/main.js
+++ b/ui/observatory/js/main.js
@@ -437,40 +437,101 @@ class Observatory {
   // ---- WebSocket live data ----
 
   _autoDetectLive() {
-    // Probe sensing server health on same origin, then common ports
+    // Probe by opening a WebSocket, not by fetching `${base}/health`.
+    //
+    // MEASURED failure of the previous HTTP-probe version (bundled sensing
+    // server, three live ESP32 nodes):
+    //
+    //   6.59s  fetch OK 200 4237ms http://localhost:8080/health
+    //   7.89s  Access to fetch at 'http://localhost:8765/health' blocked by CORS policy
+    //   9.61s  [Observatory] No sensing server detected, using demo mode
+    //
+    // The same-origin `/health` did answer, but only after 4.2 s: this page
+    // blocks its main thread building the three.js/WebGL scene, and the probe's
+    // own deadline was `AbortSignal.timeout(1500)`, so the one reachable
+    // candidate was aborted before it completed. The second candidate
+    // (`:8765/health`) is CORS-blocked — that router serves /health with no
+    // CORS headers — and the third (`:3000`) is a Docker-era HTTP port that
+    // never serves a WebSocket. Every load ended in DEMO.
+    //
+    // A WebSocket handshake is not subject to CORS and completes off the main
+    // thread, so open one and require an actual frame before claiming live.
     const host = window.location.hostname || 'localhost';
-    const candidates = [
-      window.location.origin,                   // same origin (e.g. :3000)
-      `http://${host}:8765`,                     // default WS port
-      `http://${host}:3000`,                     // default HTTP port
-    ];
-    // Deduplicate
-    const unique = [...new Set(candidates)];
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    // Same HTTP -> WS mapping the other UI services use (ui/services/sensing.service.js).
+    // The bundled server serves HTTP/UI on 8080 and the sensing WebSocket on 8765;
+    // its HTTP router also answers /ws/sensing, so the page's own port is a valid
+    // second candidate. 3000 -> 3001 is the Docker image.
+    const WS_PORT_BY_HTTP_PORT = { '3000': '3001', '8080': '8765' };
+    const ports = [
+      WS_PORT_BY_HTTP_PORT[String(window.location.port)],
+      String(window.location.port),
+      '8765',
+      '3001',
+    ].filter(Boolean);
+    const candidates = [...new Set(ports.map(p => `${proto}//${host}:${p}/ws/sensing`))];
+    void this._tryLiveCandidate(candidates, 0);
+  }
 
-    const tryNext = (i) => {
-      if (i >= unique.length) {
-        console.log('[Observatory] No sensing server detected, using demo mode');
+  /**
+   * Open `candidates[i]`, adopt it on the first real frame, else move on.
+   * A socket that opens but never delivers a frame is not live data, so the
+   * first frame — not `onopen` — is what promotes the view (ADR-295).
+   */
+  _tryLiveCandidate(candidates, i) {
+    if (i >= candidates.length) {
+      console.log('[Observatory] No sensing server detected, using demo mode');
+      return;
+    }
+    const candidate = candidates[i];
+    // ADR-272: mint a single-use ticket when the deployment has auth on; the
+    // helper returns the URL unchanged when no token is configured.
+    Promise.resolve(withWsTicket(candidate)).catch(() => candidate).then((url) => {
+      let ws;
+      try {
+        ws = new WebSocket(url);
+      } catch {
+        this._tryLiveCandidate(candidates, i + 1);
         return;
       }
-      const base = unique[i];
-      fetch(`${base}/health`, { signal: AbortSignal.timeout(1500) })
-        .then(r => r.ok ? r.json() : Promise.reject())
-        .then(data => {
-          if (data && data.status === 'ok') {
-            const wsProto = base.startsWith('https') ? 'wss:' : 'ws:';
-            const urlObj = new URL(base);
-            const wsUrl = `${wsProto}//${urlObj.host}/ws/sensing`;
-            console.log('[Observatory] Sensing server detected at', base, '→', wsUrl);
-            this.settings.dataSource = 'ws';
-            this.settings.wsUrl = wsUrl;
-            void this._connectWS(wsUrl);
-          } else {
-            tryNext(i + 1);
-          }
-        })
-        .catch(() => tryNext(i + 1));
+      let settled = false;
+      const next = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try { ws.close(); } catch { /* already gone */ }
+        this._tryLiveCandidate(candidates, i + 1);
+      };
+      const timer = setTimeout(next, 4000);
+      ws.onopen = () => console.log('[Observatory] Sensing WebSocket open at', url);
+      ws.onmessage = (evt) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try { this._liveData = JSON.parse(evt.data); } catch { /* non-JSON frame */ }
+        console.log('[Observatory] Sensing server verified at', url);
+        this.settings.dataSource = 'ws';
+        this.settings.wsUrl = url;
+        this._adoptLiveSocket(ws);
+      };
+      ws.onerror = next;
+      ws.onclose = next;
+    });
+  }
+
+  /** Take ownership of a socket that has already delivered a live frame. */
+  _adoptLiveSocket(ws) {
+    this._ws = ws;
+    ws.onerror = () => {};
+    ws.onmessage = (evt) => { try { this._liveData = JSON.parse(evt.data); } catch { /* non-JSON frame */ } };
+    ws.onclose = () => {
+      console.log('[Observatory] WebSocket closed, falling back to demo');
+      this._ws = null;
+      this._liveData = null;
+      this.settings.dataSource = 'demo';
+      this._hud.updateSourceBadge('demo', null);
     };
-    tryNext(0);
+    this._hud.updateSourceBadge('ws', ws);
   }
 
   // async: `/ws/sensing` is gated (ADR-272); mint a single-use ticket first.
@@ -479,19 +540,15 @@ class Observatory {
     let wsUrl = url;
     try { wsUrl = await withWsTicket(url); } catch { /* auth off or pre-ADR-272 server */ }
     try {
-      this._ws = new WebSocket(wsUrl);
-      this._ws.onopen = () => {
+      const ws = new WebSocket(wsUrl);
+      // _adoptLiveSocket() badges from the current readyState, which is still
+      // CONNECTING here, so re-badge once the upgrade completes.
+      ws.onopen = () => {
         console.log('[Observatory] WebSocket connected');
-        this._hud.updateSourceBadge('ws', this._ws);
+        this._hud.updateSourceBadge('ws', ws);
       };
-      this._ws.onmessage = (evt) => { try { this._liveData = JSON.parse(evt.data); } catch {} };
-      this._ws.onclose = () => {
-        console.log('[Observatory] WebSocket closed, falling back to demo');
-        this._ws = null;
-        this.settings.dataSource = 'demo';
-        this._hud.updateSourceBadge('demo', null);
-      };
-      this._ws.onerror = () => {};
+      ws.onerror = () => {};
+      this._adoptLiveSocket(ws);
     } catch {}
   }
 

--- a/ui/pose-fusion/js/csi-simulator.js
+++ b/ui/pose-fusion/js/csi-simulator.js
@@ -312,13 +312,35 @@ export class CsiSimulator {
 
   _handleJsonFrame(msg) {
     // Sensing server sends: { type: "sensing_update", nodes: [{ amplitude: [...], subcarrier_count }], classification, features }
+    //
+    // ADR-141 / ADR-295: a governed cycle emitted at privacy class Restricted
+    // (`/api/v1/status` -> `trust.raw_outputs_suppressed === true`) strips the
+    // per-node raw amplitude/phase proxies, so `amplitude` arrives as `[]` with
+    // `subcarrier_count: 0`. Such a frame is still live, but it carries no
+    // decodable CSI. Treating it as a verified frame caused two defects:
+    // `Array.isArray([])` is true, so `_markVerifiedFrame()` fired on an empty
+    // payload, and the live buffers were blanked to zeros on every suppressed
+    // cycle (46% of cycles on a measured 3-node ESP32 array whose fusion soft
+    // guard was 20 ms while the inter-node frame-arrival spread was ~33 ms),
+    // which made the live view read 0.00 while `isLive` was already true. Keep
+    // the last verified frame instead and only refresh the metadata.
+    const node = (msg.nodes && msg.nodes[0]) || msg;
+    const ampArr = node.amplitude || msg.amplitude;
+    const phaseArr = node.phase || msg.phase;
+    const iq = node.iq || msg.iq;
+    const hasAmplitude = Array.isArray(ampArr) && ampArr.length > 0;
+    const hasPhase = Array.isArray(phaseArr) && phaseArr.length > 0;
+    const hasIq = Array.isArray(iq) && iq.length > 0;
+    if (!hasAmplitude && !hasPhase && !hasIq) {
+      this._updateSensingMetadata(node, msg);
+      return;
+    }
+
     this._liveAmplitude = new Float32Array(this.subcarriers);
     this._livePhase = new Float32Array(this.subcarriers);
 
     // Extract amplitude from sensing_update node data
-    const node = (msg.nodes && msg.nodes[0]) || msg;
-    const ampArr = node.amplitude || msg.amplitude;
-    if (ampArr && Array.isArray(ampArr)) {
+    if (hasAmplitude) {
       const n = Math.min(ampArr.length, this.subcarriers);
       // Server sends raw amplitude (already magnitude), normalize to 0-1
       let maxAmp = 0;
@@ -332,11 +354,10 @@ export class CsiSimulator {
     }
 
     // Phase from node (if available)
-    const phaseArr = node.phase || msg.phase;
-    if (phaseArr && Array.isArray(phaseArr)) {
+    if (hasPhase) {
       const n = Math.min(phaseArr.length, this.subcarriers);
       for (let i = 0; i < n; i++) this._livePhase[i] = phaseArr[i];
-    } else if (ampArr) {
+    } else if (hasAmplitude) {
       // Synthesize phase from amplitude variation (Hilbert-like estimate)
       for (let i = 1; i < this.subcarriers; i++) {
         this._livePhase[i] = this._livePhase[i - 1] + (this._liveAmplitude[i] - this._liveAmplitude[i - 1]) * Math.PI;
@@ -344,8 +365,7 @@ export class CsiSimulator {
     }
 
     // Handle raw I/Q pairs
-    const iq = node.iq || msg.iq;
-    if (iq && Array.isArray(iq)) {
+    if (hasIq) {
       const n = Math.min(iq.length / 2, this.subcarriers);
       for (let i = 0; i < n; i++) {
         const real = iq[i * 2], imag = iq[i * 2 + 1];
@@ -354,6 +374,16 @@ export class CsiSimulator {
       }
     }
 
+    this._updateSensingMetadata(node, msg);
+  }
+
+  /**
+   * Refresh the non-CSI metadata carried by a `sensing_update`: the RSSI target
+   * and the server-side presence/confidence. Kept separate from the raw-CSI
+   * decode so a privacy-suppressed cycle can still update the display metadata
+   * without touching the last verified amplitude/phase frame.
+   */
+  _updateSensingMetadata(node, msg) {
     // Extract RSSI from node data
     if (typeof node.rssi_dbm === 'number') {
       this._rssiTarget = node.rssi_dbm;

--- a/ui/pose-fusion/js/main.js
+++ b/ui/pose-fusion/js/main.js
@@ -154,10 +154,24 @@ function init() {
   // a safety mechanism — `onVerifiedFrame` below (issue #1557 fix) is what
   // actually prevents an unconfirmed/failed connection from ever being shown
   // as LIVE, regardless of whether this guess is right.
+  // The bundled sensing server (v2/crates/wifi-densepose-sensing-server) serves
+  // HTTP + UI on 8080 but the sensing WebSocket on 8765, so the Docker
+  // `httpPort + 1` convention alone sent this page to 8081 and the connection
+  // failed silently — leaving the watermarked SYNTHETIC view even with a live
+  // node streaming. Keep the mapping identical to the canonical UI service
+  // (`ui/services/sensing.service.js`), then fall back to the port-plus-one
+  // guess for host-port remappings this table does not know.
+  const SENSING_WS_PORT_BY_HTTP_PORT = {
+    '3000': '3001', // Docker image: UI/API 3000, sensing stream 3001.
+    '8080': '8765', // Bundled sensing server: UI/API 8080, WS 8765.
+  };
   const httpPort = Number(window.location.port);
-  const defaultWsUrl = Number.isFinite(httpPort) && httpPort > 0
-    ? `ws://${window.location.hostname}:${httpPort + 1}/ws/sensing`
-    : 'ws://localhost:8765/ws/sensing';
+  const mappedWsPort = SENSING_WS_PORT_BY_HTTP_PORT[String(window.location.port)];
+  const defaultWsUrl = mappedWsPort
+    ? `ws://${window.location.hostname}:${mappedWsPort}/ws/sensing`
+    : Number.isFinite(httpPort) && httpPort > 0
+      ? `ws://${window.location.hostname}:${httpPort + 1}/ws/sensing`
+      : 'ws://localhost:8765/ws/sensing';
   if (wsUrlInput) wsUrlInput.value = defaultWsUrl;
   // ADR-272: exchange the stored bearer for a single-use ?ticket= before the
   // upgrade — a browser cannot set an Authorization header on a WebSocket.

--- a/v2/crates/wifi-densepose-sensing-server/src/engine_bridge.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/engine_bridge.rs
@@ -35,6 +35,7 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use wifi_densepose_bfld::{PrivacyClass, PrivacyMode};
+use wifi_densepose_signal::ruvsense::fusion_quality::ContradictionFlag;
 use wifi_densepose_engine::{AdapterInfo, EngineError, StreamingEngine, TrustedOutput};
 use wifi_densepose_geo::types::GeoRegistration;
 use wifi_densepose_signal::ruvsense::fusion_quality::CalibrationId;
@@ -48,6 +49,11 @@ use super::NodeState;
 /// every cycle; only the log line is rate-limited — a 20 Hz loop must not
 /// emit 20 warns/s).
 const ENGINE_ERROR_WARN_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Minimum spacing between demotion warn logs. Demotions are a *normal*
+/// outcome of a tolerated contradiction and can fire on every cycle, so the
+/// first one is always logged and the rest are rate-limited.
+const DEMOTION_WARN_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Owns a [`StreamingEngine`] and the WorldGraph scope (one room + sensor) the
 /// live sensing loop publishes beliefs into.
@@ -77,6 +83,20 @@ pub struct EngineBridge {
     engine_error_count: u64,
     /// Last time an engine error was actually logged (rate limiter).
     last_error_warn_at: Option<Instant>,
+    /// Why the most recent cycle was demoted, as a stable slug naming the
+    /// trigger (`timestamp_mismatch`, `calibration_id_mismatch`, ...,
+    /// `mesh_at_risk`, joined with `+` when several fired). `None` when the
+    /// last cycle was emitted at the base class. ADR-141 review finding 1c
+    /// strips the raw amplitude/phase proxies on a demoted cycle, and without
+    /// this field a consumer could only observe the stripped output — never
+    /// the reason (a 46%-of-cycles `TimestampMismatch` demotion on a real
+    /// three-node array looked exactly like a broken CSI pipeline).
+    demotion_reason: Option<String>,
+    /// Cycles demoted since startup.
+    demotion_count: u64,
+    /// Last time a demotion was actually logged (rate limiter, kept separate
+    /// from the error limiter so a demotion storm cannot hide an engine error).
+    last_demotion_warn_at: Option<Instant>,
 }
 
 impl EngineBridge {
@@ -118,6 +138,9 @@ impl EngineBridge {
             demoted: false,
             engine_error_count: 0,
             last_error_warn_at: None,
+            demotion_reason: None,
+            demotion_count: 0,
+            last_demotion_warn_at: None,
         }
     }
 
@@ -218,6 +241,30 @@ impl EngineBridge {
                 self.recalibration_recommended = trust.recalibration_recommended;
                 self.effective_class = Some(trust.effective_class);
                 self.demoted = trust.demoted;
+                if trust.demoted {
+                    self.demotion_count += 1;
+                    self.demotion_reason = Some(demotion_reason_of(&trust));
+                    let now = Instant::now();
+                    let warn_due = self.last_demotion_warn_at.map_or(true, |t| {
+                        now.duration_since(t) >= DEMOTION_WARN_INTERVAL
+                    });
+                    if warn_due {
+                        self.last_demotion_warn_at = Some(now);
+                        tracing::warn!(
+                            demotion_reason = self.demotion_reason.as_deref().unwrap_or("unnamed"),
+                            total_demotions = self.demotion_count,
+                            guard_interval_us = self.guard_interval_us,
+                            "governed cycle demoted: ADR-141 strips the per-node raw amplitude/phase \
+                             proxies from the live publish for this cycle (see /api/v1/status \
+                             trust.demotion_reason). `timestamp_mismatch` means the newest per-node \
+                             frame timestamps are further apart than the fusion soft guard \
+                             (WDP_SOFT_GUARD_US); on a node array slower than 1/soft_guard frames per \
+                             second that fires on a large fraction of cycles"
+                        );
+                    }
+                } else {
+                    self.demotion_reason = None;
+                }
                 Some(trust)
             }
             Err(e) => {
@@ -265,6 +312,18 @@ impl EngineBridge {
         self.engine_error_count
     }
 
+    /// Stable slug naming why the most recent cycle was demoted, or `None`
+    /// when it was emitted at the base class. Set by `observe_cycle`.
+    pub fn demotion_reason(&self) -> Option<&str> {
+        self.demotion_reason.as_deref()
+    }
+
+    /// Number of cycles demoted since startup (each one strips the raw
+    /// amplitude/phase proxies from the live publish).
+    pub fn demotion_count(&self) -> u64 {
+        self.demotion_count
+    }
+
     /// ADR-141 output mapping for the live publish path (review finding 1c):
     /// at effective class [`PrivacyClass::Restricted`] the bfld privacy gate
     /// drops the amplitude + phase proxies; the live `SensingUpdate` applies
@@ -274,6 +333,43 @@ impl EngineBridge {
     pub fn suppress_raw_outputs(&self) -> bool {
         self.effective_class
             .is_some_and(|c| c.as_u8() >= PrivacyClass::Restricted.as_u8())
+    }
+}
+
+/// Stable slug for every trigger that demoted this cycle, so a status
+/// consumer can tell a privacy-class policy from a timing wall without
+/// parsing a log line.
+fn demotion_reason_of(trust: &TrustedOutput) -> String {
+    let mut parts: Vec<&'static str> = Vec::new();
+    for flag in &trust.quality.contradiction_flags {
+        parts.push(contradiction_slug(flag));
+    }
+    if let Some(directional) = trust.directional.as_ref() {
+        for flag in &directional.contradictions {
+            parts.push(contradiction_slug(flag));
+        }
+    }
+    if trust.mesh.as_ref().is_some_and(|m| m.at_risk) {
+        parts.push("mesh_at_risk");
+    }
+    parts.dedup();
+    if parts.is_empty() {
+        // A demotion must come from one of the three inputs above; if one ever
+        // arrives unnamed, say so rather than inventing a cause.
+        "unnamed".to_string()
+    } else {
+        parts.join("+")
+    }
+}
+
+fn contradiction_slug(flag: &ContradictionFlag) -> &'static str {
+    match flag {
+        ContradictionFlag::TimestampMismatch { .. } => "timestamp_mismatch",
+        ContradictionFlag::CalibrationIdMismatch { .. } => "calibration_id_mismatch",
+        ContradictionFlag::PhaseAlignmentFailed { .. } => "phase_alignment_failed",
+        ContradictionFlag::DriftProfileConflict { .. } => "drift_profile_conflict",
+        ContradictionFlag::CoherenceDrop { .. } => "coherence_drop",
+        ContradictionFlag::GeometryInsufficient { .. } => "geometry_insufficient",
     }
 }
 
@@ -514,6 +610,55 @@ mod tests {
             .expect("cycle runs");
         assert_eq!(bridge.effective_class(), Some(PrivacyClass::Restricted));
         assert!(bridge.suppress_raw_outputs());
+    }
+
+    /// A demotion must name its trigger. The measured failure this guards
+    /// against: on a three-node ESP32 array the 20 ms default soft guard sat
+    /// below the inter-node frame-arrival spread, so 45.9% of cycles were
+    /// demoted by `TimestampMismatch` and lost their raw amplitude vectors —
+    /// with nothing on any surface saying why.
+    #[test]
+    fn timestamp_mismatch_demotion_is_named() {
+        let mut bridge = EngineBridge::new(PrivacyMode::PrivateHome, 1, "r", "R", None);
+        let now = Instant::now();
+        let mut states = two_node_states();
+        // 25 ms spread: above the 20 ms soft guard, well inside the 60 ms hard one.
+        states.get_mut(&0).expect("node 0").last_frame_time = Some(now - Duration::from_millis(25));
+        states.get_mut(&1).expect("node 1").last_frame_time = Some(now);
+
+        let out = bridge.observe_cycle(&states, 1_000).expect("cycle runs");
+        assert!(out.demoted, "a 25 ms spread must exceed the 20 ms soft guard");
+        assert!(
+            bridge.demotion_reason().is_some_and(|r| r.contains("timestamp_mismatch")),
+            "demotion must name the trigger, got {:?}",
+            bridge.demotion_reason()
+        );
+        assert_eq!(bridge.demotion_count(), 1);
+        assert!(bridge.suppress_raw_outputs());
+    }
+
+    /// A clean cycle must clear the reason again, so a consumer polling
+    /// `/api/v1/status` never reads a stale cause.
+    #[test]
+    fn a_clean_cycle_clears_the_demotion_reason() {
+        let mut bridge = EngineBridge::new(PrivacyMode::PrivateHome, 1, "r", "R", None);
+        let now = Instant::now();
+        let mut states = two_node_states();
+        states.get_mut(&0).expect("node 0").last_frame_time = Some(now - Duration::from_millis(25));
+        states.get_mut(&1).expect("node 1").last_frame_time = Some(now);
+        bridge.observe_cycle(&states, 1_000).expect("cycle runs");
+        assert!(bridge.demotion_reason().is_some());
+
+        // Both nodes now arrive together, inside the soft guard.
+        let now = Instant::now();
+        let mut aligned = two_node_states();
+        for id in [0u8, 1u8] {
+            aligned.get_mut(&id).expect("node").last_frame_time = Some(now);
+        }
+        let out = bridge.observe_cycle(&aligned, 2_000).expect("cycle runs");
+        assert!(!out.demoted, "aligned arrivals must not demote");
+        assert_eq!(bridge.demotion_reason(), None);
+        assert_eq!(bridge.demotion_count(), 1, "the counter is cumulative");
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -6046,6 +6046,11 @@ async fn health_ready(State(state): State<SharedState>) -> Json<serde_json::Valu
             "last_witness": s.engine_bridge.last_trust_witness().map(witness_hex),
             "effective_class": s.engine_bridge.effective_class().map(|c| format!("{c:?}")),
             "demoted": s.engine_bridge.demoted(),
+            // ADR-141 review finding 1c: a demoted cycle loses its per-node raw
+            // amplitude/phase proxies on the live publish. Name the trigger so a
+            // consumer is not left inferring 'broken CSI' from empty arrays.
+            "demotion_reason": s.engine_bridge.demotion_reason(),
+            "demotion_count": s.engine_bridge.demotion_count(),
             "recalibration_recommended": s.engine_bridge.recalibration_recommended(),
             "engine_error_count": s.engine_bridge.engine_error_count(),
             "raw_outputs_suppressed": s.engine_bridge.suppress_raw_outputs(),

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -4586,7 +4586,8 @@ async fn handle_ws_client(mut socket: WebSocket, state: SharedState) {
             msg = rx.recv() => {
                 match msg {
                     Ok(json) => {
-                        if socket.send(Message::Text(json)).await.is_err() {
+                        if let Err(e) = socket.send(Message::Text(json)).await {
+                            info!("sensing WS: send failed ({e}); closing");
                             break;
                         }
                     }
@@ -4595,19 +4596,41 @@ async fn handle_ws_client(mut socket: WebSocket, state: SharedState) {
                         tracing::debug!("WS client lagged by {n} frames, skipping");
                         continue;
                     }
-                    Err(_) => break, // channel closed
+                    Err(e) => {
+                        info!("sensing WS: broadcast channel closed ({e}); closing");
+                        break;
+                    }
                 }
             }
             _ = ping_interval.tick() => {
-                if socket.send(Message::Ping(vec![])).await.is_err() {
+                if let Err(e) = socket.send(Message::Ping(vec![])).await {
+                    info!("sensing WS: ping failed ({e}); closing");
                     break;
                 }
             }
             msg = socket.recv() => {
                 match msg {
-                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(Message::Close(c))) => {
+                        info!("sensing WS: client sent close {c:?}");
+                        break;
+                    }
+                    None => {
+                        info!("sensing WS: client stream ended");
+                        break;
+                    }
                     Some(Ok(Message::Pong(_))) => {} // keepalive response
-                    _ => {} // ignore other client messages
+                    Some(Ok(Message::Ping(p))) => {
+                        // Answer a client ping so a browser-side keepalive cannot
+                        // tear the stream down silently.
+                        let _ = socket.send(Message::Pong(p)).await;
+                    }
+                    Some(Ok(other)) => {
+                        tracing::debug!("sensing WS: ignoring client message {other:?}");
+                    }
+                    Some(Err(e)) => {
+                        info!("sensing WS: client error ({e}); closing");
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What this fixes

The pose-fusion UI (`/ui/pose-fusion.html`) served by the bundled sensing server
stayed on watermarked **SYNTHETIC** data even with three ESP32-S3 nodes
streaming CSI at ~30 fps per node. Three independent defects sat on that path;
this PR fixes the two that live in the repository and adds the server-side
diagnostics needed to see them.

### 1. `ui/pose-fusion/js/main.js` — the WS port guess never matched the bundled server

The page derived `ws://<host>:<httpPort + 1>/ws/sensing`, which is the Docker
`3000 -> 3001` convention. The bundled sensing server serves HTTP + UI on
**8080** and the sensing WebSocket on **8765** (`main.rs` binds `args.ws_port`,
default `8765`), so the guess resolved to `8081`. `connectLive()` failed
silently and the watermarked demo view stayed up.

`ui/services/sensing.service.js` already encodes the correct mapping
(`{ '3000': '3001', '8080': '8765' }`); this PR uses the same table in
pose-fusion and keeps `httpPort + 1` only as the fallback for host-port
remappings the table does not know.

### 2. `ui/pose-fusion/js/csi-simulator.js` — an amplitude-stripped cycle was treated as a verified frame

```js
const ampArr = node.amplitude || msg.amplitude;
if (ampArr && Array.isArray(ampArr)) { ...; this._markVerifiedFrame(); }
```

`Array.isArray([])` is `true`, and the live buffers were reset to zeros at the
top of `_handleJsonFrame` on **every** `sensing_update`. So a cycle that
carried no CSI still promoted the view to LIVE *and* blanked the amplitude
buffers, making the live readout show `0.00`.

Those cycles are legitimate: a governed cycle emitted at privacy class
`Restricted` strips the per-node raw amplitude/phase proxies by design
(ADR-141 output mapping — `trust.raw_outputs_suppressed: true` on
`/api/v1/status`).

**MEASURED** on this array (channel 11, 192/306/128/64-bin CSI over UDP,
~30 fps per node, fusion `soft_guard_us` at its 20 ms default):
**316 of 689** `sensing_update` messages (**45.9 %**) arrived with
`"amplitude": []` and `"subcarrier_count": 0`. `/api/v1/status` flipped
between `effective_class: "Anonymous", demoted: false` and
`effective_class: "Restricted", demoted: true` roughly once per second
(`engine_error_count: 0`, so this is a tolerated-contradiction demotion, not an
engine failure). The trigger is `ContradictionFlag::TimestampMismatch` in
`wifi-densepose-signal`'s `fuse_scored_calibrated`: it compares the **host
arrival** timestamps of the newest frame per node against `soft_guard_us`.
With three nodes each emitting one frame per ~33 ms, that spread is
approximately uniform over one frame interval, so a 20 ms soft guard sits right
at the median — ~46 % of cycles exceed it.

The fix requires a **non-empty** amplitude/phase/IQ payload before decoding,
keeps the last verified frame when a cycle carries no decodable CSI, and moves
the RSSI/presence refresh into `_updateSensingMetadata` so a suppressed cycle
still updates metadata without touching the verified frame.

### 3. `wifi-densepose-sensing-server/src/main.rs` — make the disconnect reason visible

`handle_ws_client` broke out of its `select!` on six distinct conditions and
logged none of them, so a dropped `/ws/sensing` stream was indistinguishable
from one that never opened. Each break now logs its concrete reason, and a
client `Ping` is answered with a `Pong`. No other behaviour change.

## Reproducer

```bash
# 1. run the sensing server with the fusion soft guard matched to the array's
#    inter-frame interval (see "Operator note" below; 20 ms default still works,
#    it just strips raw amplitudes on ~46% of cycles)
cd v2
OPENBLAS_SYSTEM=1 WDP_SOFT_GUARD_US=55000 cargo run -p wifi-densepose-sensing-server -- \
  --source esp32 --udp-port 5005 --udp-bind 0.0.0.0 --udp-allow 172.22.96.0/20 \
  --bind-addr 0.0.0.0 --ui-path ../ui

# 2. open the UI in a browser (no manual WebSocket URL needed after this PR)
#    http://localhost:8080/ui/pose-fusion.html
#    -> status label "LIVE CSI", button "Live ESP32", RSSI from the node
```

Raw-message check used for the 45.9 % figure (a minimal WS client that counts
per-node `amplitude` lengths) reported, over a 14 s window at the 20 ms
default: `total=689 full_amplitude=373 suppressed=316`. With
`WDP_SOFT_GUARD_US=55000`: `total=882 full_amplitude=860 suppressed=22`
(**2.5 %**), `/api/v1/status` steady at `raw_outputs_suppressed: false`.

## Verification of the UI change

Headless Chrome, fresh profile, against the bundled server, no manual WS URL:

```
<span id="status-label">LIVE CSI</span>
<button class="btn active" id="connect-ws-btn">&#10003; Live ESP32</button>
<span class="rssi-dbm" id="rssi-value">-54 dBm</span>
<span id="fps-display" class="fps-badge">31 FPS</span>
[CONSOLE] "[PoseFusion] frame 1 OK — mode=dual, csi.bufLen=1, embPts=1"
```

Reproduced twice in two independent browser profiles.

## Operator note (not part of this PR)

`WDP_SOFT_GUARD_US` is an existing override, and the upstream relation asserted
by `wifi-densepose-signal` is `stagger < soft_guard_us < guard_interval_us`. A
20 ms soft guard assumes nodes whose frames arrive within 20 ms of each other
(>50 fps per node); an ESP32-S3 CSI array at ~30 fps cannot satisfy that, so
half of the governed cycles are demoted to `Restricted` and lose their raw
amplitudes. A follow-up worth considering upstream: log a rate-limited warning
(or expose the demotion reason on `/api/v1/status`) when a cycle is demoted by
`TimestampMismatch`, instead of silently stripping the raw proxies.

## Scope

- No secrets, CSI captures, or personal data. No calibration/baseline artifacts.
- Rust change is log/diagnostic only; `cargo check -p wifi-densepose-sensing-server` clean.
- Untested in CI on this fork: the UI files are static JS covered by the
  headless-Chrome check above, not by a JS test suite.
