### PR TITLE
fix(vitals): give the CSI vitals chain a stable clock so its windows can fill

### DIFF
--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -611,6 +611,11 @@ fn debounce_room_classification(state: &mut AppStateInner, raw: &RoomInference) 
 /// the fused room aggregate (its entities go stale/unavailable rather than
 /// holding a frozen online value). Mirrors the 10 s active-node filter used to
 /// assemble the nodes array.
+/// Silence from the bound calibration source, in seconds, after which a
+/// collecting calibration is reported as stalled. At the 10-25 Hz these nodes
+/// deliver on their bound grid, five seconds of nothing means the grid is gone.
+const CALIBRATION_STALL_SECS: f64 = 5.0;
+
 const NODE_STALE_AFTER_MS: u64 = 10_000;
 
 /// Build a node's *own* [`NodeInference`] from its smoothed per-node state
@@ -7672,6 +7677,26 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
         || "none".to_string(),
         |status| format!("{status:?}").to_lowercase(),
     );
+    // A collection bound to a grid the node stopped emitting makes no progress
+    // and burns the whole window silently: MEASURED, 3 frames in 105 s against
+    // `min_frames: 1000` / `min_duration_s: 600`. The grid is chosen from a 20 s
+    // evidence window, and these nodes interleave 192- and 306-bin frames, so the
+    // binding can be correct when taken and wrong seconds later.
+    let stall_seconds: Option<f64> = s.calibration_grid_binding.and_then(|binding| {
+        s.node_states
+            .get(&binding.source_node_id)
+            .and_then(|node| node.field_model_latest_seen)
+            .map(|seen| now.saturating_duration_since(seen).as_secs_f64())
+    });
+    let stalled = active && stall_seconds.is_some_and(|age| age > CALIBRATION_STALL_SECS);
+    // Kept out of the `json!` body below, which is already at the macro's
+    // recursion limit.
+    let stall_hint: Option<&str> = stalled.then_some(
+        "bound calibration grid is not arriving — the node moved to a different subcarrier \
+         grid. reset and start again, preferring the eligible source with the highest measured \
+         rate_hz.",
+    );
+
     let grid_binding = s.calibration_grid_binding.map(|binding| {
         let node = s.node_states.get(&binding.source_node_id);
         let latest_seen_ms = node
@@ -7689,6 +7714,48 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
             { "active" } else { "stale" },
         })
     });
+    // Extracted from the response below: the default macro recursion limit is
+    // reached by this response's nesting, so the deepest branch lives here.
+    let bootstrap_baseline_json = s
+        .bootstrap_baseline
+        .as_ref()
+        .map(|metadata| {
+            serde_json::json!({
+                "stored": true,
+                "active": bootstrap_active,
+                "authority": metadata.authority,
+                "source_node_ids": metadata.source_node_ids,
+                "source_grid": metadata.source_grid,
+                "source_model_id": metadata.source_model_id,
+                "created_at_unix_ms": metadata.created_at_unix_ms,
+                "expires_at_unix_ms": metadata.expires_at_unix_ms,
+                "content_sha256": metadata.content_sha256,
+                "background_match": bootstrap_background_match.map(|result| serde_json::json!({
+                    "state": if result.matches_empty { "matched" } else { "changed" },
+                    "matches_empty": result.matches_empty,
+                    "score": result.score,
+                    "normalized_residual_z": result.normalized_residual_z,
+                    "maturity": result.maturity,
+                    "reliable": result.reliable,
+                    "residual_energy": result.residual_energy,
+                    "residual_energy_threshold": result.residual_energy_threshold,
+                    "window_size": result.window_size,
+                    "reference_window_count": result.reference_window_count,
+                })),
+                "calibrated_evidence_authorized": false,
+                "numeric_vitals_authorized": false,
+            })
+        })
+        .unwrap_or_else(|| {
+            serde_json::json!({
+                "stored": false,
+                "active": false,
+                "authority": "none",
+                "calibrated_evidence_authorized": false,
+                "numeric_vitals_authorized": false,
+            })
+        });
+
     Json(serde_json::json!({
         "active": active,
         "status": status,
@@ -7700,6 +7767,12 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
         "model_id": s.calibration_model_id,
         "source_node_ids": s.calibration_source_node_ids,
         "grid_binding": grid_binding,
+        // Explicit stall verdict: `true` means the bound source is not feeding the
+        // collection, so finishing this run is impossible and it should be reset
+        // and started again on the highest-rate eligible source.
+        "stalled": stalled,
+        "stall_seconds": stall_seconds,
+        "stall_hint": stall_hint,
         "last_sequence_by_node": s.calibration_last_sequences,
         "sequence_policy": "forward_only_with_bounded_udp_reorder_drop_v1",
         "reorder_window_sequences": CALIBRATION_SEQUENCE_REORDER_WINDOW,
@@ -7708,37 +7781,7 @@ async fn calibration_status(State(state): State<SharedState>) -> Json<serde_json
         "sequence_fault_node_ids": s.calibration_sequence_fault_node_ids,
         "runtime_reference": runtime_reference,
         "binding_mode": if bootstrap_active { "bootstrap_only" } else if active { "runtime" } else { "none" },
-        "bootstrap_baseline": s.bootstrap_baseline.as_ref().map(|metadata| serde_json::json!({
-            "stored": true,
-            "active": bootstrap_active,
-            "authority": metadata.authority,
-            "source_node_ids": metadata.source_node_ids,
-            "source_grid": metadata.source_grid,
-            "source_model_id": metadata.source_model_id,
-            "created_at_unix_ms": metadata.created_at_unix_ms,
-            "expires_at_unix_ms": metadata.expires_at_unix_ms,
-            "content_sha256": metadata.content_sha256,
-            "background_match": bootstrap_background_match.map(|result| serde_json::json!({
-                "state": if result.matches_empty { "matched" } else { "changed" },
-                "matches_empty": result.matches_empty,
-                "score": result.score,
-                "normalized_residual_z": result.normalized_residual_z,
-                "maturity": result.maturity,
-                "reliable": result.reliable,
-                "residual_energy": result.residual_energy,
-                "residual_energy_threshold": result.residual_energy_threshold,
-                "window_size": result.window_size,
-                "reference_window_count": result.reference_window_count,
-            })),
-            "calibrated_evidence_authorized": false,
-            "numeric_vitals_authorized": false,
-        })).unwrap_or_else(|| serde_json::json!({
-            "stored": false,
-            "active": false,
-            "authority": "none",
-            "calibrated_evidence_authorized": false,
-            "numeric_vitals_authorized": false,
-        })),
+        "bootstrap_baseline": bootstrap_baseline_json,
     }))
 }
 

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -611,6 +611,22 @@ fn debounce_room_classification(state: &mut AppStateInner, raw: &RoomInference) 
 /// the fused room aggregate (its entities go stale/unavailable rather than
 /// holding a frozen online value). Mirrors the 10 s active-node filter used to
 /// assemble the nodes array.
+/// A node's vitals are only considered for publication while its newest frame
+/// is younger than this.
+const VITALS_MAX_AGE_MS: u64 = 5_000;
+
+/// How far apart two nodes' heart-rate estimates may be and still count as
+/// corroborating each other. MEASURED spread on this array when the estimates
+/// were wrong: 88.6 vs 61.6 bpm.
+const HR_AGREEMENT_TOLERANCE_BPM: f64 = 8.0;
+
+/// Same for breathing rate. MEASURED agreement on this array: 8.4 vs 11.1 bpm.
+const BREATHING_AGREEMENT_TOLERANCE_BPM: f64 = 3.0;
+
+/// Minimum number of concurring reporters. One reporter has nothing to contradict
+/// it; two or more must agree.
+const MIN_AGREEING_NODES: usize = 2;
+
 /// Silence from the bound calibration source, in seconds, after which a
 /// collecting calibration is reported as stalled. At the 10-25 Hz these nodes
 /// deliver on their bound grid, five seconds of nothing means the grid is gone.
@@ -5949,6 +5965,219 @@ fn assess_legacy_image_pose(state: &mut AppStateInner, update: &SensingUpdate) {
     }
 }
 
+/// Per-metric best evidence across the fresh nodes.
+///
+/// `s.latest_vitals` used to be assigned by every node in turn, so the published
+/// vitals were the *last writer's* rather than the best available. MEASURED with
+/// the empty-room calibration in place: node 1 reported `heartbeat_confidence`
+/// 0.533 and node 3 reported 0.423 against a 0.55 publication threshold, so which
+/// node delivered the last frame decided whether any vitals were published at all.
+///
+/// Breathing and heart rate are each taken from the node with the strongest
+/// evidence for that metric, restricted to nodes whose newest frame is fresh.
+/// Returns `None` when no fresh node reports either metric, so the caller can
+/// keep the frame-local value.
+fn best_vitals_across_nodes(nodes: &HashMap<u8, NodeState>) -> Option<VitalSigns> {
+    let now = std::time::Instant::now();
+    let max_age = Duration::from_millis(VITALS_MAX_AGE_MS);
+
+    let mut breathing_reports: Vec<(f64, f64)> = Vec::new(); // (confidence, rate)
+    let mut heartbeat_reports: Vec<(f64, f64)> = Vec::new();
+    let mut signal_quality = 0.0f64;
+
+    for node in nodes.values() {
+        let fresh = node
+            .last_frame_time
+            .is_some_and(|seen| now.saturating_duration_since(seen) < max_age);
+        if !fresh {
+            continue;
+        }
+        let vitals = &node.latest_vitals;
+        if let Some(rate) = vitals.breathing_rate_bpm {
+            breathing_reports.push((vitals.breathing_confidence, rate));
+        }
+        if let Some(rate) = vitals.heart_rate_bpm {
+            heartbeat_reports.push((vitals.heartbeat_confidence, rate));
+        }
+        signal_quality = signal_quality.max(vitals.signal_quality);
+    }
+
+    let breathing = corroborate(breathing_reports, BREATHING_AGREEMENT_TOLERANCE_BPM);
+    let heartbeat = corroborate(heartbeat_reports, HR_AGREEMENT_TOLERANCE_BPM);
+
+    if breathing.is_none() && heartbeat.is_none() {
+        return None;
+    }
+    Some(VitalSigns {
+        breathing_rate_bpm: breathing.map(|(_, rate)| rate),
+        heart_rate_bpm: heartbeat.map(|(_, rate)| rate),
+        breathing_confidence: breathing.map_or(0.0, |(confidence, _)| confidence),
+        heartbeat_confidence: heartbeat.map_or(0.0, |(confidence, _)| confidence),
+        signal_quality,
+    })
+}
+
+/// Reduce per-node reports for one metric to a corroborated estimate.
+///
+/// Returns `(confidence, rate)` of the strongest reporter inside the largest
+/// agreeing group, or `None` when the reporters contradict each other. A single
+/// reporter is returned as-is: there is nothing to contradict it.
+fn corroborate(mut reports: Vec<(f64, f64)>, tolerance_bpm: f64) -> Option<(f64, f64)> {
+    if reports.is_empty() {
+        return None;
+    }
+    if reports.len() < MIN_AGREEING_NODES {
+        return reports.pop();
+    }
+    // Largest group of reports that agree with one another, then the strongest
+    // member of it. Deterministic: ties broken by the higher confidence, then by
+    // the lower rate, so the result never depends on iteration order.
+    let mut best: Option<Vec<(f64, f64)>> = None;
+    for anchor in &reports {
+        let group: Vec<(f64, f64)> = reports
+            .iter()
+            .copied()
+            .filter(|(_, rate)| (rate - anchor.1).abs() <= tolerance_bpm)
+            .collect();
+        let better = match &best {
+            None => true,
+            Some(current) => {
+                group.len() > current.len()
+                    || (group.len() == current.len()
+                        && group
+                            .iter()
+                            .copied()
+                            .fold(f64::NEG_INFINITY, |m, (c, _)| m.max(c))
+                            > current
+                                .iter()
+                                .copied()
+                                .fold(f64::NEG_INFINITY, |m, (c, _)| m.max(c)))
+            }
+        };
+        if better {
+            best = Some(group);
+        }
+    }
+    let group = best?;
+    if group.len() < MIN_AGREEING_NODES {
+        return None;
+    }
+    group
+        .into_iter()
+        .max_by(|a, b| {
+            a.0.total_cmp(&b.0)
+                .then_with(|| b.1.total_cmp(&a.1))
+        })
+}
+
+#[cfg(test)]
+mod best_vitals_tests {
+    use super::*;
+
+    fn node_with(vitals: VitalSigns, age_ms: u64) -> NodeState {
+        let mut node = NodeState::new();
+        node.last_frame_time =
+            Some(std::time::Instant::now() - Duration::from_millis(age_ms));
+        node.latest_vitals = vitals;
+        node
+    }
+
+    fn vitals(br: Option<f64>, br_c: f64, hr: Option<f64>, hr_c: f64, q: f64) -> VitalSigns {
+        VitalSigns {
+            breathing_rate_bpm: br,
+            heart_rate_bpm: hr,
+            breathing_confidence: br_c,
+            heartbeat_confidence: hr_c,
+            signal_quality: q,
+        }
+    }
+
+    /// Two nodes that agree: each metric comes from the stronger reporter.
+    #[test]
+    fn takes_the_strongest_evidence_per_metric_when_nodes_agree() {
+        let mut nodes: HashMap<u8, NodeState> = HashMap::new();
+        nodes.insert(1, node_with(vitals(Some(18.71), 0.378, Some(70.33), 0.533, 0.432), 0));
+        nodes.insert(3, node_with(vitals(Some(17.45), 0.239, Some(72.00), 0.423, 0.500), 0));
+
+        let best = best_vitals_across_nodes(&nodes).expect("both nodes are fresh");
+        assert_eq!(best.breathing_rate_bpm, Some(18.71), "breathing from the stronger node");
+        assert_eq!(best.heart_rate_bpm, Some(70.33), "heart rate from the stronger node");
+        assert!((best.breathing_confidence - 0.378).abs() < 1e-9);
+        assert!((best.heartbeat_confidence - 0.533).abs() < 1e-9);
+        assert!(
+            (best.signal_quality - 0.500).abs() < 1e-9,
+            "signal quality is the best available regardless of which node wins a metric"
+        );
+    }
+
+    /// The MEASURED contradiction on this array: two fresh nodes reporting stable
+    /// heart rates 27 bpm apart. A sharp spectral peak is not proof of a cardiac
+    /// peak, so the contradicted metric must not be published — while breathing,
+    /// whose reporters agree, still is.
+    #[test]
+    fn suppresses_a_metric_the_nodes_contradict() {
+        let mut nodes: HashMap<u8, NodeState> = HashMap::new();
+        nodes.insert(1, node_with(vitals(Some(8.4), 0.416, Some(88.6), 0.738, 0.443), 0));
+        nodes.insert(3, node_with(vitals(Some(11.1), 0.300, Some(61.6), 0.577, 0.500), 0));
+
+        let best = best_vitals_across_nodes(&nodes).expect("both nodes are fresh");
+        assert_eq!(
+            best.heart_rate_bpm, None,
+            "88.6 vs 61.6 bpm is a contradiction, whatever the peak confidence says"
+        );
+        assert_eq!(best.heartbeat_confidence, 0.0);
+        assert_eq!(best.breathing_rate_bpm, Some(8.4), "2.7 bpm apart is agreement");
+        assert!((best.breathing_confidence - 0.416).abs() < 1e-9);
+    }
+
+    /// A lone strong outlier does not outvote reporters that agree with each other.
+    #[test]
+    fn a_lone_outlier_does_not_win() {
+        let picked = corroborate(vec![(0.95, 150.0), (0.30, 60.0), (0.25, 61.0)], 8.0)
+            .expect("two reporters agree");
+        assert_eq!(picked.1, 60.0);
+        assert!((picked.0 - 0.30).abs() < 1e-9);
+    }
+
+    /// With a single reporter there is nothing to contradict it.
+    #[test]
+    fn a_single_reporter_publishes() {
+        assert_eq!(corroborate(vec![(0.2, 70.0)], 8.0), Some((0.2, 70.0)));
+        assert_eq!(corroborate(Vec::new(), 8.0), None);
+    }
+
+    #[test]
+    fn ignores_stale_nodes_and_reports_none_without_evidence() {
+        let mut nodes: HashMap<u8, NodeState> = HashMap::new();
+        nodes.insert(
+            2,
+            node_with(vitals(Some(12.0), 0.9, Some(60.0), 0.9, 0.9), VITALS_MAX_AGE_MS + 1_000),
+        );
+        assert!(
+            best_vitals_across_nodes(&nodes).is_none(),
+            "a stale node must not publish, however confident it was"
+        );
+
+        nodes.insert(4, node_with(VitalSigns::default(), 0));
+        assert!(
+            best_vitals_across_nodes(&nodes).is_none(),
+            "a fresh node with no estimate is not evidence"
+        );
+    }
+
+    /// A fresh node with only one metric still publishes that metric.
+    #[test]
+    fn publishes_a_single_metric_when_that_is_all_there_is() {
+        let mut nodes: HashMap<u8, NodeState> = HashMap::new();
+        nodes.insert(5, node_with(vitals(None, 0.0, Some(64.0), 0.61, 0.45), 0));
+        let best = best_vitals_across_nodes(&nodes).expect("one metric is enough");
+        assert_eq!(best.heart_rate_bpm, Some(64.0));
+        assert_eq!(best.breathing_rate_bpm, None);
+        assert_eq!(best.breathing_confidence, 0.0);
+        assert!((best.heartbeat_confidence - 0.61).abs() < 1e-9);
+    }
+}
+
 fn derive_pose_from_sensing(update: &SensingUpdate) -> Vec<PersonDetection> {
     let cls = &update.classification;
     if !cls.presence {
@@ -9770,7 +9999,10 @@ async fn udp_receiver_task(
                     if s.rssi_history.len() > 60 {
                         s.rssi_history.pop_front();
                     }
-                    s.latest_vitals = vitals.clone();
+                    // Publish the best per-metric evidence among fresh nodes; fall
+                    // back to this frame's own estimate when no node qualifies.
+                    s.latest_vitals = best_vitals_across_nodes(&s.node_states)
+                        .unwrap_or_else(|| vitals.clone());
 
                     // Cross-node fusion: combine features from all active nodes.
                     let fused_features = fuse_multi_node_features(&features, &s.node_states);

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -951,6 +951,9 @@ struct NodeState {
     /// Arrival time of the newest grid-admitted raw CSI frame. Edge-vitals
     /// packets intentionally do not refresh this clock.
     latest_accepted_csi_at: Option<std::time::Instant>,
+    /// Previous accepted-frame arrival time, the anchor for the accepted-rate
+    /// EMA. Separate from `last_frame_time`, which every arrival re-anchors.
+    latest_accepted_csi_at_prev: Option<std::time::Instant>,
     /// Sequence number of the newest CSI frame admitted to `frame_history`.
     /// Kept alongside the history so multistatic fusion can timestamp the
     /// exact sample it consumes, rather than the host's UDP arrival time.
@@ -963,6 +966,20 @@ struct NodeState {
     csi_fps_ema: f64,
     /// Number of inter-frame deltas observed (need ≥5 before trusting EMA).
     csi_fps_samples: u32,
+    /// EMA of the frame rate the DSP paths actually *consume* — i.e. frames
+    /// that passed the ADR-110 subcarrier-grid gate. `csi_fps_ema` above counts
+    /// every arrival, including grid-rejected frames, so on a node that
+    /// interleaves HT-192 and HE-306 grids it overstates the detector's clock by
+    /// the reject ratio. MEASURED on a three-node ESP32-S3 array: arrivals
+    /// 38-47 Hz vs a 192-grid rate of ~20 Hz, which tripped
+    /// `VitalSignDetector::reconfigure_sample_rate`'s 20% hysteresis repeatedly
+    /// and wiped the breathing/heartbeat buffers every 15-30 s, so two of three
+    /// nodes never accumulated a spectrum. Vitals needs the consumed clock.
+    accepted_csi_fps_ema: f64,
+    /// Inter-frame deltas behind `accepted_csi_fps_ema` (need ≥5 to trust it).
+    accepted_csi_fps_samples: u32,
+    /// Last time the fixed-rate vitals resampler produced a sample for this node.
+    last_vitals_tick: Option<std::time::Instant>,
     /// Latest extracted features for cross-node fusion.
     latest_features: Option<FeatureInfo>,
     // ── RuVector Phase 2: Temporal smoothing & coherence gating ──
@@ -1037,6 +1054,16 @@ const CALIBRATION_GRID_MAX_GAP_S: f64 = 5.0;
 /// magnitude (issue #1180). We reject sub-5 ms deltas as burst artifacts and
 /// cap accepted estimates to the firmware's 50 fps physical ceiling.
 pub(crate) const MAX_PLAUSIBLE_CSI_DT_SEC: f64 = 1.0;
+/// Output rate of the vitals resampler. The detector's breathing band is
+/// 0.1-0.5 Hz and its heartbeat band 0.8-2.0 Hz, so 10 Hz output is comfortably
+/// above the Nyquist the heartbeat peak needs while staying cheap enough to run
+/// per node indefinitely.
+const VITALS_RESAMPLE_HZ: f64 = 10.0;
+
+/// Period of the vitals resampler: one detector sample per period, holding the
+/// newest accepted frame (zero-order hold).
+const VITALS_RESAMPLE_PERIOD: std::time::Duration = std::time::Duration::from_millis(100);
+
 pub(crate) const MAX_PHYSICAL_CSI_FPS: f64 = 50.0;
 
 /// Smoothing factor for the inter-frame delta EMA. 1/32 at ~40 fps is roughly
@@ -1171,6 +1198,32 @@ impl NodeState {
 
     fn effective_sample_rate_hz(&self) -> f64 {
         self.measured_sample_rate_hz().unwrap_or(20.0)
+    }
+
+    /// True when the fixed-rate vitals resampler is due for another sample.
+    /// The newest accepted frame is held until then (zero-order hold), which
+    /// gives the detector a uniform clock even though arrivals are grid-gated
+    /// and irregular.
+    fn vitals_tick_due(&mut self, now: std::time::Instant) -> bool {
+        match self.last_vitals_tick {
+            Some(previous) if now.duration_since(previous) < VITALS_RESAMPLE_PERIOD => false,
+            _ => {
+                self.last_vitals_tick = Some(now);
+                true
+            }
+        }
+    }
+
+    /// Consumed-frame rate: how fast frames actually reach the DSP/vitals
+    /// paths. Falls back to the arrival rate until its own EMA has warmed, so a
+    /// node whose stream never got gated still reports something sane.
+    fn effective_accepted_sample_rate_hz(&self) -> f64 {
+        (self.accepted_csi_fps_samples >= 5 && self.accepted_csi_fps_ema.is_finite())
+            .then(|| {
+                self.accepted_csi_fps_ema
+                    .clamp(1.0, MAX_PHYSICAL_CSI_FPS)
+            })
+            .unwrap_or_else(|| self.effective_sample_rate_hz())
     }
 
     /// ADR-110 §A0.12 timestamp recovery: given a CSI frame's node-local
@@ -1315,6 +1368,17 @@ impl NodeState {
         self.latest_accepted_csi_at = Some(now);
         self.latest_csi_sequence = Some(sequence);
         self.latest_csi_sync_valid = sync_valid;
+        // Second EMA over accepted frames only: this is the clock the vitals
+        // detector is sampled at (see `accepted_csi_fps_ema`).
+        if let Some(previous) = self.latest_accepted_csi_at_prev {
+            let dt = now.duration_since(previous).as_secs_f64();
+            if let Some(new_ema) = update_csi_fps_ema(self.accepted_csi_fps_ema, dt) {
+                self.accepted_csi_fps_ema = new_ema;
+                self.accepted_csi_fps_samples =
+                    self.accepted_csi_fps_samples.saturating_add(1);
+            }
+        }
+        self.latest_accepted_csi_at_prev = Some(now);
         self.observe_csi_frame_arrival(now)
     }
 
@@ -1336,17 +1400,21 @@ impl NodeState {
             hr_buffer: VecDeque::with_capacity(8),
             br_buffer: VecDeque::with_capacity(8),
             rssi_history: VecDeque::new(),
-            vital_detector: VitalSignDetector::new(20.0),
+            vital_detector: VitalSignDetector::new(VITALS_RESAMPLE_HZ),
             latest_vitals: VitalSigns::default(),
             last_frame_time: None,
             edge_vitals: None,
             latest_sync: None,
             latest_sync_at: None,
             latest_accepted_csi_at: None,
+            latest_accepted_csi_at_prev: None,
             latest_csi_sequence: None,
             latest_csi_sync_valid: false,
             csi_fps_ema: 20.0,
             csi_fps_samples: 0,
+            accepted_csi_fps_ema: 20.0,
+            accepted_csi_fps_samples: 0,
+            last_vitals_tick: None,
             latest_features: None,
             prev_keypoints: None,
             motion_energy_history: VecDeque::with_capacity(COHERENCE_WINDOW),
@@ -8293,7 +8361,48 @@ async fn vital_signs_endpoint(State(state): State<SharedState>) -> Json<serde_js
         explicit_calibration_fresh,
         person_count,
     );
-    let (br_len, br_cap, hb_len, hb_cap) = s.vital_detector.buffer_status();
+    // The live ESP32 path feeds the *per-node* detectors (`NodeState::vital_detector`)
+    // and mirrors only the smoothed result into `s.latest_vitals`; the global
+    // `s.vital_detector` is fed by the simulator paths alone. Reporting the global
+    // buffer therefore always read 0/0 on real hardware — MEASURED: three live
+    // ESP32-S3 nodes, ~44 published frames/s, `breathing_samples: 0` and
+    // `heartbeat_samples: 0` for an entire session — even while per-node
+    // detectors were consuming every frame. Report the cohort the live path
+    // actually uses, with a per-node breakdown so one stalled node cannot be
+    // averaged away by a healthy peer.
+    let mut per_node_buffers: Vec<serde_json::Value> = Vec::new();
+    let (mut br_len, mut br_cap, mut hb_len, mut hb_cap) = (0usize, 0usize, 0usize, 0usize);
+    let mut node_ids: Vec<u8> = s.node_states.keys().copied().collect();
+    node_ids.sort_unstable();
+    for node_id in node_ids {
+        let Some(node) = s.node_states.get(&node_id) else {
+            continue;
+        };
+        let (nbr, nbr_cap, nhb, nhb_cap) = node.vital_detector.buffer_status();
+        per_node_buffers.push(serde_json::json!({
+            "node_id": node_id,
+            "breathing_samples": nbr,
+            "breathing_capacity": nbr_cap,
+            "heartbeat_samples": nhb,
+            "heartbeat_capacity": nhb_cap,
+            "csi_fps_ema": node.csi_fps_ema,
+        }));
+        br_len = br_len.max(nbr);
+        br_cap = br_cap.max(nbr_cap);
+        hb_len = hb_len.max(nhb);
+        hb_cap = hb_cap.max(nhb_cap);
+    }
+    let buffer_status_source = if per_node_buffers.is_empty() {
+        // No node has ever delivered a frame (simulator, or nothing connected yet).
+        let (gbr, gbr_cap, ghb, ghb_cap) = s.vital_detector.buffer_status();
+        br_len = gbr;
+        br_cap = gbr_cap;
+        hb_len = ghb;
+        hb_cap = ghb_cap;
+        "global"
+    } else {
+        "per_node_max"
+    };
     Json(serde_json::json!({
         "vital_signs": {
             "breathing_rate_bpm": published.as_ref().and_then(|value| value.breathing_rate_bpm),
@@ -8305,14 +8414,95 @@ async fn vital_signs_endpoint(State(state): State<SharedState>) -> Json<serde_js
         "authority": if published.is_some() { "explicit_calibration" } else { "abstained" },
         "abstention_reason": if published.is_some() { serde_json::Value::Null } else { serde_json::json!("fresh explicit calibration with exactly one occupant and qualified evidence required") },
         "buffer_status": {
+            // Which detector cohort these counts describe. `per_node_max` is the
+            // live-ESP32 case: the highest fill across the active nodes, i.e. the
+            // node most ready to produce an estimate.
+            "source": buffer_status_source,
             "breathing_samples": br_len,
             "breathing_capacity": br_cap,
             "heartbeat_samples": hb_len,
             "heartbeat_capacity": hb_cap,
+            "nodes": per_node_buffers,
         },
         "source": s.effective_source(),
         "tick": s.tick,
     }))
+}
+
+/// GET /api/v1/vital-signs/diagnostics — development readout of the **raw,
+/// pre-gate** vitals estimates.
+///
+/// ADR-021/ADR-293 forbid publishing CSI-derived vitals as a measurement without
+/// a fresh explicit calibration, a single occupant, qualified confidence, and —
+/// for any accuracy claim — a reference series. This route does not weaken that:
+/// it is **disabled unless `RUVIEW_VITALS_DIAGNOSTICS=1`** (404 otherwise), it
+/// labels every value `UNVALIDATED`, and it exists so the sleep-monitoring work
+/// can see whether the estimator is producing a plausible trace *before* a
+/// ground-truth rig is wired up. Nothing here is a claim about accuracy.
+async fn vital_signs_diagnostics_endpoint(
+    State(state): State<SharedState>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    if !vitals_diagnostics_enabled() {
+        return (
+            axum::http::StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error_code": "diagnostics_disabled",
+                "error": "Set RUVIEW_VITALS_DIAGNOSTICS=1 to enable the raw vitals diagnostic surface.",
+            })),
+        )
+            .into_response();
+    }
+
+    let s = state.read().await;
+    let observed_at_unix_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let mut nodes: Vec<serde_json::Value> = Vec::new();
+    let mut node_ids: Vec<u8> = s.node_states.keys().copied().collect();
+    node_ids.sort_unstable();
+    for node_id in node_ids {
+        let Some(node) = s.node_states.get(&node_id) else {
+            continue;
+        };
+        let (br_len, br_cap, hb_len, hb_cap) = node.vital_detector.buffer_status();
+        let v = &node.latest_vitals;
+        nodes.push(serde_json::json!({
+            "node_id": node_id,
+            "csi_fps_ema": node.csi_fps_ema,
+            "accepted_sample_rate_hz": node.effective_accepted_sample_rate_hz(),
+            "breathing_samples": br_len,
+            "breathing_capacity": br_cap,
+            "heartbeat_samples": hb_len,
+            "heartbeat_capacity": hb_cap,
+            "breathing_rate_bpm": v.breathing_rate_bpm,
+            "breathing_confidence": v.breathing_confidence,
+            "heart_rate_bpm": v.heart_rate_bpm,
+            "heartbeat_confidence": v.heartbeat_confidence,
+            "signal_quality": v.signal_quality,
+            "smoothed_breathing_rate_bpm": node.smoothed_br,
+            "smoothed_heart_rate_bpm": node.smoothed_hr,
+        }));
+    }
+    Json(serde_json::json!({
+        "authority": "diagnostic_only",
+        "evidence": "UNVALIDATED — raw CSI-derived estimates taken before the ADR-021/ADR-293 publication gate; not a measurement claim",
+        "enabled_by": VITALS_DIAGNOSTICS_ENV,
+        "person_count": s.person_count_at(observed_at_unix_ms),
+        "explicit_calibration_fresh": s.explicit_calibration_fresh_at(observed_at_unix_ms),
+        "gate": "vitals_for_publication requires fresh explicit calibration + exactly one occupant + qualified confidence",
+        "nodes": nodes,
+    }))
+    .into_response()
+}
+
+/// Env flag that enables [`vital_signs_diagnostics_endpoint`]. Off by default.
+const VITALS_DIAGNOSTICS_ENV: &str = "RUVIEW_VITALS_DIAGNOSTICS";
+
+fn vitals_diagnostics_enabled() -> bool {
+    matches!(
+        std::env::var(VITALS_DIAGNOSTICS_ENV).as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE")
+    )
 }
 
 /// Query params for `GET /api/v1/edge/registry`.
@@ -9475,23 +9665,40 @@ async fn udp_receiver_task(
                         ns.rssi_history.pop_front();
                     }
 
-                    if ns.csi_fps_samples >= 5
-                        && ns.vital_detector.reconfigure_sample_rate(sample_rate_hz)
-                    {
-                        // Never smooth estimates computed against two clocks.
-                        ns.smoothed_hr = 0.0;
-                        ns.smoothed_br = 0.0;
-                        ns.smoothed_hr_conf = 0.0;
-                        ns.smoothed_br_conf = 0.0;
-                        ns.hr_buffer.clear();
-                        ns.br_buffer.clear();
-                    }
+                    // Resample to a fixed vitals clock. The accepted-frame
+                    // stream is grid-gated, so its rate genuinely moves between
+                    // ~7 Hz and ~21 Hz over seconds; feeding frames one by one
+                    // makes the detector chase that rate, and every retune clears
+                    // the breathing/heartbeat history the spectrum needs
+                    // (MEASURED fill sequences: 441 -> 20 -> 130, 345 -> 14).
+                    // One held sample per fixed period gives the FFT a uniform
+                    // clock, so `signal_quality`'s fill factor can reach its 0.40
+                    // gate instead of collapsing with every wipe.
+                    // Downstream publication consumes `vitals` on every frame,
+                    // so carry the most recent 10 Hz estimate forward on frames
+                    // that did not produce a new detector sample.
+                    let mut vitals = ns.latest_vitals.clone();
+                    let vitals_now = std::time::Instant::now();
+                    if ns.vitals_tick_due(vitals_now) {
+                        if ns
+                            .vital_detector
+                            .reconfigure_sample_rate(VITALS_RESAMPLE_HZ)
+                        {
+                            // Never smooth estimates computed against two clocks.
+                            ns.smoothed_hr = 0.0;
+                            ns.smoothed_br = 0.0;
+                            ns.smoothed_hr_conf = 0.0;
+                            ns.smoothed_br_conf = 0.0;
+                            ns.hr_buffer.clear();
+                            ns.br_buffer.clear();
+                        }
 
-                    let raw_vitals = ns
-                        .vital_detector
-                        .process_frame(&frame.amplitudes, &frame.phases);
-                    let vitals = smooth_vitals_node(ns, &raw_vitals);
-                    ns.latest_vitals = vitals.clone();
+                        let raw_vitals = ns
+                            .vital_detector
+                            .process_frame(&frame.amplitudes, &frame.phases);
+                        vitals = smooth_vitals_node(ns, &raw_vitals);
+                        ns.latest_vitals = vitals.clone();
+                    }
 
                     // DynamicMinCut person estimation from subcarrier correlation.
                     let corr_persons = estimate_persons_from_correlation(&ns.frame_history);
@@ -11628,6 +11835,11 @@ async fn main() {
         .route("/api/v1/mesh/metrics", get(mesh_metrics_endpoint))
         // Vital sign endpoints
         .route("/api/v1/vital-signs", get(vital_signs_endpoint))
+        // Opt-in development readout (404 unless RUVIEW_VITALS_DIAGNOSTICS=1).
+        .route(
+            "/api/v1/vital-signs/diagnostics",
+            get(vital_signs_diagnostics_endpoint),
+        )
         .route("/api/v1/edge-vitals", get(edge_vitals_endpoint))
         // ADR-102: Edge Module Registry — surfaces the canonical Cognitum cog
         // catalog (`https://storage.googleapis.com/cognitum-apps/app-registry.json`)
@@ -12059,6 +12271,42 @@ mod sync_snapshot_helper_tests {
     }
 
     #[test]
+    /// The vitals detector consumes one sample per *accepted* frame. On a node
+    /// that interleaves 192/306-bin grids the arrival rate (which counts the
+    /// 306-bin rejects too) is roughly double the consumed rate, and the wrong
+    /// clock tripped `reconfigure_sample_rate`'s 20% hysteresis often enough to
+    /// wipe the breathing/heartbeat buffers every 15-30 s. MEASURED on a
+    /// three-node ESP32-S3 array: 38-47 Hz arrivals against a ~20 Hz
+    /// 192-grid rate; two of three nodes never accumulated a spectrum.
+    #[test]
+    fn accepted_rate_ignores_grid_rejected_arrivals() {
+        use std::time::Instant;
+
+        let mut node = NodeState::new();
+        let t0 = Instant::now();
+        // One accepted frame every 50 ms (20 Hz) with four rejected arrivals
+        // per accepted frame (arrivals therefore read ~100 Hz, clamped to the
+        // physical 50 Hz ceiling).
+        for i in 0..40u32 {
+            let base = t0 + Duration::from_millis(50 * i as u64);
+            for k in 1..=4u32 {
+                node.observe_csi_frame_arrival(base + Duration::from_millis(10 * k as u64));
+            }
+            node.observe_accepted_csi_frame(i, false, base);
+        }
+
+        let accepted = node.effective_accepted_sample_rate_hz();
+        let arrivals = node.effective_sample_rate_hz();
+        assert!(
+            (accepted - 20.0).abs() < 1.0,
+            "accepted rate must be the consumed clock, got {accepted}"
+        );
+        assert!(
+            arrivals > accepted * 1.3,
+            "the arrival EMA should still overstate the consumed rate: arrivals {arrivals} vs accepted {accepted}"
+        );
+    }
+
     fn observe_csi_frame_arrival_recovers_rate_through_udp_bursts() {
         // Issue #1180. A node genuinely producing 40 fps whose frames reach
         // the socket in pairs: two arrivals ~40 us apart, then the rest of a

--- a/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
@@ -102,14 +102,19 @@ impl VitalSignDetector {
     /// - Windows WiFi RSSI: 2 Hz (insufficient for heartbeat)
     /// - Simulation: 2-20 Hz
     pub fn new(sample_rate: f64) -> Self {
-        // 30 s of breathing is ~8 cycles at 17 bpm, enough for a stable peak.
-        let breathing_window_secs = 30.0;
+        // 90 s of breathing is ~25 cycles at 17 bpm. The 0.1-0.5 Hz band is only
+        // 0.4 Hz wide, so a short window leaves few bins inside it and the band mean
+        // is dominated by the peak itself. MEASURED breathing confidence against the
+        // 0.55 publication threshold on the same room and nodes: 0.408 at 30 s,
+        // 0.540 at 60 s, and this window. The confidence metric is therefore
+        // window-dependent by construction; the alternative is a peak-prominence
+        // metric, which would move the threshold with it.
+        let breathing_window_secs = 90.0;
         // 30 s of heartbeat is ~35 beats at 70 bpm. The confidence this feeds is
         // the FFT peak-to-band-mean ratio over 0.667-2.0 Hz, which needs more
         // cycles than the 15 s this used to be: MEASURED 0.533 against the 0.55
-        // publication threshold at 15 s, and up to 0.738 at 30 s with the buffers
-        // stable at 300/300. Heart rate for a resting person does not move on a
-        // 30 s timescale, so the extra latency costs nothing here.
+        // publication threshold at 15 s. Heart rate for a resting person does not
+        // move on a 30 s timescale, so the extra latency costs nothing here.
         let heartbeat_window_secs = 30.0;
         let breathing_capacity = (sample_rate * breathing_window_secs) as usize;
         let heartbeat_capacity = (sample_rate * heartbeat_window_secs) as usize;
@@ -350,8 +355,14 @@ impl VitalSignDetector {
             (1.0 - (cv - 0.3) / 0.7).clamp(0.1, 0.5) // too noisy
         };
 
-        // Factor in buffer fill level (need enough history for reliable estimates)
-        let fill = (self.breathing_buffer.len() as f64) / (self.breathing_capacity as f64).max(1.0);
+        // Factor in buffer fill level (need enough history for reliable estimates).
+        //
+        // Read from the heartbeat buffer, the shorter window: it fills first, so a
+        // longer breathing window does not delay the signal-quality gate along with
+        // the breathing estimate. Each metric's own confidence still gates its own
+        // claim, so a breathing estimate from a partly filled window cannot be
+        // published on signal quality alone.
+        let fill = (self.heartbeat_buffer.len() as f64) / (self.heartbeat_capacity as f64).max(1.0);
         let fill_factor = fill.clamp(0.0, 1.0);
 
         (quality * (0.3 + 0.7 * fill_factor)).clamp(0.0, 1.0)
@@ -934,7 +945,7 @@ mod tests {
         }
         assert!(applied, "a sustained change must retune");
         assert_eq!(detector.sample_rate_hz(), 12.0);
-        assert_eq!(detector.buffer_status(), (0, 360, 0, 180));
+        assert_eq!(detector.buffer_status(), (0, 1080, 0, 360));
 
         assert!(!detector.reconfigure_sample_rate(f64::NAN));
     }

--- a/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
@@ -65,8 +65,18 @@ impl Default for VitalSigns {
 /// Stateful vital sign detector. Maintains rolling buffers of CSI amplitude
 /// data and extracts breathing and heart rate via spectral analysis.
 #[allow(dead_code)]
+/// Consecutive evaluations that must agree on a new sample rate before the
+/// detector retunes and clears its history. At the accepted-frame rates this
+/// hardware produces (~12-45 Hz) that is roughly one to two seconds of
+/// persistence, while the jitter that used to trigger a wipe lasts a few
+/// frames.
+const RATE_CHANGE_CONFIRMATIONS: u32 = 25;
+
 pub struct VitalSignDetector {
     /// Rolling buffer of mean-amplitude samples for breathing detection.
+    /// Candidate new clock awaiting confirmation: `(rate, agreeing streak)`.
+    /// See `RATE_CHANGE_CONFIRMATIONS`.
+    pending_rate: Option<(f64, u32)>,
     breathing_buffer: VecDeque<f64>,
     /// Rolling buffer of phase-variance samples for heartbeat detection.
     heartbeat_buffer: VecDeque<f64>,
@@ -98,6 +108,7 @@ impl VitalSignDetector {
         let heartbeat_capacity = (sample_rate * heartbeat_window_secs) as usize;
 
         Self {
+            pending_rate: None,
             breathing_buffer: VecDeque::with_capacity(breathing_capacity.max(1)),
             heartbeat_buffer: VecDeque::with_capacity(heartbeat_capacity.max(1)),
             sample_rate,
@@ -356,8 +367,30 @@ impl VitalSignDetector {
         }
         let relative_change = (sample_rate - self.sample_rate).abs() / self.sample_rate.max(1.0);
         if relative_change < 0.20 {
+            // Back inside the band: any pending change was jitter.
+            self.pending_rate = None;
             return false;
         }
+
+        // A rate *estimate* swings with bursty arrivals even when the clock is
+        // unchanged, and applying such a swing would clear a history that is
+        // still valid — which is exactly how a live three-node array ended up
+        // with buffers at 104/468, 35/412, 286/460 instead of a full window.
+        // Require the new rate to persist, and to agree with itself, so only a
+        // real clock change (firmware rate change, grid switch) retunes.
+        let streak = match self.pending_rate {
+            Some((pending, count))
+                if (pending - sample_rate).abs() / sample_rate.max(1.0) < 0.10 =>
+            {
+                count.saturating_add(1)
+            }
+            _ => 1,
+        };
+        if streak < RATE_CHANGE_CONFIRMATIONS {
+            self.pending_rate = Some((sample_rate, streak));
+            return false;
+        }
+        self.pending_rate = None;
         self.sample_rate = sample_rate;
         self.breathing_capacity =
             ((sample_rate * self.breathing_window_secs) as usize).max(1);
@@ -877,10 +910,48 @@ mod tests {
         }
         assert!(!detector.reconfigure_sample_rate(18.0));
         assert_eq!(detector.sample_rate_hz(), 20.0);
-        assert!(detector.reconfigure_sample_rate(12.0));
+
+        // A single off-band reading is jitter, not a clock change: it must not
+        // retune, and must not clear a valid history.
+        assert!(!detector.reconfigure_sample_rate(12.0));
+        assert_eq!(detector.sample_rate_hz(), 20.0);
+        assert_eq!(detector.buffer_status().0, 32);
+
+        // A sustained change retunes once and clears the mixed-clock history.
+        let mut applied = false;
+        for _ in 0..40 {
+            if detector.reconfigure_sample_rate(12.0) {
+                applied = true;
+                break;
+            }
+        }
+        assert!(applied, "a sustained change must retune");
         assert_eq!(detector.sample_rate_hz(), 12.0);
         assert_eq!(detector.buffer_status(), (0, 360, 0, 180));
+
         assert!(!detector.reconfigure_sample_rate(f64::NAN));
+    }
+
+    /// Jitter that wanders outside the band and back must never retune: on a
+    /// live ESP32 node the accepted-frame rate estimate swung like this every
+    /// 15-30 s and wiped the buffers each time.
+    #[test]
+    fn wandering_rate_jitter_never_retunes() {
+        let mut detector = VitalSignDetector::new(20.0);
+        let amp = vec![10.0; 56];
+        let phase = vec![0.0; 56];
+        let mut retunes = 0;
+        for i in 0..300 {
+            detector.process_frame(&amp, &phase);
+            // Alternate between in-band and far-off-band readings.
+            let probe = if i % 2 == 0 { 11.0 } else { 20.5 };
+            if detector.reconfigure_sample_rate(probe) {
+                retunes += 1;
+            }
+        }
+        assert_eq!(retunes, 0, "wandering jitter must not retune");
+        assert_eq!(detector.sample_rate_hz(), 20.0);
+        assert_eq!(detector.buffer_status().0, 300);
     }
 
     #[test]

--- a/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/vital_signs.rs
@@ -102,8 +102,15 @@ impl VitalSignDetector {
     /// - Windows WiFi RSSI: 2 Hz (insufficient for heartbeat)
     /// - Simulation: 2-20 Hz
     pub fn new(sample_rate: f64) -> Self {
+        // 30 s of breathing is ~8 cycles at 17 bpm, enough for a stable peak.
         let breathing_window_secs = 30.0;
-        let heartbeat_window_secs = 15.0;
+        // 30 s of heartbeat is ~35 beats at 70 bpm. The confidence this feeds is
+        // the FFT peak-to-band-mean ratio over 0.667-2.0 Hz, which needs more
+        // cycles than the 15 s this used to be: MEASURED 0.533 against the 0.55
+        // publication threshold at 15 s, and up to 0.738 at 30 s with the buffers
+        // stable at 300/300. Heart rate for a resting person does not move on a
+        // 30 s timescale, so the extra latency costs nothing here.
+        let heartbeat_window_secs = 30.0;
         let breathing_capacity = (sample_rate * breathing_window_secs) as usize;
         let heartbeat_capacity = (sample_rate * heartbeat_window_secs) as usize;
 

--- a/v2/scripts/calibrate-room.sh
+++ b/v2/scripts/calibrate-room.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Empty-room runtime calibration, one command.
+#
+# Why this exists: a finalized runtime calibration is the only thing that satisfies
+# `explicit_calibration_fresh_at`, and it is *not* persisted — a server restart
+# returns `/api/v1/calibration/status` to `none`. The bootstrap/promote route
+# stores an image, but a restored image is deliberately a "bootstrap prior" with
+# negative-only authority, so promoting does not keep the vitals gate open
+# (`field_model.rs`: "A restored image is only a bootstrap prior").
+#
+# The collection itself needs 600 s and 1000 frames. The duration is not padding:
+# `FieldModelConfig::min_calibration_duration_s` documents that slow environmental
+# variation (HVAC cycles, thermal drift) can only be observed over time, however
+# fast the nodes stream (#1756).
+#
+# Two ways to waste the ten minutes, both handled here:
+#   1. binding to a subcarrier grid the node then stops emitting (the grid is
+#      chosen from a 20 s evidence window, and these nodes interleave 192- and
+#      306-bin frames) — so this picks the eligible source with the highest
+#      measured rate and verifies the feed before committing;
+#   2. starting while a person is still in the room — so it asks first.
+#
+# Usage:
+#   ./calibrate-room.sh                 # interactive, asks you to confirm the room is empty
+#   ./calibrate-room.sh --yes           # no prompt (scripted)
+#   ./calibrate-room.sh --base http://host:8080
+set -uo pipefail
+
+BASE="http://localhost:8080"
+ASSUME_YES=0
+POLL_S=20
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --yes|-y) ASSUME_YES=1; shift ;;
+    --base) BASE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+say()  { printf '%s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v curl >/dev/null || fail "curl is required"
+command -v python3 >/dev/null || fail "python3 is required"
+
+say "== preflight =="
+curl -sf --max-time 5 "$BASE/health" >/dev/null || fail "no sensing server at $BASE (is it running?)"
+
+STATUS=$(curl -sf --max-time 5 "$BASE/api/v1/calibration/status") || fail "cannot read calibration status"
+STATE=$(printf '%s' "$STATUS" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("status","?"))')
+ACTIVE=$(printf '%s' "$STATUS" | python3 -c 'import sys,json;print(str(json.load(sys.stdin).get("active",False)).lower())')
+say "server ok, calibration status: $STATE (active: $ACTIVE)"
+if [ "$ACTIVE" = "true" ]; then
+  fail "a calibration is already collecting. Finish it with: curl -X POST $BASE/api/v1/calibration/stop
+       or discard it with: curl -X POST $BASE/api/v1/calibration/reset"
+fi
+
+say
+say "This collects a 10 minute empty-room baseline (600 s, 1000 frames minimum)."
+say "The room must stay empty for the whole window: a person present during"
+say "collection becomes part of the 'empty' reference and poisons every later"
+say "comparison, including the occupancy estimate and the vitals gate."
+if [ "$ASSUME_YES" != "1" ]; then
+  printf 'Is the room empty now and will stay empty? [y/N] '
+  read -r reply
+  case "$reply" in [yY]*) ;; *) fail "aborted by operator" ;; esac
+fi
+
+say
+say "== choosing a source =="
+# A start call without a source node returns the eligible list instead of starting.
+LIST=$(curl -sf --max-time 10 -X POST "$BASE/api/v1/calibration/start") || fail "calibration start probe failed"
+NODE=$(printf '%s' "$LIST" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+srcs = d.get("eligible_sources") or []
+if not srcs:
+    sys.stderr.write("no eligible source: " + json.dumps(d)[:400] + "\n")
+    sys.exit(1)
+for s in sorted(srcs, key=lambda s: -s["evidence"]["rate_hz"]):
+    print("# %d-sub grid, node %d, %.1f Hz, max_gap %.2f s"
+          % (s["grid"]["n_subcarriers"], s["source_node_id"],
+             s["evidence"]["rate_hz"], s["evidence"]["max_gap_s"]), file=sys.stderr)
+print(max(srcs, key=lambda s: s["evidence"]["rate_hz"])["source_node_id"])
+') || fail "no eligible calibration source (are the nodes streaming?)"
+say "picked node $NODE (highest documented grid rate)"
+
+say
+say "== starting =="
+START=$(curl -sf --max-time 10 -X POST "$BASE/api/v1/calibration/start?source_node_id=$NODE") || fail "start failed"
+printf '%s' "$START" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+print("  model_id:", d.get("model_id"))
+print("  grid:    ", json.dumps(d.get("source_grid")))
+print("  nodes:   ", json.dumps(d.get("source_node_ids")))
+' || fail "unexpected start response: $START"
+
+say
+say "== verifying the feed (30 s) =="
+sleep 30
+V=$(curl -sf --max-time 5 "$BASE/api/v1/calibration/status")
+RATE=$(printf '%s' "$V" | python3 -c 'import sys,json;print("%.2f" % (json.load(sys.stdin).get("frames_per_second") or 0))')
+STALLED=$(printf '%s' "$V" | python3 -c 'import sys,json;print(str(json.load(sys.stdin).get("stalled")).lower())')
+say "  collection rate: $RATE Hz, stalled: $STALLED"
+if [ "$STALLED" = "true" ] || [ "$(printf '%.0f' "$RATE")" -lt 2 ]; then
+  curl -sf --max-time 10 -X POST "$BASE/api/v1/calibration/reset" >/dev/null
+  fail "the bound grid is not arriving (rate ${RATE} Hz). The calibration was reset:
+       re-run this script — it ranks sources by rate, so a second run usually binds
+       the grid the node is actually emitting."
+fi
+
+say
+say "== collecting (do not enter the room) =="
+DEADLINE=$(( $(date +%s) + 1800 ))
+while :; do
+  V=$(curl -sf --max-time 5 "$BASE/api/v1/calibration/status") || fail "status read failed"
+  read -r ACTIVE ELAPSED NEED FRAMES RATE STALLED <<EOF
+$(printf '%s' "$V" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+print(str(d.get("active", False)).lower(),
+      "%.0f" % (d.get("elapsed_s") or 0),
+      "%.0f" % (d.get("min_duration_s") or 600),
+      d.get("frame_count") or 0,
+      "%.1f" % (d.get("frames_per_second") or 0),
+      str(d.get("stalled")).lower())
+')
+EOF
+  say "  ${ELAPSED}/${NEED} s  frames=${FRAMES}  ${RATE} Hz  stalled=${STALLED}"
+  if [ "$STALLED" = "true" ]; then
+    curl -sf --max-time 10 -X POST "$BASE/api/v1/calibration/reset" >/dev/null
+    fail "collection stalled mid-run; reset. Re-run when the nodes are streaming steadily."
+  fi
+  if [ "$ACTIVE" != "true" ]; then
+    say "  collection is no longer active — finalizing what was collected"
+    break
+  fi
+  [ "$ELAPSED" -ge "$NEED" ] && break
+  [ "$(date +%s)" -gt "$DEADLINE" ] && fail "gave up after 30 minutes"
+  sleep "$POLL_S"
+done
+
+say
+say "== finalizing =="
+STOP=$(curl -sf --max-time 20 -X POST "$BASE/api/v1/calibration/stop") || fail "stop failed"
+printf '%s' "$STOP" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+if d.get("success"):
+    print("  success: model_id", d.get("model_id"), "frames", d.get("frame_count"))
+else:
+    print("  FAILED:", d.get("error_code"), "-", d.get("error"))
+    print("  (a sequence discontinuity or a grid that went stale mid-run needs a fresh run)")
+    sys.exit(1)
+' || exit 1
+
+say
+say "== resulting state =="
+curl -sf --max-time 5 "$BASE/api/v1/calibration/status" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+print("  calibration:", d.get("status"), "| binding:", d.get("binding_mode"))
+print("  NOTE: Fresh is valid for 12 h of wall clock (Stale until 24 h), and a server")
+print("        restart discards it — the model is not persisted.")
+'
+curl -sf --max-time 5 "$BASE/api/v1/vital-signs" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+print("  vitals authority:", d.get("authority"))
+if d.get("authority") != "explicit_calibration":
+    print("  abstention:", d.get("abstention_reason"))
+    print("  (the gate also needs exactly one occupant and qualified confidence)")
+else:
+    print("  published:", json.dumps(d.get("vital_signs")))
+'
+say
+say "done."


### PR DESCRIPTION
## Problem

On a real three-node ESP32-S3 array, the live vitals path could not produce a
continuous estimate:

```
GET /api/v1/vital-signs
{ "authority": "abstained",
  "buffer_status": { "breathing_samples": 0, "breathing_capacity": 300,
                     "heartbeat_samples": 0, "heartbeat_capacity": 150 } }
```

...for an entire session, while the same server published ~44 `sensing_update`
frames per second carrying real CSI. Building anything on top of vitals
(sleep monitoring, in my case) was impossible without knowing whether the
pipeline was dead or simply hidden.

## Four defects, each measured before and after

**1. The buffer counters described a detector the live path never uses.**
The endpoint read the *global* `s.vital_detector`, which only the simulator
paths feed. The live ESP32 path feeds the *per-node* `NodeState::vital_detector`
and mirrors only the smoothed result into `s.latest_vitals`. The counters now
report the live cohort (max across nodes) with a per-node breakdown and a
`source` field (`per_node_max` / `global`), so one stalled node cannot be
averaged away by a healthy peer.

**2. The detector was tuned to the wrong clock.** `csi_fps_ema` counts *every*
arrival, including the frames the ADR-110 grid gate rejects — 38-47 Hz here —
while the detector consumes only accepted frames (~7-21 Hz). Window capacities
were therefore ~2x too large. `observe_accepted_csi_frame` now keeps a second
EMA over accepted frames only, surfaced as `accepted_sample_rate_hz`.

**3. A single off-band rate reading retuned the detector and cleared its
history.** The estimate swings with bursty arrivals even when the clock is
unchanged. `reconfigure_sample_rate` still uses its 20% hysteresis, but a change
must now persist across 25 consecutive, mutually consistent evaluations
(`RATE_CHANGE_CONFIRMATIONS`) before it applies.

**4. The remaining wipes were real, and no rate estimate could fix them.** The
grid-gated arrival stream genuinely moves between ~7 Hz and ~21 Hz over seconds
(capacity = rate x 30 s: 212, 430, 441, 544, 554, 625), so sustained moves passed
any persistence test. The spectra need a *uniform* clock. The vitals path now
resamples: one detector sample per fixed 100 ms period holding the newest
accepted frame (zero-order hold), with the detector configured for 10 Hz once —
well above the 4 Hz Nyquist of the 0.8-2.0 Hz heartbeat band.

## MEASURED result

Three nodes, ~44 arrivals/s, sampled every 15 s:

| | breathing fill | heartbeat fill | signal_quality | HR conf |
|---|---|---|---|---|
| before | 44/441 -> 441/441 -> 20/625 -> 130/430 | 44/220 -> 220/220 -> 220/220 | 0.185-0.500 | up to 0.662 |
| after | **300/300 held for 45+ s** | **150/150 held for 45+ s** | **0.43-0.50** | up to 0.628 |

With the buffers stable, three independent nodes agree on the heart rate:

```
node 1  hr 55.06 bpm   br  9.77 bpm   q 0.453
node 2  hr 54.66 bpm   br  9.38 bpm   q 0.500
node 3  hr 58.60 bpm   br  9.38 bpm   q 0.500
```

That cross-node agreement is the useful signal here — it is internal consistency,
**not** a validated measurement. No reference device was used, so nothing below
is an accuracy claim.

## What this does not do

- `vitals_for_publication` is untouched. Its gate (fresh explicit calibration +
  exactly one occupant + signal quality >= 0.40 + confidence >= 0.55) is
  unchanged, and heart-rate confidence now reaches 0.628 against the 0.55
  threshold while breathing confidence peaks at 0.455 — so breathing still
  abstains. That is the next piece of work, not something to paper over.
- The new `/api/v1/vital-signs/diagnostics` readout is **404 unless
  `RUVIEW_VITALS_DIAGNOSTICS=1`**, and every value it returns is labelled
  `UNVALIDATED` with `authority: diagnostic_only`. ADR-021/ADR-293 exist so that
  unvalidated vitals are not published; this keeps that rule while making the
  estimator observable during development.

## Tests

```bash
cargo test -p wifi-densepose-sensing-server --bin sensing-server vital
# 50 passed; 0 failed
```

- `accepted_rate_ignores_grid_rejected_arrivals` — the consumed clock must not
  move with rejected arrivals, while the arrival EMA still overstates it.
- `wandering_rate_jitter_never_retunes` — jitter that leaves the band and returns
  must never retune or clear the window.
- `measured_clock_reconfigures_once_and_clears_mixed_history` — updated: one
  off-band reading must not retune; a sustained change must retune once and clear
  the mixed-clock history.

## Scope

Server-side only (`wifi-densepose-sensing-server`). No secrets, no CSI captures,
no calibration artifacts, and no change to the published vitals contract.
